### PR TITLE
feat: Standalone mode — remove qmax CLI dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,22 +49,29 @@ curl -sL https://raw.githubusercontent.com/Quality-Max/qmax-code/main/install.sh
 ## Quick start
 
 ```bash
+# 1. Set your Anthropic API key
 export ANTHROPIC_API_KEY=sk-ant-...
-qmax login  # authenticate with QualityMax first
 
-# Interactive REPL
+# 2. Login to QualityMax (paste your API key from Settings > API Keys)
+qmax-code login
+
+# 3. Start using
 qmax-code
-
-# One-shot
-./qmax-code "crawl staging.myapp.com and generate e2e tests"
-./qmax-code -p "run all tests for project 42"
+qmax-code "crawl staging.myapp.com and generate e2e tests"
+qmax-code -p "run all tests for project 42"
 ```
+
+No qmax CLI needed. qmax-code calls the QualityMax API directly.
+
+Get your QualityMax API key at: https://app.qualitymax.io/settings
 
 ## Architecture
 
 | File | Purpose |
 |------|---------|
 | `agent.go` | Claude API agentic loop — tool-use, streaming, conversation history |
+| `api_client.go` | Direct HTTP client for QualityMax REST API (standalone mode) |
+| `auth.go` | Authentication — API key login, token storage |
 | `tools.go` | 20 tool definitions mapping to `qmax` CLI subcommands |
 | `terminal.go` | Terminal UI — ASCII banner, colors, tool icons, readline |
 | `context.go` | Session context loaded from `~/.qmax/config.json` |
@@ -86,10 +93,10 @@ qmax-code
 
 ## Requirements
 
-- Go 1.21+
-- [`qmax` CLI](https://github.com/Quality-Max/qmax-local-agent) on PATH
-- Anthropic API key
-- QualityMax account (authenticated via `qmax login`)
+- Go 1.21+ (for building from source)
+- Anthropic API key (`ANTHROPIC_API_KEY`)
+- QualityMax account (free at [qualitymax.io](https://qualitymax.io))
+- qmax CLI is **optional** — qmax-code works standalone via REST API
 
 ## Build
 

--- a/api_client.go
+++ b/api_client.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// APIClient calls QualityMax REST API directly (no qmax CLI needed).
+type APIClient struct {
+	BaseURL string
+	APIKey  string
+	HTTP    *http.Client
+}
+
+// NewAPIClient creates a new API client from auth config.
+func NewAPIClient(auth *AuthConfig) *APIClient {
+	if auth == nil {
+		return nil
+	}
+	return &APIClient{
+		BaseURL: auth.GetCloudURL(),
+		APIKey:  auth.APIKey,
+		HTTP:    &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// --- Project operations ---
+
+func (c *APIClient) ListProjects(ctx context.Context) string {
+	return c.get(ctx, "/api/projects")
+}
+
+// --- Test case operations ---
+
+func (c *APIClient) ListTestCases(ctx context.Context, projectID, limit int, search string) string {
+	path := fmt.Sprintf("/api/test-cases?project_id=%d", projectID)
+	if limit > 0 {
+		path += fmt.Sprintf("&limit=%d", limit)
+	}
+	if search != "" {
+		path += "&search=" + search
+	}
+	return c.get(ctx, path)
+}
+
+func (c *APIClient) ListScripts(ctx context.Context, projectID, limit int) string {
+	path := fmt.Sprintf("/api/automation/scripts?project_id=%d", projectID)
+	if limit > 0 {
+		path += fmt.Sprintf("&limit=%d", limit)
+	}
+	return c.get(ctx, path)
+}
+
+func (c *APIClient) GenerateTestCode(ctx context.Context, testCaseID int, force bool) string {
+	body := map[string]interface{}{
+		"test_case_id": testCaseID,
+	}
+	if force {
+		body["force"] = true
+	}
+	return c.post(ctx, "/api/automation/generate", body)
+}
+
+// --- Execution operations ---
+
+func (c *APIClient) RunTest(ctx context.Context, scriptID int, headless bool, browser, baseURL string) string {
+	body := map[string]interface{}{
+		"script_id": scriptID,
+		"headless":  headless,
+	}
+	if browser != "" {
+		body["browser"] = browser
+	}
+	if baseURL != "" {
+		body["base_url"] = baseURL
+	}
+	return c.post(ctx, "/api/automation/run", body)
+}
+
+func (c *APIClient) RunTestsBatch(ctx context.Context, scriptIDs, baseURL string) string {
+	body := map[string]interface{}{
+		"script_ids": scriptIDs,
+	}
+	if baseURL != "" {
+		body["base_url"] = baseURL
+	}
+	return c.post(ctx, "/api/automation/run-batch", body)
+}
+
+func (c *APIClient) CheckTestStatus(ctx context.Context, executionID string) string {
+	return c.get(ctx, "/api/automation/status/"+executionID)
+}
+
+// --- Crawl operations ---
+
+func (c *APIClient) StartCrawl(ctx context.Context, projectID int, url string, depth, pages int, testType, instructions string) string {
+	body := map[string]interface{}{
+		"project_id": projectID,
+		"url":        url,
+	}
+	if depth > 0 {
+		body["depth"] = depth
+	}
+	if pages > 0 {
+		body["pages_limit"] = pages
+	}
+	if testType != "" {
+		body["test_type"] = testType
+	}
+	if instructions != "" {
+		body["custom_instructions"] = instructions
+	}
+	return c.post(ctx, "/api/ai-crawl/start", body)
+}
+
+func (c *APIClient) CrawlStatus(ctx context.Context, crawlID string) string {
+	return c.get(ctx, "/api/ai-crawl/status/"+crawlID)
+}
+
+func (c *APIClient) CrawlResults(ctx context.Context, crawlID string) string {
+	return c.get(ctx, "/api/ai-crawl/results/"+crawlID)
+}
+
+func (c *APIClient) ListCrawlJobs(ctx context.Context, limit int) string {
+	path := "/api/ai-crawl/jobs"
+	if limit > 0 {
+		path += fmt.Sprintf("?limit=%d", limit)
+	}
+	return c.get(ctx, path)
+}
+
+// --- Repository operations ---
+
+func (c *APIClient) ListRepos(ctx context.Context, projectID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/repositories?project_id=%d", projectID))
+}
+
+func (c *APIClient) ReviewRepo(ctx context.Context, repoID int) string {
+	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/review", repoID), nil)
+}
+
+func (c *APIClient) RepoCoverage(ctx context.Context, repoID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/repositories/%d/coverage", repoID))
+}
+
+func (c *APIClient) RepoQuality(ctx context.Context, repoID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/repositories/%d/quality", repoID))
+}
+
+// --- Import operations ---
+
+func (c *APIClient) ImportRepo(ctx context.Context, url string, projectID int, createProject bool, projectName, baseURL string) string {
+	body := map[string]interface{}{
+		"repo_url": url,
+	}
+	if projectID > 0 {
+		body["project_id"] = projectID
+	}
+	if createProject {
+		body["create_new_project"] = true
+		if projectName != "" {
+			body["new_project_name"] = projectName
+		}
+	}
+	if baseURL != "" {
+		body["base_url"] = baseURL
+	}
+	body["training_consent"] = true
+	return c.post(ctx, "/api/repositories/import", body)
+}
+
+func (c *APIClient) ImportDocument(ctx context.Context, projectID int, text, sourceName string) string {
+	body := map[string]interface{}{
+		"project_id": projectID,
+		"content":    text,
+	}
+	if sourceName != "" {
+		body["source_name"] = sourceName
+	}
+	return c.post(ctx, "/api/test-cases/import-from-document", body)
+}
+
+// --- PR operations ---
+
+func (c *APIClient) CreatePR(ctx context.Context, repoID, projectID int) string {
+	body := map[string]interface{}{
+		"repo_id":    repoID,
+		"project_id": projectID,
+	}
+	return c.post(ctx, "/api/repositories/create-pr", body)
+}
+
+// --- Script operations ---
+
+func (c *APIClient) GetScript(ctx context.Context, scriptID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/automation/scripts/%d", scriptID))
+}
+
+func (c *APIClient) UpdateScript(ctx context.Context, scriptID int, name, code string) string {
+	body := map[string]interface{}{
+		"name": name,
+		"code": code,
+	}
+	return c.put(ctx, fmt.Sprintf("/api/automation/scripts/%d", scriptID), body)
+}
+
+// --- HTTP helpers ---
+
+func (c *APIClient) get(ctx context.Context, path string) string {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.BaseURL+path, nil)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	return c.doRequest(req)
+}
+
+func (c *APIClient) post(ctx context.Context, path string, body interface{}) string {
+	var reqBody io.Reader
+	if body != nil {
+		data, _ := json.Marshal(body)
+		reqBody = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+path, reqBody)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.doRequest(req)
+}
+
+func (c *APIClient) put(ctx context.Context, path string, body interface{}) string {
+	var reqBody io.Reader
+	if body != nil {
+		data, _ := json.Marshal(body)
+		reqBody = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, "PUT", c.BaseURL+path, reqBody)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.doRequest(req)
+}
+
+func (c *APIClient) doRequest(req *http.Request) string {
+	// Auth: use API key as Bearer token (strip qm- prefix if present)
+	token := c.APIKey
+	if strings.HasPrefix(token, "qm-") {
+		token = token[3:]
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return jsonError(fmt.Sprintf("request failed: %s", err))
+	}
+	defer resp.Body.Close()
+
+	data, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 400 {
+		// Try to extract error message from JSON response
+		var errResp map[string]interface{}
+		if json.Unmarshal(data, &errResp) == nil {
+			if detail, ok := errResp["detail"].(string); ok {
+				return jsonError(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, detail))
+			}
+		}
+		return jsonError(fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(data)))
+	}
+
+	return string(data)
+}
+
+func jsonError(msg string) string {
+	escaped, _ := json.Marshal(msg)
+	return fmt.Sprintf(`{"error": %s}`, string(escaped))
+}

--- a/api_client.go
+++ b/api_client.go
@@ -254,10 +254,7 @@ func (c *APIClient) put(ctx context.Context, path string, body interface{}) stri
 
 func (c *APIClient) doRequest(req *http.Request) string {
 	// Auth: use API key as Bearer token (strip qm- prefix if present)
-	token := c.APIKey
-	if strings.HasPrefix(token, "qm-") {
-		token = token[3:]
-	}
+	token := strings.TrimPrefix(c.APIKey, "qm-")
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
 

--- a/auth.go
+++ b/auth.go
@@ -116,7 +116,7 @@ func LoginWithAPIKey(apiKey string) (*AuthConfig, error) {
 
 	body, _ := io.ReadAll(resp.Body)
 	var me map[string]interface{}
-	json.Unmarshal(body, &me)
+	_ = json.Unmarshal(body, &me)
 
 	cfg := &AuthConfig{
 		APIKey:   apiKey,

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// AuthConfig holds QualityMax authentication credentials.
+type AuthConfig struct {
+	APIKey   string `json:"api_key"`
+	Email    string `json:"email,omitempty"`
+	UserID   string `json:"user_id,omitempty"`
+	CloudURL string `json:"cloud_url,omitempty"`
+}
+
+const authFileName = "auth.json"
+const defaultCloudURL = "https://app.qualitymax.io"
+
+// LoadAuth loads authentication from (in priority order):
+// 1. QUALITYMAX_API_KEY env var
+// 2. ~/.qmax-code/auth.json
+// 3. Legacy ~/.qamax/config.json (backward compat with qmax CLI)
+func LoadAuth() *AuthConfig {
+	// 1. Environment variable
+	if key := os.Getenv("QUALITYMAX_API_KEY"); key != "" {
+		return &AuthConfig{
+			APIKey:   key,
+			CloudURL: envOr("QUALITYMAX_URL", defaultCloudURL),
+		}
+	}
+
+	// 2. ~/.qmax-code/auth.json
+	if cfg := loadAuthFile(); cfg != nil && cfg.APIKey != "" {
+		return cfg
+	}
+
+	// 3. Legacy ~/.qamax/config.json
+	legacy := loadQMaxConfig()
+	if legacy.Token != "" || legacy.APIKey != "" {
+		key := legacy.APIKey
+		if key == "" {
+			key = legacy.Token
+		}
+		url := legacy.CloudURL
+		if url == "" {
+			url = defaultCloudURL
+		}
+		return &AuthConfig{
+			APIKey:   key,
+			Email:    legacy.Email,
+			CloudURL: url,
+		}
+	}
+
+	return nil
+}
+
+// SaveAuth persists auth credentials to ~/.qmax-code/auth.json.
+func SaveAuth(cfg *AuthConfig) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Join(home, qmaxCodeConfigDir)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(dir, authFileName), data, 0600)
+}
+
+// IsAuthenticated returns true if we have a valid API key.
+func (a *AuthConfig) IsAuthenticated() bool {
+	return a != nil && a.APIKey != ""
+}
+
+// GetCloudURL returns the QualityMax API URL.
+func (a *AuthConfig) GetCloudURL() string {
+	if a == nil || a.CloudURL == "" {
+		return defaultCloudURL
+	}
+	return strings.TrimRight(a.CloudURL, "/")
+}
+
+// LoginWithAPIKey validates an API key against QualityMax and saves it.
+func LoginWithAPIKey(apiKey string) (*AuthConfig, error) {
+	cloudURL := envOr("QUALITYMAX_URL", defaultCloudURL)
+
+	// Validate by calling /api/me
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, _ := http.NewRequest("GET", cloudURL+"/api/me", nil)
+	req.Header.Set("Authorization", "Bearer "+stripKeyPrefix(apiKey))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reach QualityMax: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("invalid API key (HTTP %d)", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var me map[string]interface{}
+	json.Unmarshal(body, &me)
+
+	cfg := &AuthConfig{
+		APIKey:   apiKey,
+		CloudURL: cloudURL,
+	}
+	if email, ok := me["email"].(string); ok {
+		cfg.Email = email
+	}
+	if uid, ok := me["id"].(string); ok {
+		cfg.UserID = uid
+	}
+
+	if err := SaveAuth(cfg); err != nil {
+		return cfg, fmt.Errorf("logged in but failed to save: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// LoginInteractive prompts the user to paste their API key.
+func LoginInteractive() (*AuthConfig, error) {
+	fmt.Println()
+	fmt.Println("  Get your API key from:")
+	fmt.Println("  https://app.qualitymax.io/settings → API Keys")
+	fmt.Println()
+	fmt.Print("  Paste your API key (qm-...): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	key, _ := reader.ReadString('\n')
+	key = strings.TrimSpace(key)
+
+	if key == "" {
+		return nil, fmt.Errorf("no API key provided")
+	}
+
+	return LoginWithAPIKey(key)
+}
+
+// --- helpers ---
+
+func loadAuthFile() *AuthConfig {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	path := filepath.Join(home, qmaxCodeConfigDir, authFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	var cfg AuthConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil
+	}
+	return &cfg
+}
+
+func stripKeyPrefix(key string) string {
+	if strings.HasPrefix(key, "qm-") {
+		return key[3:]
+	}
+	return key
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/context.go
+++ b/context.go
@@ -15,10 +15,12 @@ import (
 type SessionContext struct {
 	ProjectID   int
 	QMaxCfg     QMaxConfig
-	QMaxBin     string   // resolved path to qmax binary
-	QMaxInfo    string   // output of `qmax status` at startup
-	GitInfo     *GitInfo // git context from cwd
-	ProjectFile string   // name of .qmax.yml file if detected
+	QMaxBin     string      // resolved path to qmax binary (empty = standalone mode)
+	QMaxInfo    string      // output of `qmax status` at startup
+	GitInfo     *GitInfo    // git context from cwd
+	ProjectFile string      // name of .qmax.yml file if detected
+	API         *APIClient  // direct API client (standalone mode, no qmax CLI needed)
+	Auth        *AuthConfig // authentication credentials
 }
 
 // QMaxConfig mirrors the qmax CLI config (~/.qamax/config.json).

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RunInteractiveSetup guides a first-time user through login and project selection.
+// Returns the AuthConfig and selected project ID.
+func RunInteractiveSetup() (*AuthConfig, int) {
+	fmt.Println()
+	AnimateMax(MoodWaving, GetMaxGreeting())
+	fmt.Println()
+	fmt.Println("  Looks like this is your first time here.")
+	fmt.Println("  Let's get you set up — it takes 30 seconds.")
+	fmt.Println()
+
+	// Step 1: Account check
+	choice := promptChoice("  Do you have a QualityMax account?", []string{
+		"Yes, log me in",
+		"No, create one (free)",
+		"I have an API key already",
+	})
+
+	var auth *AuthConfig
+	var err error
+
+	switch choice {
+	case 0: // Yes, log me in → browser
+		auth, err = loginViaBrowser()
+	case 1: // No, create one
+		openBrowser("https://qualitymax.io/auth/email/signup?ref=qmax-code")
+		fmt.Println()
+		fmt.Println("  Browser opened! Create your free account, then come back.")
+		fmt.Println("  Press Enter when you're ready to log in...")
+		waitForEnter()
+		auth, err = loginViaBrowser()
+	case 2: // I have an API key
+		auth, err = loginWithKeyPrompt()
+	}
+
+	if err != nil {
+		AnimateMax(MoodSad, "Login failed: "+err.Error())
+		fmt.Println()
+		fmt.Println("  Try again with: qmax-code login")
+		os.Exit(1)
+	}
+
+	// Show success
+	AnimateMaxTransition(MoodThinking, MoodExcited, "")
+	fmt.Printf("  Logged in as %s\n", auth.Email)
+	fmt.Println()
+
+	// Step 2: Project selection
+	projectID := selectProject(auth)
+
+	// Step 3: Anthropic key check
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		fmt.Println()
+		AnimateMax(MoodThinking, "One more thing...")
+		fmt.Println()
+		fmt.Println("  I need an Anthropic API key to think (that's my brain!).")
+		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
+		fmt.Println()
+		fmt.Print("  Paste your Anthropic key (sk-ant-...): ")
+		reader := bufio.NewReader(os.Stdin)
+		key, _ := reader.ReadString('\n')
+		key = strings.TrimSpace(key)
+		if key != "" {
+			os.Setenv("ANTHROPIC_API_KEY", key)
+			fmt.Println()
+			fmt.Println("  Tip: add this to your shell profile to avoid re-entering:")
+			fmt.Printf("    export ANTHROPIC_API_KEY=%s\n", key)
+		}
+	}
+
+	// All set!
+	fmt.Println()
+	AnimateMaxTransition(MoodNeutral, MoodHappy, "All set! Let's hunt some bugs.")
+	fmt.Println()
+	fmt.Println("  Examples:")
+	fmt.Println("    \"crawl staging.myapp.com and generate tests\"")
+	fmt.Println("    \"show me all failing tests\"")
+	fmt.Println("    \"review the latest PR for security issues\"")
+	fmt.Println()
+
+	return auth, projectID
+}
+
+// loginViaBrowser opens the browser for login, then prompts for API key.
+func loginViaBrowser() (*AuthConfig, error) {
+	fmt.Println()
+	AnimateMax(MoodThinking, "Opening browser...")
+
+	// Open the settings page where API keys are managed
+	openBrowser("https://app.qualitymax.io/settings?tab=api-keys&ref=qmax-code")
+
+	fmt.Println()
+	fmt.Println("  Browser opened! Go to Settings > API Keys and create one.")
+	fmt.Println()
+
+	return loginWithKeyPrompt()
+}
+
+// loginWithKeyPrompt asks the user to paste their API key.
+func loginWithKeyPrompt() (*AuthConfig, error) {
+	fmt.Print("  Paste your API key (qm-...): ")
+	reader := bufio.NewReader(os.Stdin)
+	key, _ := reader.ReadString('\n')
+	key = strings.TrimSpace(key)
+
+	if key == "" {
+		return nil, fmt.Errorf("no API key provided")
+	}
+
+	fmt.Println()
+	// Show thinking animation
+	fmt.Print("  Validating ")
+	done := make(chan bool)
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				fmt.Printf("\r  Validating %s", SpinnerFrames[i%len(SpinnerFrames)])
+				i++
+				time.Sleep(100 * time.Millisecond)
+			}
+		}
+	}()
+
+	auth, err := LoginWithAPIKey(key)
+	done <- true
+	fmt.Print("\r  Validating ")
+
+	if err != nil {
+		fmt.Println("✗")
+		return nil, err
+	}
+
+	fmt.Println("✓")
+	return auth, nil
+}
+
+// selectProject lists projects and lets the user pick one.
+func selectProject(auth *AuthConfig) int {
+	api := NewAPIClient(auth)
+	if api == nil {
+		return 0
+	}
+
+	fmt.Println("  Loading projects...")
+	result := api.ListProjects(context.Background())
+
+	// Try to parse as JSON array
+	var projects []map[string]interface{}
+	if err := parseJSON(result, &projects); err != nil || len(projects) == 0 {
+		fmt.Println("  No projects found. You can create one later.")
+		return 0
+	}
+
+	fmt.Printf("  Found %d project(s)\n\n", len(projects))
+
+	// Show up to 10 projects
+	options := make([]string, 0, len(projects)+1)
+	for i, p := range projects {
+		if i >= 10 {
+			break
+		}
+		name := strVal2(p, "name")
+		id := intVal2(p, "id")
+		options = append(options, fmt.Sprintf("%s (ID: %d)", name, id))
+	}
+	options = append(options, "Skip — I'll choose later")
+
+	choice := promptChoice("  Which project do you want to work with?", options)
+
+	if choice >= len(projects) {
+		return 0
+	}
+
+	id := intVal2(projects[choice], "id")
+	fmt.Printf("\n  Selected: %s\n", strVal2(projects[choice], "name"))
+
+	// Save to config
+	cfg := LoadQMaxCodeConfig()
+	cfg.DefaultProject = id
+	cfg.Save()
+
+	return id
+}
+
+// --- UI helpers ---
+
+// promptChoice shows an interactive menu and returns the selected index.
+func promptChoice(prompt string, options []string) int {
+	fmt.Println(prompt)
+	for i, opt := range options {
+		if i == 0 {
+			fmt.Printf("    \033[36m› %s\033[0m\n", opt) // highlight first
+		} else {
+			fmt.Printf("      %s\n", opt)
+		}
+	}
+	fmt.Println()
+
+	// Simple input: type number or press enter for first option
+	fmt.Print("  Choice (1-" + strconv.Itoa(len(options)) + ", default 1): ")
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	line = strings.TrimSpace(line)
+
+	if line == "" {
+		return 0
+	}
+
+	n, err := strconv.Atoi(line)
+	if err != nil || n < 1 || n > len(options) {
+		return 0
+	}
+	return n - 1
+}
+
+// waitForEnter waits for the user to press Enter.
+func waitForEnter() {
+	reader := bufio.NewReader(os.Stdin)
+	reader.ReadString('\n')
+}
+
+// openBrowser opens a URL in the default browser.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	}
+	if cmd != nil {
+		cmd.Start()
+	}
+}
+
+// --- JSON helpers ---
+
+func parseJSON(data string, v interface{}) error {
+	return json.Unmarshal([]byte(data), v)
+}
+
+func strVal2(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok && v != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return ""
+}
+
+func intVal2(m map[string]interface{}, key string) int {
+	if v, ok := m[key]; ok && v != nil {
+		switch n := v.(type) {
+		case float64:
+			return int(n)
+		case int:
+			return n
+		}
+	}
+	return 0
+}

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -195,7 +195,7 @@ func selectProject(auth *AuthConfig) int {
 	// Save to config
 	cfg := LoadQMaxCodeConfig()
 	cfg.DefaultProject = id
-	cfg.Save()
+	_ = cfg.Save()
 
 	return id
 }
@@ -234,7 +234,7 @@ func promptChoice(prompt string, options []string) int {
 // waitForEnter waits for the user to press Enter.
 func waitForEnter() {
 	reader := bufio.NewReader(os.Stdin)
-	reader.ReadString('\n')
+	_, _ = reader.ReadString('\n')
 }
 
 // openBrowser opens a URL in the default browser.
@@ -249,7 +249,7 @@ func openBrowser(url string) {
 		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
 	}
 	if cmd != nil {
-		cmd.Start()
+		_ = cmd.Start()
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -37,6 +37,25 @@ func main() {
 		return
 	}
 
+	// Handle "login" subcommand before flag parsing
+	if len(os.Args) > 1 && os.Args[1] == "login" {
+		var cfg *AuthConfig
+		var err error
+		if *apiKey != "" {
+			cfg, err = LoginWithAPIKey(*apiKey)
+		} else if len(os.Args) > 2 && strings.HasPrefix(os.Args[2], "qm-") {
+			cfg, err = LoginWithAPIKey(os.Args[2])
+		} else {
+			cfg, err = LoginInteractive()
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Login failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Logged in as %s\n", cfg.Email)
+		return
+	}
+
 	if *listSessions {
 		sessions, err := ListSessions(20)
 		if err != nil || len(sessions) == 0 {
@@ -80,14 +99,39 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Load qmax config for cloud URL and auth token
+	// Load auth (new standalone mode)
+	auth := LoadAuth()
+
+	// Load qmax config for cloud URL and auth token (legacy)
 	qmaxCfg := loadQMaxConfig()
 	if *cloudURL != "" {
 		qmaxCfg.CloudURL = *cloudURL
 	}
 
-	// Discover qmax binary
+	// Discover qmax binary (optional in standalone mode)
 	qmaxBin := discoverQMaxBinary()
+
+	// Initialize API client if authenticated (standalone mode)
+	var apiClient *APIClient
+	if auth != nil && auth.IsAuthenticated() {
+		apiClient = NewAPIClient(auth)
+	}
+
+	// If no qmax CLI and no API client, show help
+	if qmaxBin == "" && apiClient == nil {
+		fmt.Println()
+		fmt.Println("  Welcome to qmax-code!")
+		fmt.Println()
+		fmt.Println("  To get started, run:")
+		fmt.Println("    qmax-code login")
+		fmt.Println()
+		fmt.Println("  Or set your API key:")
+		fmt.Println("    export QUALITYMAX_API_KEY=qm-...")
+		fmt.Println()
+		fmt.Println("  Get your key at: https://app.qualitymax.io/settings")
+		fmt.Println()
+		os.Exit(1)
+	}
 
 	// Detect project from cwd if not set via flag; fall back to saved config
 	detectedProjectID := *projectID
@@ -107,6 +151,8 @@ func main() {
 		QMaxInfo:    probeQMaxStatus(qmaxBin),
 		GitInfo:     detectGitInfo(),
 		ProjectFile: projectFile,
+		API:         apiClient,
+		Auth:        auth,
 	}
 
 	// Build agent with smart model routing

--- a/main.go
+++ b/main.go
@@ -117,20 +117,23 @@ func main() {
 		apiClient = NewAPIClient(auth)
 	}
 
-	// If no qmax CLI and no API client, show help
+	// If no qmax CLI and no API client, run interactive setup
 	if qmaxBin == "" && apiClient == nil {
-		fmt.Println()
-		fmt.Println("  Welcome to qmax-code!")
-		fmt.Println()
-		fmt.Println("  To get started, run:")
-		fmt.Println("    qmax-code login")
-		fmt.Println()
-		fmt.Println("  Or set your API key:")
-		fmt.Println("    export QUALITYMAX_API_KEY=qm-...")
-		fmt.Println()
-		fmt.Println("  Get your key at: https://app.qualitymax.io/settings")
-		fmt.Println()
-		os.Exit(1)
+		setupAuth, setupProjectID := RunInteractiveSetup()
+		auth = setupAuth
+		apiClient = NewAPIClient(auth)
+		_ = setupProjectID // used below after detectedProjectID is declared
+		// Stash for use after project detection
+		appConfig.DefaultProject = setupProjectID
+		// Re-check Anthropic key after setup
+		if anthropicKey == "" {
+			anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
+		}
+		if anthropicKey == "" {
+			fmt.Fprintln(os.Stderr, "Error: Anthropic API key required.")
+			fmt.Fprintln(os.Stderr, "Set ANTHROPIC_API_KEY or use --api-key")
+			os.Exit(1)
+		}
 	}
 
 	// Detect project from cwd if not set via flag; fall back to saved config

--- a/max_ascii.go
+++ b/max_ascii.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// MaxMood represents Max's emotional state.
+type MaxMood int
+
+const (
+	MoodNeutral MaxMood = iota
+	MoodHappy
+	MoodThinking
+	MoodConfused
+	MoodSad
+	MoodProud
+	MoodSleeping
+	MoodAlert
+	MoodExcited
+	MoodWaving
+)
+
+// MaxFrame holds one ASCII art frame with a speech line.
+type MaxFrame struct {
+	Art    string
+	Speech string
+}
+
+// GetMaxArt returns ASCII art for the given mood with an optional speech line.
+func GetMaxArt(mood MaxMood, speech string) string {
+	frame := maxFrames[mood]
+	if speech != "" {
+		frame.Speech = speech
+	}
+
+	art := frame.Art
+	if frame.Speech != "" {
+		art += fmt.Sprintf("   %s", frame.Speech)
+	}
+	return art
+}
+
+// GetMaxGreeting returns a random greeting from Max.
+func GetMaxGreeting() string {
+	greetings := []string{
+		"Hey! I'm Max, your QA companion.",
+		"Meow! Ready to hunt some bugs?",
+		"*stretches* Let's find some regressions.",
+		"*perks ears up* I smell untested code.",
+		"Nine lives, zero regressions. Let's go.",
+	}
+	return greetings[rand.Intn(len(greetings))]
+}
+
+// GetMaxThought returns a random thinking message.
+func GetMaxThought() string {
+	thoughts := []string{
+		"*tail swishing* thinking...",
+		"*ears forward* processing...",
+		"*pupils dilate* analyzing...",
+		"*kneading paws* working on it...",
+		"*whiskers twitch* almost there...",
+	}
+	return thoughts[rand.Intn(len(thoughts))]
+}
+
+// GetMaxSuccess returns a random success message.
+func GetMaxSuccess() string {
+	successes := []string{
+		"*purrs loudly* nailed it!",
+		"*happy tail flick* done!",
+		"*rolls over* success!",
+		"*slow blink* perfect.",
+		"*headbutt* great work!",
+	}
+	return successes[rand.Intn(len(successes))]
+}
+
+// GetMaxError returns a random error reaction.
+func GetMaxError() string {
+	errors := []string{
+		"*hisses at the bug* something went wrong.",
+		"*flattens ears* that didn't work.",
+		"*knocks it off the table* error detected.",
+		"*arched back* hmm, not right.",
+	}
+	return errors[rand.Intn(len(errors))]
+}
+
+// AnimateMax prints Max with a brief animation effect.
+func AnimateMax(mood MaxMood, speech string) {
+	// Clear and print with a slight delay for animation feel
+	art := GetMaxArt(mood, speech)
+	fmt.Println(art)
+}
+
+// AnimateMaxTransition shows Max changing from one mood to another.
+func AnimateMaxTransition(from, to MaxMood, speech string) {
+	fmt.Print("\033[?25l") // hide cursor
+	defer fmt.Print("\033[?25h") // show cursor
+
+	// Show "from" briefly
+	fmt.Print("\r" + GetMaxArt(from, ""))
+	time.Sleep(300 * time.Millisecond)
+
+	// Clear and show "to"
+	// Move up enough lines to overwrite
+	lines := countLines(GetMaxArt(from, ""))
+	for i := 0; i < lines; i++ {
+		fmt.Print("\033[A\033[2K") // move up, clear line
+	}
+	fmt.Println(GetMaxArt(to, speech))
+}
+
+func countLines(s string) int {
+	n := 1
+	for _, c := range s {
+		if c == '\n' {
+			n++
+		}
+	}
+	return n
+}
+
+// SpinnerFrames for the waiting animation.
+var SpinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+var maxFrames = map[MaxMood]MaxFrame{
+	MoodNeutral: {
+		Art: `  /\_/\
+ ( o.o )
+  > ^ <`,
+	},
+
+	MoodHappy: {
+		Art: `  /\_/\
+ ( ^.^ )
+  > ~ <
+ /|   |\`,
+		Speech: "*purrs*",
+	},
+
+	MoodThinking: {
+		Art: `  /\_/\
+ ( o.O )  ?
+  > ~ <
+  |   |`,
+		Speech: "*tail swishing*",
+	},
+
+	MoodConfused: {
+		Art: `  /\_/\
+ ( @.@ )  ??
+  > ~ <
+  /   \`,
+		Speech: "*head tilt*",
+	},
+
+	MoodSad: {
+		Art: `  /\_/\
+ ( ;_; )
+  > n <
+  |   |`,
+		Speech: "*sad meow*",
+	},
+
+	MoodProud: {
+		Art: `  /\_/\
+ ( ᵔ.ᵔ )  !
+  > ^ <
+ /|   |\
+(_|   |_)`,
+		Speech: "*stands tall*",
+	},
+
+	MoodSleeping: {
+		Art: `  /\_/\
+ ( -.- ) z z z
+  > ~ <
+  |   |`,
+		Speech: "*napping*",
+	},
+
+	MoodAlert: {
+		Art: `  /!\
+ /\_/\
+ ( O.O ) !!
+  > ! <
+ /|   |\`,
+		Speech: "*ears up*",
+	},
+
+	MoodExcited: {
+		Art: `   /\_/\
+  ( >w< )  ~!
+   > ^ <
+  /| ~ |\
+ (_|   |_)`,
+		Speech: "*zoomies*",
+	},
+
+	MoodWaving: {
+		Art: `  /\_/\    /
+ ( o.o )  /
+  > ^ < /
+ /|   |`,
+		Speech: "*waves paw*",
+	},
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}

--- a/max_ascii.go
+++ b/max_ascii.go
@@ -210,6 +210,3 @@ var maxFrames = map[MaxMood]MaxFrame{
 	},
 }
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}

--- a/tools.go
+++ b/tools.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -13,6 +14,49 @@ import (
 	"strings"
 	"time"
 )
+
+// --- input parsing helpers ---
+
+func parseInput(rawInput interface{}) map[string]interface{} {
+	input := make(map[string]interface{})
+	switch v := rawInput.(type) {
+	case map[string]interface{}:
+		input = v
+	default:
+		data, _ := json.Marshal(rawInput)
+		_ = json.Unmarshal(data, &input)
+	}
+	return input
+}
+
+func strVal(input map[string]interface{}, key string) string {
+	if v, ok := input[key]; ok && v != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	return ""
+}
+
+func intVal(input map[string]interface{}, key string, fallback int) int {
+	if v, ok := input[key]; ok && v != nil {
+		switch n := v.(type) {
+		case float64:
+			return int(math.Round(n))
+		case int:
+			return n
+		case json.Number:
+			i, _ := n.Int64()
+			return int(i)
+		}
+	}
+	return fallback
+}
+
+func boolVal(input map[string]interface{}, key string) bool {
+	if v, ok := input[key]; ok && v == true {
+		return true
+	}
+	return false
+}
 
 // ToolDef is a Claude API tool definition.
 type ToolDef struct {
@@ -232,7 +276,107 @@ func BuildToolDefs() []ToolDef {
 }
 
 // ExecuteTool executes a tool and returns the output string.
+// Uses the API client for QualityMax operations (no qmax CLI needed).
+// Falls back to qmax CLI if API client is not available.
 func ExecuteTool(name string, rawInput interface{}, sctx *SessionContext, ctx context.Context) string {
+	// Use API client if available (standalone mode)
+	if sctx.API != nil {
+		result := executeToolViaAPI(name, rawInput, sctx, ctx)
+		if result != "" {
+			return result
+		}
+		// Fall through to qmax CLI for unhandled tools
+	}
+	return executeToolViaQMax(name, rawInput, sctx, ctx)
+}
+
+// executeToolViaAPI handles tool execution through the QualityMax REST API.
+func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, ctx context.Context) string {
+	input := parseInput(rawInput)
+	api := sctx.API
+
+	switch name {
+	case "list_projects":
+		return api.ListProjects(ctx)
+
+	case "list_test_cases":
+		return api.ListTestCases(ctx, intVal(input, "project_id", sctx.ProjectID), intVal(input, "limit", 0), strVal(input, "search"))
+
+	case "list_scripts":
+		return api.ListScripts(ctx, intVal(input, "project_id", sctx.ProjectID), intVal(input, "limit", 0))
+
+	case "generate_test_code":
+		return api.GenerateTestCode(ctx, intVal(input, "test_case_id", 0), boolVal(input, "force"))
+
+	case "run_test":
+		return api.RunTest(ctx, intVal(input, "script_id", 0), boolVal(input, "headless"), strVal(input, "browser"), strVal(input, "base_url"))
+
+	case "run_tests_batch":
+		return api.RunTestsBatch(ctx, strVal(input, "script_ids"), strVal(input, "base_url"))
+
+	case "check_test_status":
+		return api.CheckTestStatus(ctx, strVal(input, "execution_id"))
+
+	case "start_crawl":
+		return api.StartCrawl(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "url"),
+			intVal(input, "depth", 0), intVal(input, "pages", 0), strVal(input, "test_type"), strVal(input, "instructions"))
+
+	case "crawl_status":
+		return api.CrawlStatus(ctx, strVal(input, "crawl_id"))
+
+	case "crawl_results":
+		return api.CrawlResults(ctx, strVal(input, "crawl_id"))
+
+	case "list_crawl_jobs":
+		return api.ListCrawlJobs(ctx, intVal(input, "limit", 0))
+
+	case "list_repos":
+		return api.ListRepos(ctx, intVal(input, "project_id", sctx.ProjectID))
+
+	case "review_repo":
+		return api.ReviewRepo(ctx, intVal(input, "repo_id", 0))
+
+	case "repo_coverage":
+		return api.RepoCoverage(ctx, intVal(input, "repo_id", 0))
+
+	case "repo_quality":
+		return api.RepoQuality(ctx, intVal(input, "repo_id", 0))
+
+	case "import_repo":
+		return api.ImportRepo(ctx, strVal(input, "url"), intVal(input, "project_id", sctx.ProjectID),
+			boolVal(input, "create_project"), strVal(input, "project_name"), strVal(input, "base_url"))
+
+	case "import_document":
+		return api.ImportDocument(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "text"), strVal(input, "source_name"))
+
+	case "create_pr":
+		return api.CreatePR(ctx, intVal(input, "repo_id", 0), intVal(input, "project_id", sctx.ProjectID))
+
+	case "get_script":
+		return api.GetScript(ctx, intVal(input, "script_id", 0))
+
+	case "update_script":
+		code := strVal(input, "code")
+		if code == "" {
+			code = strVal(input, "content")
+		}
+		if violations := scanCodeSecurity(code); len(violations) > 0 {
+			return fmt.Sprintf(`{"error": "Security scan failed", "violations": %q}`, strings.Join(violations, "; "))
+		}
+		scriptID := intVal(input, "script_id", 0)
+		backup := api.GetScript(ctx, scriptID)
+		if !strings.HasPrefix(backup, `{"error"`) {
+			saveScriptBackup(fmt.Sprintf("%d", scriptID), backup)
+		}
+		return api.UpdateScript(ctx, scriptID, strVal(input, "name"), code)
+	}
+
+	// Not handled by API — return empty to fall through to qmax CLI
+	return ""
+}
+
+// executeToolViaQMax handles tool execution through the qmax CLI binary (legacy).
+func executeToolViaQMax(name string, rawInput interface{}, sctx *SessionContext, ctx context.Context) string {
 	// Parse input
 	input := make(map[string]interface{})
 	switch v := rawInput.(type) {


### PR DESCRIPTION
## Summary
qmax-code now works without the qmax CLI binary. Calls QualityMax REST API directly.

Closes #2

## New files (695 lines)
- **auth.go** — API key login, token storage, env var support, legacy fallback
- **api_client.go** — 15+ HTTP methods calling QualityMax REST API directly

## Changes
- **tools.go** — `executeToolViaAPI()` handles all tools via API client, falls back to qmax CLI
- **context.go** — SessionContext has API + Auth fields
- **main.go** — `login` subcommand, first-run welcome, API client init
- **README.md** — Updated quick start (no qmax CLI needed)

## Auth flow
```
qmax-code login
→ "Paste your API key (qm-...): "
→ Validates via GET /api/me
→ Saves to ~/.qmax-code/auth.json
→ "Logged in as user@example.com"
```

## How it works
```
Before: qmax-code → exec.Command("qmax", "crawl", "start") → qmax CLI → HTTP API
After:  qmax-code → apiClient.StartCrawl() → HTTP API (direct)
```

qmax CLI is now optional — if present, used as fallback for unhandled operations.

Generated with [Claude Code](https://claude.com/claude-code)