### PR TITLE
feat: Review preferences, capability lanes, discovery nudges

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -790,7 +790,23 @@ RULES:
 5. Be concise. Lead with the answer. Max 3-4 lines for simple questions.
 6. You CAN write files using write_file tool or run_command with heredoc/echo.
 
-COSTS: Free=list/status/read/get_script. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
+COSTS: Free=list/status/read/get_script/get_review_preferences/set_review_preferences. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
+
+## Capability Lanes
+1. AI code review → review_repo, create_pr, get_review_preferences, set_review_preferences
+2. Test generation → generate_test_code, enhance_test_case, generate_gap_tests
+3. AI-crawl discovery → start_crawl, crawl_status, crawl_results
+4. Execution → run_test, run_native_test, run_tests_batch, check_test_status
+5. k6 load testing → k6_generate, k6_run_test, k6_check_status, k6_report, k6_convert
+6. Coverage & analytics → repo_coverage, repo_quality, get_project_summary
+7. QTML → export_qtml, import_qtml
+8. CI/CD → setup_cicd, trigger_framework_run, get_install_command
+
+## Review Preferences
+Before running review_repo, call get_review_preferences. If unconfigured, walk user through set_review_preferences (global first, then per-repo overrides).
+
+## Discovery Nudges
+After completing the user's ask, mention ONE adjacent capability they might not know about. One short sentence. At most one per turn; never repeat in a session.
 
 ## Test Healing — Autonomous Script Repair
 
@@ -841,7 +857,23 @@ RULES:
 5. Be concise. Lead with the answer. Max 3-4 lines for simple questions.
 6. You CAN write files using write_file tool or run_command with heredoc/echo.
 
-COSTS: Free=list/status/read/get_script. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
+COSTS: Free=list/status/read/get_script/get_review_preferences/set_review_preferences. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
+
+## Capability Lanes
+1. AI code review → review_repo, create_pr, get_review_preferences, set_review_preferences
+2. Test generation → generate_test_code, enhance_test_case, generate_gap_tests
+3. AI-crawl discovery → start_crawl, crawl_status, crawl_results
+4. Execution → run_test, run_native_test, run_tests_batch, check_test_status
+5. k6 load testing → k6_generate, k6_run_test, k6_check_status, k6_report, k6_convert
+6. Coverage & analytics → repo_coverage, repo_quality, get_project_summary
+7. QTML → export_qtml, import_qtml
+8. CI/CD → setup_cicd, trigger_framework_run, get_install_command
+
+## Review Preferences
+Before running review_repo, call get_review_preferences. If unconfigured, walk user through set_review_preferences (global first, then per-repo overrides).
+
+## Discovery Nudges
+After completing the user's ask, mention ONE adjacent capability they might not know about. One short sentence. At most one per turn; never repeat in a session.
 
 ## Test Healing — Autonomous Script Repair
 

--- a/api_client.go
+++ b/api_client.go
@@ -281,6 +281,25 @@ func (c *APIClient) ReviewRepo(ctx context.Context, repoID int) string {
 	return c.post(ctx, fmt.Sprintf("/api/repositories/%d/ai-review", repoID), map[string]interface{}{})
 }
 
+func (c *APIClient) GetReviewPreferences(ctx context.Context, repoID int) string {
+	body := map[string]interface{}{}
+	if repoID > 0 {
+		body["repository_id"] = repoID
+	}
+	return c.post(ctx, "/api/mcp/tool/get_review_preferences", body)
+}
+
+func (c *APIClient) SetReviewPreferences(ctx context.Context, scope string, repoID int, preferences interface{}) string {
+	body := map[string]interface{}{
+		"scope":       scope,
+		"preferences": preferences,
+	}
+	if repoID > 0 {
+		body["repository_id"] = repoID
+	}
+	return c.post(ctx, "/api/mcp/tool/set_review_preferences", body)
+}
+
 func (c *APIClient) RepoCoverage(ctx context.Context, repoID int) string {
 	return c.get(ctx, fmt.Sprintf("/api/repositories/%d/coverage", repoID))
 }

--- a/tools.go
+++ b/tools.go
@@ -443,9 +443,25 @@ func BuildToolDefs() []ToolDef {
 		},
 		{
 			Name:        "review_repo",
-			Description: "Start an AI-powered code review for a repository. Analyzes testing quality, security, and suggests improvements.",
+			Description: "Start an AI-powered code review for a repository. Analyzes testing quality, security, and suggests improvements. Respects the user's saved review preferences (which categories to check/skip).",
 			InputSchema: obj(props(
 				prop("repo_id", "integer", "Repository ID", true),
+			)),
+		},
+		{
+			Name:        "get_review_preferences",
+			Description: "Get the user's AI code-review preferences (which categories to check, which to skip). Returns effective preferences: per-repo overrides merged over global defaults. Call without repository_id for global defaults only.",
+			InputSchema: obj(props(
+				prop("repository_id", "integer", "Repository ID. Omit to get global defaults only.", false),
+			)),
+		},
+		{
+			Name:        "set_review_preferences",
+			Description: "Set or update AI code-review preferences. Categories: security, performance, test_coverage, type_safety, accessibility, style, secrets_scanning, ai_safety_for_agents (booleans). Plus optional custom_focus (string, max 500 chars). Use scope='global' for defaults, scope='repo' with repository_id for per-repo overrides.",
+			InputSchema: obj(props(
+				prop("scope", "string", "global or repo", true),
+				prop("repository_id", "integer", "Required when scope is repo", false),
+				prop("preferences", "object", "Key-value map of review categories (boolean) and optional custom_focus (string)", true),
 			)),
 		},
 		{
@@ -630,6 +646,12 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 
 	case "review_repo":
 		return api.ReviewRepo(ctx, intVal(input, "repo_id", 0))
+
+	case "get_review_preferences":
+		return api.GetReviewPreferences(ctx, intVal(input, "repository_id", 0))
+
+	case "set_review_preferences":
+		return api.SetReviewPreferences(ctx, strVal(input, "scope"), intVal(input, "repository_id", 0), input["preferences"])
 
 	case "repo_coverage":
 		return api.RepoCoverage(ctx, intVal(input, "repo_id", 0))
@@ -1306,6 +1328,8 @@ func ToolCost(name string) string {
 		return "high" // significant AI + execution cost
 	case "import_repo", "import_document", "create_pr", "update_script", "rollback_script":
 		return "medium"
+	case "get_review_preferences", "set_review_preferences":
+		return "free"
 	default:
 		return "free"
 	}


### PR DESCRIPTION
## Summary
- Add `get_review_preferences` and `set_review_preferences` tools (57 total)
- API client methods for `/api/mcp/tool/*` endpoints
- System prompt: 8 capability lanes, review-preferences calibration flow, one-per-turn discovery nudges
- Both professional + cat personality modes updated

Syncs with qamax-rag-app PR #408 (MCP server brief) and PR #409 (AI review preferences Phase 1-3).

## Test plan
- [x] `go build` — compiles clean
- [x] `go test ./... -short` — all pass
- [ ] Manual: connect to qualitymax.io, run `get_review_preferences`, `set_review_preferences`
- [ ] Manual: verify discovery nudge fires after first tool completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)