### PR TITLE
feat: Tool parity v1.4.0 — 49 tools (k6, CRUD, frameworks, AI, QTML)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -50,13 +50,21 @@ type Message struct {
 
 // ContentBlock is a typed content block in a message.
 type ContentBlock struct {
-	Type      string      `json:"type"`
-	Text      string      `json:"text,omitempty"`
-	ID        string      `json:"id,omitempty"`
-	Name      string      `json:"name,omitempty"`
-	Input     interface{} `json:"input,omitempty"`
-	ToolUseID string      `json:"tool_use_id,omitempty"`
-	Content   string      `json:"content,omitempty"`
+	Type      string       `json:"type"`
+	Text      string       `json:"text,omitempty"`
+	ID        string       `json:"id,omitempty"`
+	Name      string       `json:"name,omitempty"`
+	Input     interface{}  `json:"input,omitempty"`
+	ToolUseID string       `json:"tool_use_id,omitempty"`
+	Content   string       `json:"content,omitempty"`
+	Source    *ImageSource `json:"source,omitempty"` // for type="image"
+}
+
+// ImageSource is the source data for an image content block.
+type ImageSource struct {
+	Type      string `json:"type"`       // "base64"
+	MediaType string `json:"media_type"` // "image/png", "image/jpeg", "image/gif", "image/webp"
+	Data      string `json:"data"`       // base64-encoded image data
 }
 
 // APIRequest is the Claude API request body.
@@ -249,13 +257,60 @@ func (a *Agent) compressHistory() {
 }
 
 // RunStreaming executes a prompt with real-time SSE streaming to the terminal.
+// BuildUserContent creates a content payload for a user message.
+// If images are provided, it builds a multi-block content array (text + images).
+// Otherwise, it returns the plain string (simpler, lower token usage).
+func BuildUserContent(text string, images []ImageAttachment) interface{} {
+	if len(images) == 0 {
+		return text
+	}
+	blocks := make([]ContentBlock, 0, len(images)+1)
+	for _, img := range images {
+		blocks = append(blocks, ContentBlock{
+			Type: "image",
+			Source: &ImageSource{
+				Type:      "base64",
+				MediaType: img.MediaType,
+				Data:      img.Data,
+			},
+		})
+	}
+	if text != "" {
+		blocks = append(blocks, ContentBlock{
+			Type: "text",
+			Text: text,
+		})
+	}
+	return blocks
+}
+
+// ImageAttachment holds a base64-encoded image to send with a message.
+type ImageAttachment struct {
+	MediaType string // "image/png", "image/jpeg", etc.
+	Data      string // base64-encoded
+	FileName  string // original filename (for display)
+}
+
+// RunStreamingWithImages is like RunStreaming but supports image attachments.
+func (a *Agent) RunStreamingWithImages(prompt string, images []ImageAttachment, term *Terminal) (string, error) {
+	a.history = append(a.history, Message{
+		Role:    "user",
+		Content: BuildUserContent(prompt, images),
+	})
+	a.logger.Info("agent", "user_message_with_images", map[string]interface{}{"turns": len(a.history), "images": len(images)})
+	return a.runStreamingLoop(term)
+}
+
 func (a *Agent) RunStreaming(prompt string, term *Terminal) (string, error) {
 	a.history = append(a.history, Message{
 		Role:    "user",
 		Content: prompt,
 	})
 	a.logger.Info("agent", "user_message", map[string]interface{}{"turns": len(a.history)})
+	return a.runStreamingLoop(term)
+}
 
+func (a *Agent) runStreamingLoop(term *Terminal) (string, error) {
 	for iterations := 0; iterations < 20; iterations++ {
 		// Compress history before each API call to stay within token budget
 		a.compressHistory()

--- a/api_client.go
+++ b/api_client.go
@@ -210,6 +210,236 @@ func (c *APIClient) UpdateScript(ctx context.Context, scriptID int, name, code s
 	return c.put(ctx, fmt.Sprintf("/api/automation/scripts/%d", scriptID), body)
 }
 
+// --- k6 Performance Testing ---
+
+func (c *APIClient) K6ListScripts(ctx context.Context, projectID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/k6/scripts?project_id=%d", projectID))
+}
+
+func (c *APIClient) K6CreateScript(ctx context.Context, projectID int, name, testType, targetURL, code string) string {
+	body := map[string]interface{}{
+		"project_id": projectID,
+		"name":       name,
+		"test_type":  testType,
+		"target_url": targetURL,
+	}
+	if code != "" {
+		body["code"] = code
+	}
+	return c.post(ctx, "/api/k6/scripts", body)
+}
+
+func (c *APIClient) K6GetScript(ctx context.Context, scriptID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/k6/scripts/%d", scriptID))
+}
+
+func (c *APIClient) K6RunTest(ctx context.Context, scriptID, vus int, duration string) string {
+	body := map[string]interface{}{
+		"script_id": scriptID,
+	}
+	if vus > 0 {
+		body["vus"] = vus
+	}
+	if duration != "" {
+		body["duration"] = duration
+	}
+	return c.post(ctx, fmt.Sprintf("/api/k6/run/%d", scriptID), body)
+}
+
+func (c *APIClient) K6CheckStatus(ctx context.Context, executionID string) string {
+	return c.get(ctx, "/api/k6/status/"+executionID)
+}
+
+func (c *APIClient) K6Report(ctx context.Context, executionID string) string {
+	return c.get(ctx, "/api/k6/executions/"+executionID+"/report")
+}
+
+func (c *APIClient) K6Generate(ctx context.Context, projectID int, targetURL, testType string, endpoints string) string {
+	body := map[string]interface{}{
+		"project_id": projectID,
+		"target_url": targetURL,
+		"test_type":  testType,
+	}
+	if endpoints != "" {
+		body["endpoints"] = endpoints
+	}
+	return c.post(ctx, "/api/k6/generate", body)
+}
+
+func (c *APIClient) K6Convert(ctx context.Context, sourceCode, sourceFramework, testType string) string {
+	body := map[string]interface{}{
+		"source_code":      sourceCode,
+		"source_framework": sourceFramework,
+		"test_type":        testType,
+	}
+	return c.post(ctx, "/api/k6/convert", body)
+}
+
+// --- Test Case CRUD ---
+
+func (c *APIClient) CreateTestCase(ctx context.Context, projectID int, title, description, category, priority string) string {
+	body := map[string]interface{}{
+		"project_id":  projectID,
+		"title":       title,
+		"description": description,
+	}
+	if category != "" {
+		body["category"] = category
+	}
+	if priority != "" {
+		body["priority"] = priority
+	}
+	return c.post(ctx, "/api/test-cases/", body)
+}
+
+func (c *APIClient) UpdateTestCase(ctx context.Context, testCaseID int, title, description, category, priority, status string) string {
+	body := map[string]interface{}{}
+	if title != "" {
+		body["title"] = title
+	}
+	if description != "" {
+		body["description"] = description
+	}
+	if category != "" {
+		body["category"] = category
+	}
+	if priority != "" {
+		body["priority"] = priority
+	}
+	if status != "" {
+		body["status"] = status
+	}
+	return c.put(ctx, fmt.Sprintf("/api/test-cases/%d", testCaseID), body)
+}
+
+func (c *APIClient) DeleteTestCase(ctx context.Context, testCaseID int) string {
+	return c.delete(ctx, fmt.Sprintf("/api/test-cases/%d", testCaseID))
+}
+
+// --- Project CRUD ---
+
+func (c *APIClient) CreateProject(ctx context.Context, name, description, baseURL string) string {
+	body := map[string]interface{}{
+		"name": name,
+	}
+	if description != "" {
+		body["description"] = description
+	}
+	if baseURL != "" {
+		body["base_url"] = baseURL
+	}
+	return c.post(ctx, "/api/projects", body)
+}
+
+func (c *APIClient) UpdateProject(ctx context.Context, projectID int, name, description, baseURL string) string {
+	body := map[string]interface{}{}
+	if name != "" {
+		body["name"] = name
+	}
+	if description != "" {
+		body["description"] = description
+	}
+	if baseURL != "" {
+		body["base_url"] = baseURL
+	}
+	return c.put(ctx, fmt.Sprintf("/api/projects/%d", projectID), body)
+}
+
+func (c *APIClient) DeleteProject(ctx context.Context, projectID int) string {
+	return c.delete(ctx, fmt.Sprintf("/api/projects/%d", projectID))
+}
+
+func (c *APIClient) GetProjectSummary(ctx context.Context, projectID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/projects/%d", projectID))
+}
+
+// --- Framework Operations ---
+
+func (c *APIClient) TriggerFrameworkRun(ctx context.Context, projectID int, frameworkType string) string {
+	body := map[string]interface{}{}
+	if frameworkType != "" {
+		body["framework_type"] = frameworkType
+	}
+	return c.post(ctx, fmt.Sprintf("/api/frameworks/%d/run", projectID), body)
+}
+
+func (c *APIClient) AddScriptToFramework(ctx context.Context, projectID, scriptID int) string {
+	body := map[string]interface{}{
+		"script_id": scriptID,
+	}
+	return c.post(ctx, fmt.Sprintf("/api/frameworks/%d/add-script", projectID), body)
+}
+
+func (c *APIClient) ExportFramework(ctx context.Context, projectID int, framework string) string {
+	path := fmt.Sprintf("/api/frameworks/%d/export", projectID)
+	if framework != "" {
+		path += "?framework=" + framework
+	}
+	return c.get(ctx, path)
+}
+
+func (c *APIClient) GetInstallCommand(ctx context.Context, projectID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/frameworks/%d/install-command", projectID))
+}
+
+// --- AI-Powered Tools ---
+
+func (c *APIClient) EnhanceTestCase(ctx context.Context, testCaseID int) string {
+	return c.post(ctx, fmt.Sprintf("/api/test-cases/%d/enhance", testCaseID), nil)
+}
+
+func (c *APIClient) GenerateGapTests(ctx context.Context, repoID int) string {
+	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/generate-gaps", repoID), nil)
+}
+
+func (c *APIClient) StartCrawlFromTestCase(ctx context.Context, testCaseID int) string {
+	body := map[string]interface{}{
+		"test_case_id": testCaseID,
+	}
+	return c.post(ctx, "/api/ai-crawl/start-from-test-case", body)
+}
+
+// --- QTML ---
+
+func (c *APIClient) ExportQTML(ctx context.Context, projectID int) string {
+	return c.get(ctx, fmt.Sprintf("/api/qtml/export?project_id=%d", projectID))
+}
+
+func (c *APIClient) ImportQTML(ctx context.Context, projectID int, qtmlContent string) string {
+	body := map[string]interface{}{
+		"project_id": projectID,
+		"content":    qtmlContent,
+	}
+	return c.post(ctx, "/api/qtml/import", body)
+}
+
+func (c *APIClient) ConvertQTMLToPlaywright(ctx context.Context, qtmlContent string) string {
+	body := map[string]interface{}{
+		"content": qtmlContent,
+	}
+	return c.post(ctx, "/api/qtml/convert-to-playwright", body)
+}
+
+// --- Deployment Testing ---
+
+func (c *APIClient) TestDeployedEnvironment(ctx context.Context, projectID int, url string) string {
+	body := map[string]interface{}{
+		"project_id": projectID,
+		"url":        url,
+	}
+	return c.post(ctx, "/api/automation/test-deployed", body)
+}
+
+// --- Delete helper ---
+
+func (c *APIClient) delete(ctx context.Context, path string) string {
+	req, err := http.NewRequestWithContext(ctx, "DELETE", c.BaseURL+path, nil)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	return c.doRequest(req)
+}
+
 // --- HTTP helpers ---
 
 func (c *APIClient) get(ctx context.Context, path string) string {

--- a/api_client.go
+++ b/api_client.go
@@ -138,11 +138,11 @@ func (c *APIClient) ListCrawlJobs(ctx context.Context, limit int) string {
 // --- Repository operations ---
 
 func (c *APIClient) ListRepos(ctx context.Context, projectID int) string {
-	return c.get(ctx, fmt.Sprintf("/api/repositories?project_id=%d", projectID))
+	return c.get(ctx, fmt.Sprintf("/api/repositories/project/%d", projectID))
 }
 
 func (c *APIClient) ReviewRepo(ctx context.Context, repoID int) string {
-	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/ai-review", repoID), nil)
+	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/ai-review", repoID), map[string]interface{}{})
 }
 
 func (c *APIClient) RepoCoverage(ctx context.Context, repoID int) string {
@@ -389,7 +389,7 @@ func (c *APIClient) EnhanceTestCase(ctx context.Context, testCaseID int) string 
 }
 
 func (c *APIClient) GenerateGapTests(ctx context.Context, repoID int) string {
-	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/generate-gap-tests", repoID), nil)
+	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/generate-gap-tests", repoID), map[string]interface{}{})
 }
 
 func (c *APIClient) StartCrawlFromTestCase(ctx context.Context, testCaseID int) string {

--- a/api_client.go
+++ b/api_client.go
@@ -430,6 +430,12 @@ func (c *APIClient) TestDeployedEnvironment(ctx context.Context, projectID int, 
 	return c.post(ctx, "/api/automation/test-deployed", body)
 }
 
+// --- Background Job Status ---
+
+func (c *APIClient) CheckBackgroundJob(ctx context.Context, jobID string) string {
+	return c.get(ctx, "/api/job-health/background/"+jobID)
+}
+
 // --- Delete helper ---
 
 func (c *APIClient) delete(ctx context.Context, path string) string {

--- a/api_client.go
+++ b/api_client.go
@@ -171,7 +171,7 @@ func (c *APIClient) ImportRepo(ctx context.Context, url string, projectID int, c
 	if baseURL != "" {
 		body["base_url"] = baseURL
 	}
-	body["training_consent"] = true
+	body["training_consent"] = "opt_in"
 	return c.post(ctx, "/api/repositories/import", body)
 }
 

--- a/api_client.go
+++ b/api_client.go
@@ -142,7 +142,7 @@ func (c *APIClient) ListRepos(ctx context.Context, projectID int) string {
 }
 
 func (c *APIClient) ReviewRepo(ctx context.Context, repoID int) string {
-	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/review", repoID), nil)
+	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/ai-review", repoID), nil)
 }
 
 func (c *APIClient) RepoCoverage(ctx context.Context, repoID int) string {
@@ -389,7 +389,7 @@ func (c *APIClient) EnhanceTestCase(ctx context.Context, testCaseID int) string 
 }
 
 func (c *APIClient) GenerateGapTests(ctx context.Context, repoID int) string {
-	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/generate-gaps", repoID), nil)
+	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/generate-gap-tests", repoID), nil)
 }
 
 func (c *APIClient) StartCrawlFromTestCase(ctx context.Context, testCaseID int) string {

--- a/api_client.go
+++ b/api_client.go
@@ -71,8 +71,7 @@ func (c *APIClient) GenerateTestCode(ctx context.Context, testCaseID int, force 
 
 func (c *APIClient) RunTest(ctx context.Context, scriptID int, headless bool, browser, baseURL string) string {
 	body := map[string]interface{}{
-		"script_id": scriptID,
-		"headless":  headless,
+		"headless": headless,
 	}
 	if browser != "" {
 		body["browser"] = browser
@@ -80,7 +79,7 @@ func (c *APIClient) RunTest(ctx context.Context, scriptID int, headless bool, br
 	if baseURL != "" {
 		body["base_url"] = baseURL
 	}
-	return c.post(ctx, "/api/automation/run", body)
+	return c.post(ctx, fmt.Sprintf("/api/playwright-execution/run/%d", scriptID), body)
 }
 
 func (c *APIClient) RunTestsBatch(ctx context.Context, scriptIDs, baseURL string) string {
@@ -90,11 +89,11 @@ func (c *APIClient) RunTestsBatch(ctx context.Context, scriptIDs, baseURL string
 	if baseURL != "" {
 		body["base_url"] = baseURL
 	}
-	return c.post(ctx, "/api/automation/run-batch", body)
+	return c.post(ctx, "/api/playwright-execution/run-batch", body)
 }
 
 func (c *APIClient) CheckTestStatus(ctx context.Context, executionID string) string {
-	return c.get(ctx, "/api/automation/status/"+executionID)
+	return c.get(ctx, "/api/playwright-execution/status/"+executionID)
 }
 
 // --- Crawl operations ---

--- a/auth.go
+++ b/auth.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -157,11 +156,7 @@ func LoginInteractive() (*AuthConfig, error) {
 	fmt.Println("  Get your API key from:")
 	fmt.Println("  https://app.qualitymax.io/settings → API Keys")
 	fmt.Println()
-	fmt.Print("  Paste your API key (qm-...): ")
-
-	reader := bufio.NewReader(os.Stdin)
-	key, _ := reader.ReadString('\n')
-	key = strings.TrimSpace(key)
+	key := readSecret("  Paste your API key (qm-...): ")
 
 	if key == "" {
 		return nil, fmt.Errorf("no API key provided")

--- a/config.go
+++ b/config.go
@@ -22,28 +22,22 @@ const qmaxCodeConfigFile = "config.json"
 // LoadQMaxCodeConfig reads persistent user preferences from ~/.qmax-code/config.json
 // and loads the Anthropic key from the OS keychain.
 func LoadQMaxCodeConfig() *Config {
+	cfg := defaultConfig()
+
 	home, err := os.UserHomeDir()
-	if err != nil {
-		return defaultConfig()
+	if err == nil {
+		path := filepath.Join(home, qmaxCodeConfigDir, qmaxCodeConfigFile)
+		if data, err := os.ReadFile(path); err == nil {
+			_ = json.Unmarshal(data, cfg)
+		}
 	}
 
-	path := filepath.Join(home, qmaxCodeConfigDir, qmaxCodeConfigFile)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return defaultConfig()
-	}
-
-	var cfg Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return defaultConfig()
-	}
-
-	// Load Anthropic key from keychain (not stored in JSON)
+	// Load Anthropic key from OS keychain (never stored in JSON)
 	if key, err := LoadFromKeychain("anthropic_key"); err == nil && key != "" {
 		cfg.AnthropicKey = key
 	}
 
-	return &cfg
+	return cfg
 }
 
 // SaveAnthropicKey securely stores the Anthropic API key in the OS keychain.

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Professional   bool   `json:"professional,omitempty"` // disable cat personality
 	AutoSave       bool   `json:"auto_save"`              // auto-save session on exit (default true)
 	MaxTokenBudget int    `json:"max_token_budget,omitempty"`
+	AnthropicKey   string `json:"anthropic_key,omitempty"` // persisted Anthropic API key
 }
 
 const qmaxCodeConfigDir = ".qmax-code"

--- a/config.go
+++ b/config.go
@@ -13,13 +13,14 @@ type Config struct {
 	Professional   bool   `json:"professional,omitempty"` // disable cat personality
 	AutoSave       bool   `json:"auto_save"`              // auto-save session on exit (default true)
 	MaxTokenBudget int    `json:"max_token_budget,omitempty"`
-	AnthropicKey   string `json:"anthropic_key,omitempty"` // persisted Anthropic API key
+	AnthropicKey string `json:"-"` // NOT stored in JSON — use keychain instead
 }
 
 const qmaxCodeConfigDir = ".qmax-code"
 const qmaxCodeConfigFile = "config.json"
 
-// LoadQMaxCodeConfig reads persistent user preferences from ~/.qmax-code/config.json.
+// LoadQMaxCodeConfig reads persistent user preferences from ~/.qmax-code/config.json
+// and loads the Anthropic key from the OS keychain.
 func LoadQMaxCodeConfig() *Config {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -36,7 +37,18 @@ func LoadQMaxCodeConfig() *Config {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return defaultConfig()
 	}
+
+	// Load Anthropic key from keychain (not stored in JSON)
+	if key, err := LoadFromKeychain("anthropic_key"); err == nil && key != "" {
+		cfg.AnthropicKey = key
+	}
+
 	return &cfg
+}
+
+// SaveAnthropicKey securely stores the Anthropic API key in the OS keychain.
+func SaveAnthropicKey(key string) error {
+	return SaveToKeychain("anthropic_key", key)
 }
 
 // Save persists the config to ~/.qmax-code/config.json.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/glamour v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/chzyer/readline v1.5.1
+	golang.org/x/sys v0.36.0
 )
 
 require (
@@ -34,7 +35,6 @@ require (
 	github.com/yuin/goldmark v1.7.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.3 // indirect
 	golang.org/x/net v0.27.0 // indirect
-	golang.org/x/sys v0.36.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 )

--- a/input.go
+++ b/input.go
@@ -25,6 +25,7 @@ var slashMenuItems = []SlashMenuItem{
 	{"/resume", "Resume a session"},
 	{"/save", "Save current session"},
 	{"/project", "Set active project"},
+	{"/keys", "Set API keys (interactive)"},
 	{"/screenshot", "Capture & analyze a screenshot"},
 	{"/paste", "Paste from clipboard (image or text)"},
 	{"/set", "Update config"},

--- a/input.go
+++ b/input.go
@@ -25,6 +25,8 @@ var slashMenuItems = []SlashMenuItem{
 	{"/resume", "Resume a session"},
 	{"/save", "Save current session"},
 	{"/project", "Set active project"},
+	{"/screenshot", "Capture & analyze a screenshot"},
+	{"/paste", "Paste from clipboard (image or text)"},
 	{"/set", "Update config"},
 	{"/clear", "Clear history"},
 	{"/quit", "Exit"},

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -194,21 +194,66 @@ func selectProject(auth *AuthConfig) int {
 	return id
 }
 
-// readSecret reads a line of input, then overwrites it with a masked version.
+// readSecret reads a line of input with characters hidden (replaced with dots).
+// Shows a masked preview after completion.
 func readSecret(prompt string) string {
 	fmt.Print(prompt)
-	reader := bufio.NewReader(os.Stdin)
-	key, _ := reader.ReadString('\n')
-	key = strings.TrimSpace(key)
-	if key != "" {
-		// Move cursor up, clear line, reprint with masked value
-		masked := key[:4] + "..." + key[len(key)-4:]
-		if len(key) <= 8 {
-			masked = "****"
+
+	// Switch terminal to raw mode to hide input
+	oldState, err := enableRawMode()
+	if err != nil {
+		// Fallback: plain read + mask after
+		reader := bufio.NewReader(os.Stdin)
+		key, _ := reader.ReadString('\n')
+		key = strings.TrimSpace(key)
+		if key != "" {
+			masked := maskKey(key)
+			fmt.Printf("\033[1A\033[2K%s%s\n", prompt, masked)
 		}
-		fmt.Printf("\033[1A\033[2K%s%s\n", prompt, masked)
+		return key
 	}
-	return key
+
+	var input []byte
+	buf := make([]byte, 1)
+	for {
+		n, _ := os.Stdin.Read(buf)
+		if n == 0 {
+			continue
+		}
+		ch := buf[0]
+		switch ch {
+		case '\n', '\r':
+			restoreTermMode(oldState)
+			fmt.Println()
+			key := strings.TrimSpace(string(input))
+			if key != "" {
+				masked := maskKey(key)
+				fmt.Printf("\033[1A\033[2K%s%s\n", prompt, masked)
+			}
+			return key
+		case 127, '\b': // backspace
+			if len(input) > 0 {
+				input = input[:len(input)-1]
+				fmt.Print("\b \b")
+			}
+		case 3: // Ctrl+C
+			restoreTermMode(oldState)
+			fmt.Println()
+			return ""
+		default:
+			if ch >= 32 { // printable
+				input = append(input, ch)
+				fmt.Print("•")
+			}
+		}
+	}
+}
+
+func maskKey(key string) string {
+	if len(key) <= 8 {
+		return "••••"
+	}
+	return key[:4] + "•••" + key[len(key)-4:]
 }
 
 // --- UI helpers ---

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -77,10 +77,7 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 		fmt.Println("  I need an Anthropic API key to think (that's my brain!).")
 		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
 		fmt.Println()
-		fmt.Print("  Paste your Anthropic key (sk-ant-...): ")
-		reader := bufio.NewReader(os.Stdin)
-		key, _ := reader.ReadString('\n')
-		key = strings.TrimSpace(key)
+		key := readSecret("  Paste your Anthropic key (sk-ant-...): ")
 		if key != "" {
 			os.Setenv("ANTHROPIC_API_KEY", key)
 			// Save to OS keychain
@@ -112,10 +109,7 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 
 // loginWithKeyPrompt asks the user to paste their API key.
 func loginWithKeyPrompt() (*AuthConfig, error) {
-	fmt.Print("  Paste your API key (qm-...): ")
-	reader := bufio.NewReader(os.Stdin)
-	key, _ := reader.ReadString('\n')
-	key = strings.TrimSpace(key)
+	key := readSecret("  Paste your API key (qm-...): ")
 
 	if key == "" {
 		return nil, fmt.Errorf("no API key provided")
@@ -198,6 +192,23 @@ func selectProject(auth *AuthConfig) int {
 	_ = cfg.Save()
 
 	return id
+}
+
+// readSecret reads a line of input, then overwrites it with a masked version.
+func readSecret(prompt string) string {
+	fmt.Print(prompt)
+	reader := bufio.NewReader(os.Stdin)
+	key, _ := reader.ReadString('\n')
+	key = strings.TrimSpace(key)
+	if key != "" {
+		// Move cursor up, clear line, reprint with masked value
+		masked := key[:4] + "..." + key[len(key)-4:]
+		if len(key) <= 8 {
+			masked = "****"
+		}
+		fmt.Printf("\033[1A\033[2K%s%s\n", prompt, masked)
+	}
+	return key
 }
 
 // --- UI helpers ---

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -65,7 +65,12 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 	projectID := selectProject(auth)
 
 	// Step 3: Anthropic key check
-	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+	cfg := LoadQMaxCodeConfig()
+	anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
+	if anthropicKey == "" {
+		anthropicKey = cfg.AnthropicKey
+	}
+	if anthropicKey == "" {
 		fmt.Println()
 		AnimateMax(MoodThinking, "One more thing...")
 		fmt.Println()
@@ -78,10 +83,14 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 		key = strings.TrimSpace(key)
 		if key != "" {
 			os.Setenv("ANTHROPIC_API_KEY", key)
+			// Save persistently
+			cfg.AnthropicKey = key
+			_ = cfg.Save()
 			fmt.Println()
-			fmt.Println("  Tip: add this to your shell profile to avoid re-entering:")
-			fmt.Printf("    export ANTHROPIC_API_KEY=%s\n", key)
+			fmt.Println("  Key saved to ~/.qmax-code/config.json")
 		}
+	} else {
+		os.Setenv("ANTHROPIC_API_KEY", anthropicKey)
 	}
 
 	// All set!

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -83,11 +83,15 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 		key = strings.TrimSpace(key)
 		if key != "" {
 			os.Setenv("ANTHROPIC_API_KEY", key)
-			// Save persistently
-			cfg.AnthropicKey = key
-			_ = cfg.Save()
-			fmt.Println()
-			fmt.Println("  Key saved to ~/.qmax-code/config.json")
+			// Save to OS keychain
+			if err := SaveAnthropicKey(key); err != nil {
+				// Fallback: warn but continue
+				fmt.Printf("\n  Note: Could not save to keychain (%s)\n", err)
+				fmt.Println("  Key is set for this session. Set ANTHROPIC_API_KEY in your shell profile to persist.")
+			} else {
+				fmt.Println()
+				fmt.Println("  Key saved securely to OS keychain")
+			}
 		}
 	} else {
 		os.Setenv("ANTHROPIC_API_KEY", anthropicKey)

--- a/keychain.go
+++ b/keychain.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const keychainService = "qmax-code"
+
+// SaveToKeychain securely stores a key in the OS keychain.
+// macOS: Keychain Access, Linux: secret-tool, Fallback: config.json (0600 perms)
+func SaveToKeychain(account, secret string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		// Delete existing entry first (ignore errors)
+		_ = exec.Command("security", "delete-generic-password",
+			"-s", keychainService, "-a", account).Run()
+		// Add new entry
+		cmd := exec.Command("security", "add-generic-password",
+			"-s", keychainService, "-a", account,
+			"-w", secret, "-U")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("keychain save failed: %s", strings.TrimSpace(string(out)))
+		}
+		return nil
+
+	case "linux":
+		cmd := exec.Command("secret-tool", "store",
+			"--label", fmt.Sprintf("qmax-code %s", account),
+			"service", keychainService, "account", account)
+		cmd.Stdin = strings.NewReader(secret)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("secret-tool not available: %w", err)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("keychain not supported on %s", runtime.GOOS)
+	}
+}
+
+// LoadFromKeychain retrieves a key from the OS keychain.
+func LoadFromKeychain(account string) (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		out, err := exec.Command("security", "find-generic-password",
+			"-s", keychainService, "-a", account, "-w").Output()
+		if err != nil {
+			return "", fmt.Errorf("not found in keychain")
+		}
+		return strings.TrimSpace(string(out)), nil
+
+	case "linux":
+		out, err := exec.Command("secret-tool", "lookup",
+			"service", keychainService, "account", account).Output()
+		if err != nil {
+			return "", fmt.Errorf("not found in secret-tool")
+		}
+		return strings.TrimSpace(string(out)), nil
+
+	default:
+		return "", fmt.Errorf("keychain not supported on %s", runtime.GOOS)
+	}
+}
+
+// DeleteFromKeychain removes a key from the OS keychain.
+func DeleteFromKeychain(account string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("security", "delete-generic-password",
+			"-s", keychainService, "-a", account).Run()
+	case "linux":
+		return exec.Command("secret-tool", "clear",
+			"service", keychainService, "account", account).Run()
+	default:
+		return nil
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
 	"os"
@@ -137,10 +136,7 @@ func main() {
 		fmt.Println("  Anthropic API key needed (this powers the AI).")
 		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
 		fmt.Println()
-		fmt.Print("  Paste your Anthropic key (sk-ant-...): ")
-		reader := bufio.NewReader(os.Stdin)
-		key, _ := reader.ReadString('\n')
-		key = strings.TrimSpace(key)
+		key := readSecret("  Paste your Anthropic key: ")
 		if key != "" {
 			anthropicKey = key
 			os.Setenv("ANTHROPIC_API_KEY", key)
@@ -635,10 +631,7 @@ func handleKeys(agent *Agent, term *Terminal) {
 		fmt.Println()
 		fmt.Println("  Get your key at: https://console.anthropic.com/settings/keys")
 		fmt.Println()
-		fmt.Print("  Paste your Anthropic key: ")
-		reader := bufio.NewReader(os.Stdin)
-		key, _ := reader.ReadString('\n')
-		key = strings.TrimSpace(key)
+		key := readSecret("  Paste your Anthropic key: ")
 		if key == "" {
 			term.PrintSystem("Cancelled.")
 			return

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	Version = "1.3.0"
+	Version = "1.4.0"
 	Name    = "qmax-code"
 )
 

--- a/main.go
+++ b/main.go
@@ -93,18 +93,13 @@ func main() {
 	}
 	effectiveModel = resolveModel(effectiveModel)
 
-	// Resolve Anthropic API key: flag > env > saved config
+	// Resolve Anthropic API key: flag > env > keychain
 	anthropicKey := *apiKey
 	if anthropicKey == "" {
 		anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
 	}
 	if anthropicKey == "" && appConfig.AnthropicKey != "" {
 		anthropicKey = appConfig.AnthropicKey
-	}
-	if anthropicKey == "" {
-		fmt.Fprintln(os.Stderr, "Error: Anthropic API key required.")
-		fmt.Fprintln(os.Stderr, "Set ANTHROPIC_API_KEY or use --api-key")
-		os.Exit(1)
 	}
 
 	// Load auth (new standalone mode)
@@ -126,22 +121,24 @@ func main() {
 	}
 
 	// If no qmax CLI and no API client, run interactive setup
+	// (this also prompts for Anthropic key if missing)
 	if qmaxBin == "" && apiClient == nil {
 		setupAuth, setupProjectID := RunInteractiveSetup()
 		auth = setupAuth
 		apiClient = NewAPIClient(auth)
-		_ = setupProjectID // used below after detectedProjectID is declared
-		// Stash for use after project detection
 		appConfig.DefaultProject = setupProjectID
-		// Re-check Anthropic key after setup
+		// Re-check Anthropic key after setup (setup saves to keychain + env)
 		if anthropicKey == "" {
 			anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
 		}
-		if anthropicKey == "" {
-			fmt.Fprintln(os.Stderr, "Error: Anthropic API key required.")
-			fmt.Fprintln(os.Stderr, "Set ANTHROPIC_API_KEY or use --api-key")
-			os.Exit(1)
-		}
+	}
+
+	// Final check — if still no key after setup, exit
+	if anthropicKey == "" {
+		fmt.Fprintln(os.Stderr, "Error: Anthropic API key required.")
+		fmt.Fprintln(os.Stderr, "  Run:  qmax-code  (interactive setup will prompt)")
+		fmt.Fprintln(os.Stderr, "  Or:   export ANTHROPIC_API_KEY=sk-ant-...")
+		os.Exit(1)
 	}
 
 	// Detect project from cwd if not set via flag; fall back to saved config

--- a/main.go
+++ b/main.go
@@ -447,10 +447,66 @@ func runREPL(agent *Agent, quietMode bool) {
 		case strings.HasPrefix(input, "/set "):
 			handleSetCommand(input, agent, term)
 			continue
+		case input == "/screenshot":
+			img, err := CaptureScreenshot()
+			if err != nil {
+				term.PrintError(err.Error())
+				continue
+			}
+			term.PrintSystem(fmt.Sprintf("Screenshot captured (%s)", img.FileName))
+			llmResult, err := agent.RunStreamingWithImages("Analyze this screenshot.", []ImageAttachment{*img}, term)
+			if err != nil {
+				term.PrintError(err.Error())
+			}
+			if llmResult != "" {
+				fmt.Println()
+			}
+			autoSave()
+			continue
+		case input == "/paste":
+			// Try image first, then text
+			img, imgErr := PasteImageFromClipboard()
+			if imgErr == nil {
+				term.PrintSystem(fmt.Sprintf("Pasted image from clipboard (%s)", img.FileName))
+				llmResult, err := agent.RunStreamingWithImages("Analyze this pasted image.", []ImageAttachment{*img}, term)
+				if err != nil {
+					term.PrintError(err.Error())
+				}
+				if llmResult != "" {
+					fmt.Println()
+				}
+				autoSave()
+				continue
+			}
+			// Fall back to text paste
+			text, textErr := PasteTextFromClipboard()
+			if textErr != nil || text == "" {
+				term.PrintError("Nothing in clipboard")
+				continue
+			}
+			term.PrintSystem(fmt.Sprintf("Pasted %d chars from clipboard", len(text)))
+			input = text // fall through to normal processing
 		}
 
+		// Detect image file paths dragged/pasted into input
+		cleanInput, images := DetectAndLoadImages(input)
+
 		// Run through the LLM agent with streaming
-		llmResult, err := agent.RunStreaming(input, term)
+		var llmResult string
+		var err error
+		if len(images) > 0 {
+			names := make([]string, len(images))
+			for i, img := range images {
+				names[i] = img.FileName
+			}
+			term.PrintSystem(fmt.Sprintf("Attached %d image(s): %s", len(images), strings.Join(names, ", ")))
+			if cleanInput == "" {
+				cleanInput = "Analyze these images."
+			}
+			llmResult, err = agent.RunStreamingWithImages(cleanInput, images, term)
+		} else {
+			llmResult, err = agent.RunStreaming(input, term)
+		}
 		if err != nil {
 			term.PrintError(err.Error())
 			autoSave() // save even on error — preserves context
@@ -531,6 +587,8 @@ Commands:
   /context       Show current session context
   /cost          Show session token usage and estimated cost
   /config        Show current config settings
+  /screenshot    Capture a screenshot and analyze it
+  /paste         Paste from clipboard (image or text)
   /set <k> <v>   Update config (model, project, professional, autosave, budget)
   /save          Save current session
   /sessions      List recent sessions

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
@@ -450,6 +451,9 @@ func runREPL(agent *Agent, quietMode bool) {
 		case strings.HasPrefix(input, "/set "):
 			handleSetCommand(input, agent, term)
 			continue
+		case input == "/keys":
+			handleKeys(agent, term)
+			continue
 		case input == "/screenshot":
 			img, err := CaptureScreenshot()
 			if err != nil {
@@ -580,6 +584,70 @@ func handleDisconnect(agent *Agent, term *Terminal) {
 	term.PrintSystem("Run /connect to log in again.")
 }
 
+// handleKeys provides an interactive TUI for managing API keys.
+func handleKeys(agent *Agent, term *Terminal) {
+	fmt.Println()
+
+	// Show current key status
+	anthropicKey := agent.config.AnthropicKey
+	if anthropicKey == "" {
+		anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	qmaxConnected := agent.config.Context.Auth != nil && agent.config.Context.Auth.IsAuthenticated()
+
+	fmt.Printf("  %s API Keys %s\n\n", "\033[1m", "\033[0m")
+
+	if anthropicKey != "" {
+		masked := anthropicKey[:7] + "..." + anthropicKey[len(anthropicKey)-4:]
+		fmt.Printf("  Anthropic:   %s● Set%s (%s)\n", "\033[32m", "\033[0m", masked)
+	} else {
+		fmt.Printf("  Anthropic:   %s● Not set%s\n", "\033[33m", "\033[0m")
+	}
+
+	if qmaxConnected {
+		fmt.Printf("  QualityMax:  %s● Connected%s (%s)\n", "\033[32m", "\033[0m", agent.config.Context.Auth.Email)
+	} else {
+		fmt.Printf("  QualityMax:  %s● Not connected%s\n", "\033[33m", "\033[0m")
+	}
+	fmt.Println()
+
+	choice := promptChoice("  What would you like to do?", []string{
+		"Set Anthropic API key",
+		"Connect to QualityMax (browser)",
+		"Disconnect from QualityMax",
+		"Cancel",
+	})
+
+	switch choice {
+	case 0: // Anthropic key
+		fmt.Println()
+		fmt.Println("  Get your key at: https://console.anthropic.com/settings/keys")
+		fmt.Println()
+		fmt.Print("  Paste your Anthropic key: ")
+		reader := bufio.NewReader(os.Stdin)
+		key, _ := reader.ReadString('\n')
+		key = strings.TrimSpace(key)
+		if key == "" {
+			term.PrintSystem("Cancelled.")
+			return
+		}
+		os.Setenv("ANTHROPIC_API_KEY", key)
+		agent.config.AnthropicKey = key
+		if err := SaveAnthropicKey(key); err != nil {
+			term.PrintSystem(fmt.Sprintf("Key set for this session (keychain unavailable: %s)", err))
+		} else {
+			AnimateMax(MoodHappy, "Key saved to OS keychain!")
+			fmt.Println()
+		}
+	case 1: // QualityMax connect
+		handleConnect(agent, term)
+	case 2: // Disconnect
+		handleDisconnect(agent, term)
+	case 3: // Cancel
+		return
+	}
+}
+
 func printREPLHelp() {
 	fmt.Println(`
 Commands:
@@ -590,6 +658,7 @@ Commands:
   /context       Show current session context
   /cost          Show session token usage and estimated cost
   /config        Show current config settings
+  /keys          Set API keys (interactive menu)
   /screenshot    Capture a screenshot and analyze it
   /paste         Paste from clipboard (image or text)
   /set <k> <v>   Update config (model, project, professional, autosave, budget)
@@ -726,14 +795,18 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 		agent.config.Context.API = NewAPIClient(auth)
 		AnimateMax(MoodHappy, fmt.Sprintf("Connected as %s", auth.Email))
 		fmt.Println()
+		return // auth.json handles persistence
 
 	case "anthropic-key", "anthropic_key":
-		// Save Anthropic API key persistently
+		// Save Anthropic API key to OS keychain
 		os.Setenv("ANTHROPIC_API_KEY", value)
 		agent.config.AnthropicKey = value
-		cfg.AnthropicKey = value
-		term.PrintSystem("Anthropic API key saved.")
-		return // don't save to config.json, auth.json is handled by LoginWithAPIKey
+		if err := SaveAnthropicKey(value); err != nil {
+			term.PrintSystem(fmt.Sprintf("Key set for this session (keychain: %s)", err))
+		} else {
+			term.PrintSystem("Anthropic API key saved to OS keychain.")
+		}
+		return // don't save to config.json — keychain handles it
 
 	default:
 		term.PrintError(fmt.Sprintf("Unknown config key: %s", key))

--- a/main.go
+++ b/main.go
@@ -120,24 +120,39 @@ func main() {
 		apiClient = NewAPIClient(auth)
 	}
 
-	// If no qmax CLI and no API client, run interactive setup
-	// (this also prompts for Anthropic key if missing)
+	// If no qmax CLI and no API client, run full interactive setup
 	if qmaxBin == "" && apiClient == nil {
 		setupAuth, setupProjectID := RunInteractiveSetup()
 		auth = setupAuth
 		apiClient = NewAPIClient(auth)
 		appConfig.DefaultProject = setupProjectID
-		// Re-check Anthropic key after setup (setup saves to keychain + env)
 		if anthropicKey == "" {
 			anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
 		}
 	}
 
-	// Final check — if still no key after setup, exit
+	// If connected but missing Anthropic key, prompt for it
 	if anthropicKey == "" {
-		fmt.Fprintln(os.Stderr, "Error: Anthropic API key required.")
-		fmt.Fprintln(os.Stderr, "  Run:  qmax-code  (interactive setup will prompt)")
-		fmt.Fprintln(os.Stderr, "  Or:   export ANTHROPIC_API_KEY=sk-ant-...")
+		fmt.Println()
+		fmt.Println("  Anthropic API key needed (this powers the AI).")
+		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
+		fmt.Println()
+		fmt.Print("  Paste your Anthropic key (sk-ant-...): ")
+		reader := bufio.NewReader(os.Stdin)
+		key, _ := reader.ReadString('\n')
+		key = strings.TrimSpace(key)
+		if key != "" {
+			anthropicKey = key
+			os.Setenv("ANTHROPIC_API_KEY", key)
+			if err := SaveAnthropicKey(key); err == nil {
+				fmt.Println("  Saved to OS keychain.")
+			}
+		}
+	}
+
+	if anthropicKey == "" {
+		fmt.Fprintln(os.Stderr, "\nError: Anthropic API key required.")
+		fmt.Fprintln(os.Stderr, "  export ANTHROPIC_API_KEY=sk-ant-...")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -92,10 +92,13 @@ func main() {
 	}
 	effectiveModel = resolveModel(effectiveModel)
 
-	// Resolve Anthropic API key
+	// Resolve Anthropic API key: flag > env > saved config
 	anthropicKey := *apiKey
 	if anthropicKey == "" {
 		anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if anthropicKey == "" && appConfig.AnthropicKey != "" {
+		anthropicKey = appConfig.AnthropicKey
 	}
 	if anthropicKey == "" {
 		fmt.Fprintln(os.Stderr, "Error: Anthropic API key required.")
@@ -723,6 +726,13 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 		agent.config.Context.API = NewAPIClient(auth)
 		AnimateMax(MoodHappy, fmt.Sprintf("Connected as %s", auth.Email))
 		fmt.Println()
+
+	case "anthropic-key", "anthropic_key":
+		// Save Anthropic API key persistently
+		os.Setenv("ANTHROPIC_API_KEY", value)
+		agent.config.AnthropicKey = value
+		cfg.AnthropicKey = value
+		term.PrintSystem("Anthropic API key saved.")
 		return // don't save to config.json, auth.json is handled by LoginWithAPIKey
 
 	default:

--- a/media.go
+++ b/media.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// imageExtensions maps file extensions to MIME types.
+var imageExtensions = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+}
+
+// IsImagePath returns true if the path looks like an image file.
+func IsImagePath(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	_, ok := imageExtensions[ext]
+	return ok
+}
+
+// LoadImageFromFile reads an image file and returns an ImageAttachment.
+func LoadImageFromFile(path string) (*ImageAttachment, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read image: %w", err)
+	}
+
+	ext := strings.ToLower(filepath.Ext(path))
+	mediaType, ok := imageExtensions[ext]
+	if !ok {
+		return nil, fmt.Errorf("unsupported image format: %s", ext)
+	}
+
+	// Limit to 20MB (Claude API limit is ~20MB for images)
+	if len(data) > 20*1024*1024 {
+		return nil, fmt.Errorf("image too large (%d MB, max 20MB)", len(data)/(1024*1024))
+	}
+
+	return &ImageAttachment{
+		MediaType: mediaType,
+		Data:      base64.StdEncoding.EncodeToString(data),
+		FileName:  filepath.Base(path),
+	}, nil
+}
+
+// CaptureScreenshot takes a screenshot using macOS screencapture and returns it as an attachment.
+func CaptureScreenshot() (*ImageAttachment, error) {
+	tmpFile := filepath.Join(os.TempDir(), "qmax-screenshot.png")
+	defer os.Remove(tmpFile)
+
+	// Interactive screenshot selection on macOS
+	cmd := exec.Command("screencapture", "-i", tmpFile)
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("screenshot failed: %w", err)
+	}
+
+	// Check if file was created (user might have cancelled)
+	if _, err := os.Stat(tmpFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("screenshot cancelled")
+	}
+
+	return LoadImageFromFile(tmpFile)
+}
+
+// PasteImageFromClipboard checks if the clipboard has an image and returns it.
+func PasteImageFromClipboard() (*ImageAttachment, error) {
+	tmpFile := filepath.Join(os.TempDir(), "qmax-clipboard.png")
+	defer os.Remove(tmpFile)
+
+	// Try pngpaste first (brew install pngpaste)
+	cmd := exec.Command("pngpaste", tmpFile)
+	if err := cmd.Run(); err != nil {
+		// Fallback: use osascript to check clipboard
+		return nil, fmt.Errorf("no image in clipboard (install pngpaste for image paste support)")
+	}
+
+	if _, err := os.Stat(tmpFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("no image in clipboard")
+	}
+
+	return LoadImageFromFile(tmpFile)
+}
+
+// PasteTextFromClipboard returns the text content of the clipboard.
+func PasteTextFromClipboard() (string, error) {
+	out, err := exec.Command("pbpaste").Output()
+	if err != nil {
+		return "", fmt.Errorf("clipboard read failed: %w", err)
+	}
+	return string(out), nil
+}
+
+// DetectAndLoadImages checks if the input contains file paths to images.
+// Returns the cleaned text (without paths) and any loaded images.
+func DetectAndLoadImages(input string) (string, []ImageAttachment) {
+	words := strings.Fields(input)
+	var cleanWords []string
+	var images []ImageAttachment
+
+	for _, word := range words {
+		// Strip quotes that terminals add when dragging files
+		clean := strings.Trim(word, "'\"")
+		if IsImagePath(clean) {
+			if img, err := LoadImageFromFile(clean); err == nil {
+				images = append(images, *img)
+				continue
+			}
+		}
+		cleanWords = append(cleanWords, word)
+	}
+
+	cleanText := strings.Join(cleanWords, " ")
+	return cleanText, images
+}

--- a/term_raw.go
+++ b/term_raw.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package main
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+// enableRawMode puts the terminal into raw mode (no echo, no line buffering).
+// Returns the old state for restoration.
+func enableRawMode() (*unix.Termios, error) {
+	fd := int(os.Stdin.Fd())
+	old, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	if err != nil {
+		return nil, err
+	}
+
+	raw := *old
+	raw.Lflag &^= unix.ECHO | unix.ICANON
+	raw.Cc[unix.VMIN] = 1
+	raw.Cc[unix.VTIME] = 0
+
+	if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, &raw); err != nil {
+		return nil, err
+	}
+	return old, nil
+}
+
+// restoreTermMode restores the terminal to its previous state.
+func restoreTermMode(old *unix.Termios) {
+	if old != nil {
+		fd := int(os.Stdin.Fd())
+		_ = unix.IoctlSetTermios(fd, unix.TIOCSETA, old)
+	}
+}

--- a/term_raw_linux.go
+++ b/term_raw_linux.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build linux
 
 package main
 
@@ -9,7 +9,7 @@ import (
 
 func enableRawMode() (*unix.Termios, error) {
 	fd := int(os.Stdin.Fd())
-	old, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+	old, err := unix.IoctlGetTermios(fd, unix.TCGETS)
 	if err != nil {
 		return nil, err
 	}
@@ -17,7 +17,7 @@ func enableRawMode() (*unix.Termios, error) {
 	raw.Lflag &^= unix.ECHO | unix.ICANON
 	raw.Cc[unix.VMIN] = 1
 	raw.Cc[unix.VTIME] = 0
-	if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, &raw); err != nil {
+	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &raw); err != nil {
 		return nil, err
 	}
 	return old, nil
@@ -25,6 +25,6 @@ func enableRawMode() (*unix.Termios, error) {
 
 func restoreTermMode(old *unix.Termios) {
 	if old != nil {
-		_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TIOCSETA, old)
+		_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, old)
 	}
 }

--- a/terminal.go
+++ b/terminal.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -299,15 +300,46 @@ func (t *Terminal) PrintToolStart(name string, input interface{}) {
 	fmt.Println()
 }
 
-// PrintToolResult shows tool output (abbreviated).
+// PrintToolResult shows tool output with smart formatting for known result types.
 func (t *Terminal) PrintToolResult(name string, output string) {
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-	lineCount := len(lines)
-
 	if strings.HasPrefix(output, "{\"error\"") {
 		fmt.Printf("  %s %s\n", styleError.Render("✗ Error"), styleDim.Render(truncateStr(output, 120)))
 		return
 	}
+
+	// Smart display for execution status results
+	if (name == "check_test_status" || name == "run_test") && strings.Contains(output, "execution_id") {
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(output), &data); err == nil {
+			execID, _ := data["execution_id"].(string)
+			status, _ := data["status"].(string)
+			fmt.Printf("  Execution: %s\n", styleDim.Render(execID))
+			switch status {
+			case "passed":
+				fmt.Printf("    Status: %s\n", styleSuccess.Render("✓ PASSED"))
+			case "failed":
+				fmt.Printf("    Status: %s\n", styleError.Render("✗ FAILED"))
+			default:
+				fmt.Printf("    Status: %s\n", styleSystem.Render(status))
+			}
+			if msg, ok := data["message"].(string); ok && msg != "" {
+				fmt.Printf("    Message: %s\n", styleDim.Render(truncateStr(msg, 120)))
+			}
+			if errs, ok := data["test_errors"].(string); ok && errs != "" {
+				fmt.Printf("    Errors: %s\n", styleError.Render(truncateStr(errs, 200)))
+			}
+			if screenshots, ok := data["screenshot_paths"].([]interface{}); ok && len(screenshots) > 0 {
+				fmt.Printf("    Screenshots: %d captured\n", len(screenshots))
+			}
+			if video, ok := data["video_path"].(string); ok && video != "" {
+				fmt.Printf("    Video: %s\n", styleDim.Render("recorded"))
+			}
+			return
+		}
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	lineCount := len(lines)
 
 	if lineCount <= 3 {
 		for _, line := range lines {

--- a/terminal.go
+++ b/terminal.go
@@ -82,8 +82,9 @@ var toolIcons = map[string]string{
 type Terminal struct {
 	rl            *readline.Instance
 	renderer      *glamour.TermRenderer
-	streaming     bool   // true when we're in the middle of streaming text
-	currentPrompt string // track prompt for readline recreation
+	streaming     bool           // true when we're in the middle of streaming text
+	streamBuf     strings.Builder // buffers streamed text for post-render
+	currentPrompt string          // track prompt for readline recreation
 }
 
 // NewTerminal creates a new interactive terminal with markdown rendering.
@@ -226,19 +227,36 @@ func (t *Terminal) PrintBanner(version string, ctx *SessionContext) {
 func (t *Terminal) StreamText(text string) {
 	if !t.streaming {
 		t.streaming = true
+		t.streamBuf.Reset()
 		fmt.Println() // newline before assistant response
 	}
 	fmt.Print(text)
+	t.streamBuf.WriteString(text)
 }
 
 // FinishMarkdown is called when a text block is complete.
-// We already streamed the raw text, so now we just mark streaming as done.
-// Glamour rendering happens for the full response, not mid-stream.
+// Re-renders the streamed text with glamour for syntax highlighting.
 func (t *Terminal) FinishMarkdown(fullText string) {
 	if t.streaming {
 		t.streaming = false
-		// We already printed the raw text via StreamText.
-		// For a clean look, add a trailing newline if needed.
+
+		// If the text contains code blocks, re-render with glamour for highlighting
+		if t.renderer != nil && strings.Contains(fullText, "```") {
+			// Move cursor up to overwrite raw output, then print rendered version
+			rawLines := strings.Count(t.streamBuf.String(), "\n") + 1
+			// Clear the raw streamed output
+			for i := 0; i < rawLines; i++ {
+				fmt.Print("\033[1A\033[2K") // move up + clear line
+			}
+			rendered, err := t.renderer.Render(fullText)
+			if err == nil {
+				fmt.Print(rendered)
+				t.streamBuf.Reset()
+				return
+			}
+		}
+
+		t.streamBuf.Reset()
 		if !strings.HasSuffix(fullText, "\n") {
 			fmt.Println()
 		}

--- a/tools.go
+++ b/tools.go
@@ -127,6 +127,14 @@ func BuildToolDefs() []ToolDef {
 			)),
 		},
 
+		{
+			Name:        "check_job_status",
+			Description: "Check the status of a background job (AI review, gap analysis, etc). Use this for any job_id that starts with 'repo_ai_review_' or 'gap_analysis_'. NOT for test executions — use check_test_status for those.",
+			InputSchema: obj(props(
+				prop("job_id", "string", "Background job ID", true),
+			)),
+		},
+
 		// --- Local test execution (pytest, etc.) ---
 		{
 			Name:        "run_local_test",
@@ -590,6 +598,9 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 			saveScriptBackup(fmt.Sprintf("%d", scriptID), backup)
 		}
 		return api.UpdateScript(ctx, scriptID, strVal(input, "name"), code)
+
+	case "check_job_status":
+		return api.CheckBackgroundJob(ctx, strVal(input, "job_id"))
 
 	// --- k6 Performance Testing ---
 	case "k6_list_scripts":

--- a/tools.go
+++ b/tools.go
@@ -121,7 +121,7 @@ func BuildToolDefs() []ToolDef {
 		},
 		{
 			Name:        "check_test_status",
-			Description: "Check the status of a running test execution.",
+			Description: "Check the status of a test execution. Returns status, progress, message, test_errors, console_logs, screenshot_paths, video_path. When status is 'failed', always report the test_errors and message to the user.",
 			InputSchema: obj(props(
 				prop("execution_id", "string", "Execution ID to check", true),
 			)),
@@ -684,9 +684,15 @@ func runLocalTest(ctx context.Context, sctx *SessionContext, scriptID int, baseU
 		return raw
 	}
 
-	var script map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &script); err != nil {
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
 		return jsonError("Failed to parse script: " + err.Error())
+	}
+
+	// API returns {"success": true, "script": {...}} — unwrap
+	script, _ := resp["script"].(map[string]interface{})
+	if script == nil {
+		script = resp // fallback: maybe the response IS the script
 	}
 
 	code := ""

--- a/tools.go
+++ b/tools.go
@@ -137,6 +137,217 @@ func BuildToolDefs() []ToolDef {
 			)),
 		},
 
+		// --- k6 Performance Testing ---
+		{
+			Name:        "k6_list_scripts",
+			Description: "List k6 performance test scripts for a project.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+			)),
+		},
+		{
+			Name:        "k6_create_script",
+			Description: "Create a k6 performance test script. Supports load, stress, spike, soak, smoke, breakpoint, API, security, and browser test types.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+				prop("name", "string", "Script name", true),
+				prop("test_type", "string", "Test type: load, stress, spike, soak, smoke, breakpoint, api, security, browser", true),
+				prop("target_url", "string", "Target URL to test", true),
+				prop("code", "string", "k6 script code (optional — auto-generated if empty)", false),
+			)),
+		},
+		{
+			Name:        "k6_get_script",
+			Description: "Get a k6 script by ID including its code.",
+			InputSchema: obj(props(
+				prop("script_id", "integer", "k6 script ID", true),
+			)),
+		},
+		{
+			Name:        "k6_run_test",
+			Description: "Execute a k6 performance test. Returns an execution ID for polling status.",
+			InputSchema: obj(props(
+				prop("script_id", "integer", "k6 script ID to execute", true),
+				prop("vus", "integer", "Number of virtual users (override)", false),
+				prop("duration", "string", "Test duration override (e.g. '30s', '5m')", false),
+			)),
+		},
+		{
+			Name:        "k6_check_status",
+			Description: "Check the status and results of a k6 test execution.",
+			InputSchema: obj(props(
+				prop("execution_id", "string", "k6 execution ID", true),
+			)),
+		},
+		{
+			Name:        "k6_report",
+			Description: "Get the full report of a k6 test execution with metrics, thresholds, and HTTP stats.",
+			InputSchema: obj(props(
+				prop("execution_id", "string", "k6 execution ID", true),
+			)),
+		},
+		{
+			Name:        "k6_generate",
+			Description: "Generate a k6 performance test script from a target URL. Auto-creates load profiles with thresholds.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+				prop("target_url", "string", "URL to generate test for", true),
+				prop("test_type", "string", "Test type: load, stress, spike, soak, smoke", false),
+				prop("endpoints", "string", "Comma-separated endpoint paths to test", false),
+			)),
+		},
+		{
+			Name:        "k6_convert",
+			Description: "Convert performance test scripts from JMeter, Gatling, Locust, or Playwright to k6.",
+			InputSchema: obj(props(
+				prop("source_code", "string", "Source test script code", true),
+				prop("source_framework", "string", "Source framework: jmeter, gatling, locust, playwright", true),
+				prop("test_type", "string", "Target k6 test type (default: load)", false),
+			)),
+		},
+
+		// --- Test Case CRUD ---
+		{
+			Name:        "create_test_case",
+			Description: "Create a new test case in a project.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+				prop("title", "string", "Test case title", true),
+				prop("description", "string", "Test case description/steps", true),
+				prop("category", "string", "Category: functional, api, ui, security, performance, accessibility", false),
+				prop("priority", "string", "Priority: critical, high, medium, low", false),
+			)),
+		},
+		{
+			Name:        "update_test_case",
+			Description: "Update an existing test case.",
+			InputSchema: obj(props(
+				prop("test_case_id", "integer", "Test case ID", true),
+				prop("title", "string", "New title", false),
+				prop("description", "string", "New description", false),
+				prop("category", "string", "New category", false),
+				prop("priority", "string", "New priority", false),
+				prop("status", "string", "New status: active, draft, deprecated", false),
+			)),
+		},
+		{
+			Name:        "delete_test_case",
+			Description: "Delete a test case. This is irreversible.",
+			InputSchema: obj(props(
+				prop("test_case_id", "integer", "Test case ID to delete", true),
+			)),
+		},
+
+		// --- Project CRUD ---
+		{
+			Name:        "create_project",
+			Description: "Create a new QualityMax project.",
+			InputSchema: obj(props(
+				prop("name", "string", "Project name", true),
+				prop("description", "string", "Project description", false),
+				prop("base_url", "string", "Base URL of the app under test", false),
+			)),
+		},
+		{
+			Name:        "update_project",
+			Description: "Update a project's name, description, or base URL.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+				prop("name", "string", "New name", false),
+				prop("description", "string", "New description", false),
+				prop("base_url", "string", "New base URL", false),
+			)),
+		},
+		{
+			Name:        "delete_project",
+			Description: "Delete a project and all its test cases and scripts. This is irreversible.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID to delete", true),
+			)),
+		},
+		{
+			Name:        "get_project_summary",
+			Description: "Get a project's summary including test case count, script count, and recent activity.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+			)),
+		},
+
+		// --- Framework Operations ---
+		{
+			Name:        "trigger_framework_run",
+			Description: "Trigger a CI test run for a project's framework (runs all tests in the GitHub Action).",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+				prop("framework_type", "string", "Framework: playwright or pytest", false),
+			)),
+		},
+		{
+			Name:        "export_framework",
+			Description: "Export a project's test framework as a downloadable zip with all scripts and config.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+				prop("framework", "string", "Framework type: playwright (default) or pytest", false),
+			)),
+		},
+		{
+			Name:        "get_install_command",
+			Description: "Get the one-liner install command for a project's test framework (for CI/CD setup).",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+			)),
+		},
+
+		// --- AI-Powered ---
+		{
+			Name:        "enhance_test_case",
+			Description: "Use AI to enhance a test case — adds detailed steps, edge cases, and assertions.",
+			InputSchema: obj(props(
+				prop("test_case_id", "integer", "Test case ID to enhance", true),
+			)),
+		},
+		{
+			Name:        "generate_gap_tests",
+			Description: "Analyze a repository and generate test cases for untested code paths.",
+			InputSchema: obj(props(
+				prop("repo_id", "integer", "Repository ID", true),
+			)),
+		},
+		{
+			Name:        "start_crawl_from_test_case",
+			Description: "Start an AI crawl that targets a specific test case — generates automation for that test scenario.",
+			InputSchema: obj(props(
+				prop("test_case_id", "integer", "Test case ID", true),
+			)),
+		},
+
+		// --- QTML ---
+		{
+			Name:        "export_qtml",
+			Description: "Export a project's test cases as QTML (QualityMax Test Markup Language) for portability.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID to export", true),
+			)),
+		},
+		{
+			Name:        "import_qtml",
+			Description: "Import test cases from QTML format into a project.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Target project ID", true),
+				prop("content", "string", "QTML content to import", true),
+			)),
+		},
+
+		// --- Deployment Testing ---
+		{
+			Name:        "test_deployed_environment",
+			Description: "Run a smoke test against a deployed environment URL.",
+			InputSchema: obj(props(
+				prop("project_id", "integer", "Project ID", true),
+				prop("url", "string", "Deployment URL to test", true),
+			)),
+		},
+
 		// --- Crawl operations ---
 		{
 			Name:        "start_crawl",
@@ -379,6 +590,68 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 			saveScriptBackup(fmt.Sprintf("%d", scriptID), backup)
 		}
 		return api.UpdateScript(ctx, scriptID, strVal(input, "name"), code)
+
+	// --- k6 Performance Testing ---
+	case "k6_list_scripts":
+		return api.K6ListScripts(ctx, intVal(input, "project_id", sctx.ProjectID))
+	case "k6_create_script":
+		return api.K6CreateScript(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "name"), strVal(input, "test_type"), strVal(input, "target_url"), strVal(input, "code"))
+	case "k6_get_script":
+		return api.K6GetScript(ctx, intVal(input, "script_id", 0))
+	case "k6_run_test":
+		return api.K6RunTest(ctx, intVal(input, "script_id", 0), intVal(input, "vus", 0), strVal(input, "duration"))
+	case "k6_check_status":
+		return api.K6CheckStatus(ctx, strVal(input, "execution_id"))
+	case "k6_report":
+		return api.K6Report(ctx, strVal(input, "execution_id"))
+	case "k6_generate":
+		return api.K6Generate(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "target_url"), strVal(input, "test_type"), strVal(input, "endpoints"))
+	case "k6_convert":
+		return api.K6Convert(ctx, strVal(input, "source_code"), strVal(input, "source_framework"), strVal(input, "test_type"))
+
+	// --- Test Case CRUD ---
+	case "create_test_case":
+		return api.CreateTestCase(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "title"), strVal(input, "description"), strVal(input, "category"), strVal(input, "priority"))
+	case "update_test_case":
+		return api.UpdateTestCase(ctx, intVal(input, "test_case_id", 0), strVal(input, "title"), strVal(input, "description"), strVal(input, "category"), strVal(input, "priority"), strVal(input, "status"))
+	case "delete_test_case":
+		return api.DeleteTestCase(ctx, intVal(input, "test_case_id", 0))
+
+	// --- Project CRUD ---
+	case "create_project":
+		return api.CreateProject(ctx, strVal(input, "name"), strVal(input, "description"), strVal(input, "base_url"))
+	case "update_project":
+		return api.UpdateProject(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "name"), strVal(input, "description"), strVal(input, "base_url"))
+	case "delete_project":
+		return api.DeleteProject(ctx, intVal(input, "project_id", 0))
+	case "get_project_summary":
+		return api.GetProjectSummary(ctx, intVal(input, "project_id", sctx.ProjectID))
+
+	// --- Framework Operations ---
+	case "trigger_framework_run":
+		return api.TriggerFrameworkRun(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "framework_type"))
+	case "export_framework":
+		return api.ExportFramework(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "framework"))
+	case "get_install_command":
+		return api.GetInstallCommand(ctx, intVal(input, "project_id", sctx.ProjectID))
+
+	// --- AI-Powered ---
+	case "enhance_test_case":
+		return api.EnhanceTestCase(ctx, intVal(input, "test_case_id", 0))
+	case "generate_gap_tests":
+		return api.GenerateGapTests(ctx, intVal(input, "repo_id", 0))
+	case "start_crawl_from_test_case":
+		return api.StartCrawlFromTestCase(ctx, intVal(input, "test_case_id", 0))
+
+	// --- QTML ---
+	case "export_qtml":
+		return api.ExportQTML(ctx, intVal(input, "project_id", sctx.ProjectID))
+	case "import_qtml":
+		return api.ImportQTML(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "content"))
+
+	// --- Deployment Testing ---
+	case "test_deployed_environment":
+		return api.TestDeployedEnvironment(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "url"))
 
 	case "run_local_test":
 		return runLocalTest(ctx, sctx, intVal(input, "script_id", 0), strVal(input, "base_url"))


### PR DESCRIPTION
## Summary
Brings qmax-code from 25 to 49 tools, closing the gap with QualityMax MCP server.

### New tools by phase:
- **k6 Performance** (8): list, create, get, run, status, report, generate, convert
- **Test Case CRUD** (3): create, update, delete
- **Project CRUD** (4): create, update, delete, get_summary
- **Frameworks** (3): trigger CI run, export zip, install command
- **AI-Powered** (3): enhance test case, generate gap tests, crawl from test case
- **QTML** (2): export, import
- **Deployment** (1): smoke test URL

### Not in this PR (follow-up):
- Image/screenshot/paste support (Phase 8)
- Report local test results back to platform (Phase 7)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Test k6 tools: "list k6 scripts for project 128"
- [ ] Test CRUD: "create a test case called Login Test"
- [ ] Test framework: "get install command for project 128"

🤖 Generated with [Claude Code](https://claude.com/claude-code)