### PR TITLE
fix: API client auth, project create, crawl from test case

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -33,7 +33,11 @@ func NewAPIClient(auth *AuthConfig) *APIClient {
 // --- Project operations ---
 
 func (c *APIClient) ListProjects(ctx context.Context) string {
-	return c.get(ctx, "/api/projects")
+	return c.get(ctx, "/api/projects?limit=200")
+}
+
+func (c *APIClient) GetProjectBySlug(ctx context.Context, slug string) string {
+	return c.get(ctx, "/api/projects/by-slug/"+slug)
 }
 
 // --- Test case operations ---
@@ -330,14 +334,28 @@ func (c *APIClient) DeleteTestCase(ctx context.Context, testCaseID int) string {
 // --- Project CRUD ---
 
 func (c *APIClient) CreateProject(ctx context.Context, name, description, baseURL string) string {
+	// Auto-generate project key from name (uppercase, alphanumeric, max 10 chars)
+	key := ""
+	for _, ch := range strings.ToUpper(name) {
+		if (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') {
+			key += string(ch)
+		}
+		if len(key) >= 10 {
+			break
+		}
+	}
+	if key == "" {
+		key = "PROJ"
+	}
 	body := map[string]interface{}{
 		"name": name,
+		"key":  key,
 	}
 	if description != "" {
 		body["description"] = description
 	}
 	if baseURL != "" {
-		body["base_url"] = baseURL
+		body["main_url"] = baseURL
 	}
 	return c.post(ctx, "/api/projects", body)
 }
@@ -404,10 +422,7 @@ func (c *APIClient) GenerateGapTests(ctx context.Context, repoID int) string {
 }
 
 func (c *APIClient) StartCrawlFromTestCase(ctx context.Context, testCaseID int) string {
-	body := map[string]interface{}{
-		"test_case_id": testCaseID,
-	}
-	return c.post(ctx, "/api/ai-crawl/start-from-test-case", body)
+	return c.post(ctx, fmt.Sprintf("/api/ai-crawl/start-from-test-case/%d", testCaseID), nil)
 }
 
 // --- QTML ---
@@ -500,9 +515,8 @@ func (c *APIClient) put(ctx context.Context, path string, body interface{}) stri
 }
 
 func (c *APIClient) doRequest(req *http.Request) string {
-	// Auth: use API key as Bearer token (strip qm- prefix if present)
-	token := strings.TrimPrefix(c.APIKey, "qm-")
-	req.Header.Set("Authorization", "Bearer "+token)
+	// Auth: send full API key as Bearer token (backend handles qm- prefix)
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := c.HTTP.Do(req)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Version = "1.5.2"
+	Version = "1.5.3"
 	Name    = "qmax-code"
 )
 


### PR DESCRIPTION
## Summary
- Fix Bearer auth: send full API key with `qm-` prefix (backend needs it for hash verification)
- Fix `CreateProject`: add required `key` field, use `main_url` not `base_url`
- Fix `StartCrawlFromTestCase`: use path param `/start-from-test-case/{id}` (was sending as body → 405)
- Fix `ListProjects`: add `?limit=200` (was truncating at 20)
- Add `GetProjectBySlug` for slug-based lookup

## Problem
- **403 on AI crawl**: Bearer token was sent without `qm-` prefix → API token hash mismatch → auth failure on some endpoints
- **405 on crawl from test case**: wrong URL pattern (body vs path param)
- **422 on create project**: missing required `key` field
- **Only 20 projects visible**: no limit param in API call
- **Can't find projects by slug**: no slug lookup function

## Test plan
- [x] `go build` compiles clean
- [x] `go test ./...` passes
- [ ] Manual: verify all 46 projects list
- [ ] Manual: create project, start crawl from test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)