### PR TITLE
feat: BYO Claude Code / Codex interop mode (consent-first)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -612,10 +612,13 @@ func (a *Agent) callStreamingAPI(term *Terminal, model string) ([]ContentBlock, 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		apiErr := fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
-		a.logger.Error("api", apiErr.Error())
-		CaptureError(apiErr, map[string]interface{}{
-			"model":        model,
-			"status_code":  fmt.Sprintf("%d", resp.StatusCode),
+		a.logger.Error("api", apiErr.Error()) // local logger only — not sent off-machine
+		// Telemetry: send only the structural fields and the API error code.
+		// The body (which may include echoed-back prompt content in validation
+		// errors) is logged locally but NOT forwarded to Bugsink.
+		CaptureError(fmt.Errorf("anthropic API error %d", resp.StatusCode), map[string]interface{}{
+			"model":         model,
+			"status_code":   fmt.Sprintf("%d", resp.StatusCode),
 			"message_count": fmt.Sprintf("%d", len(a.history)),
 		})
 		return nil, "", apiErr

--- a/cc_agent.go
+++ b/cc_agent.go
@@ -34,15 +34,33 @@ type CLIAgent interface {
 //  4. qmax-code parses CC's stream-json and renders in the terminal
 //  5. CC session ID is saved for --resume on the next turn
 type CCAgent struct {
-	claudeBin     string
-	modelID       string // "" = let CC decide; otherwise passed as --model
-	effort        string // "low" | "medium" | "high" — injected into system prompt
-	ccSessionID   string // CC's own session ID, for --resume
-	mcpConfigPath string // temp MCP config written once per qmax session
-	sctx          *SessionContext
-	lastToolName  string // track last tool name for result display
-	mu            sync.Mutex
+	claudeBin      string
+	modelID        string // "" = let CC decide; otherwise passed as --model
+	effort         string // "low" | "medium" | "high" — injected into system prompt
+	permissionMode string // "standard" | "unattended" — see Run() for behavior
+	ccSessionID    string // CC's own session ID, for --resume
+	mcpConfigPath  string // temp MCP config written once per qmax session
+	sctx           *SessionContext
+	lastToolName   string // track last tool name for result display
+	mu             sync.Mutex
 }
+
+// ccStandardAllowlist is the curated list passed to `claude --allowedTools` in
+// "standard" permission mode. Tools on this list are auto-approved without
+// prompting CC's permission UI; tools NOT on this list will refuse silently
+// in --print mode. The list covers everything QMax users routinely need:
+// file inspection, search, git read ops, common test runners, all qmax MCP tools.
+// Mutating filesystem ops (Edit, Write) and destructive shell are deliberately
+// excluded — those require Unattended mode.
+const ccStandardAllowlist = "Read,Glob,Grep,WebFetch," +
+	"Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git branch:*),Bash(git show:*),Bash(git stash:*),Bash(git remote:*)," +
+	"Bash(ls:*),Bash(cat:*),Bash(head:*),Bash(tail:*),Bash(pwd:*),Bash(echo:*),Bash(which:*),Bash(file:*),Bash(wc:*),Bash(find:*),Bash(env:*),Bash(date:*),Bash(uname:*)," +
+	"Bash(npm test:*),Bash(npm run test:*),Bash(npm list:*),Bash(yarn test:*),Bash(pnpm test:*)," +
+	"Bash(go test:*),Bash(go vet:*),Bash(go build:*),Bash(go run:*),Bash(go list:*),Bash(go mod:*)," +
+	"Bash(pytest:*),Bash(python -m pytest:*),Bash(python3 -m pytest:*),Bash(python -m unittest:*),Bash(python3 -m unittest:*)," +
+	"Bash(cargo test:*),Bash(cargo check:*),Bash(cargo build:*),Bash(cargo run:*)," +
+	"Bash(jest:*),Bash(rspec:*),Bash(make test:*),Bash(make check:*),Bash(make build:*)," +
+	"mcp__qmax__*"
 
 // ccQASystemPrompt is injected via --append-system-prompt on every CC turn.
 // Tools are discovered via MCP so we don't list them — instead we focus on
@@ -137,11 +155,22 @@ func FindClaudeCode() string {
 // NewCCAgent creates a CC subprocess orchestrator.
 // modelID is passed as --model to the claude CLI (empty = CC's default).
 // effort is "low" | "medium" | "high" (empty defaults to "high").
-func NewCCAgent(claudeBin, modelID, effort string, sctx *SessionContext) *CCAgent {
+// permissionMode is "standard" (curated allowlist) or "unattended"
+// (--dangerously-skip-permissions). Both require explicit user consent.
+func NewCCAgent(claudeBin, modelID, effort, permissionMode string, sctx *SessionContext) *CCAgent {
 	if effort == "" {
 		effort = "high"
 	}
-	return &CCAgent{claudeBin: claudeBin, modelID: modelID, effort: effort, sctx: sctx}
+	if permissionMode == "" {
+		permissionMode = "standard"
+	}
+	return &CCAgent{
+		claudeBin:      claudeBin,
+		modelID:        modelID,
+		effort:         effort,
+		permissionMode: permissionMode,
+		sctx:           sctx,
+	}
 }
 
 // writeMCPConfig writes a temp JSON file that tells CC where to find our MCP server.
@@ -204,8 +233,20 @@ func (a *CCAgent) Run(userMsg string, term *Terminal) (string, error) {
 	args := []string{
 		"--print", userMsg,
 		"--output-format", "stream-json",
+		"--verbose",
 		"--append-system-prompt", systemPrompt,
 		"--mcp-config", mcpPath,
+	}
+	switch a.permissionMode {
+	case "unattended":
+		// Full autonomy. Only present after explicit user consent.
+		args = append(args, "--dangerously-skip-permissions")
+	default: // "standard"
+		// Curated allowlist: read tools, test runners, qmax MCP tools auto-approve;
+		// Edit/Write/destructive shell silently refuse in --print mode. Less
+		// babysitting than vanilla CC (no per-read prompts) without ceding control
+		// over file mutations.
+		args = append(args, "--allowedTools", ccStandardAllowlist)
 	}
 	if a.modelID != "" {
 		args = append(args, "--model", a.modelID)

--- a/cc_agent.go
+++ b/cc_agent.go
@@ -1,0 +1,422 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// CLIAgent is the interface implemented by both CCAgent (claude CLI) and
+// CodexAgent (codex CLI). It lets main.go switch backends without caring
+// which CLI is underneath.
+type CLIAgent interface {
+	Run(userMsg string, term *Terminal) (string, error)
+	Cleanup()
+}
+
+// CCAgent orchestrates a Claude Code CLI subprocess for LLM inference.
+// All inference runs through the user's CC subscription — zero Anthropic API
+// tokens consumed by qmax-code itself. qmax tools are exposed to CC as an MCP
+// server so CC can call them natively via its own tool-use mechanism.
+//
+// Per-message flow:
+//  1. qmax-code spawns:  claude --print "msg" --output-format stream-json
+//     --append-system-prompt <QA_PROMPT> --mcp-config <temp_file>
+//     [--resume <cc_session_id>]
+//  2. CC spawns: qmax-code serve --mcp  (our MCP server subprocess)
+//  3. CC uses qmax tools via MCP, runs on its own subscription
+//  4. qmax-code parses CC's stream-json and renders in the terminal
+//  5. CC session ID is saved for --resume on the next turn
+type CCAgent struct {
+	claudeBin     string
+	modelID       string // "" = let CC decide; otherwise passed as --model
+	effort        string // "low" | "medium" | "high" — injected into system prompt
+	ccSessionID   string // CC's own session ID, for --resume
+	mcpConfigPath string // temp MCP config written once per qmax session
+	sctx          *SessionContext
+	lastToolName  string // track last tool name for result display
+	mu            sync.Mutex
+}
+
+// ccQASystemPrompt is injected via --append-system-prompt on every CC turn.
+// Tools are discovered via MCP so we don't list them — instead we focus on
+// methodology and on explicitly inheriting ALL of CC's native capabilities.
+const ccQASystemPrompt = `
+You are QMax, an elite QA engineer running inside Claude Code (CC). This means you inherit
+EVERY capability CC has — bash, file read/write, web fetch, computer use — AND the full
+QualityMax platform via the "qmax" MCP server. Both toolsets are always active.
+
+== FULL CAPABILITY INHERITANCE ==
+
+You have TWO complete toolsets. Use them together — that combination is the superpower.
+
+Claude Code native tools (always available):
+  bash        → run builds, tests, lint, git ops, any shell command
+  read_file   → inspect source code, configs, existing tests, logs, lock files
+  write_file  → patch files, create test fixtures, update configs
+  web_fetch   → read docs, check API specs, fetch error context from URLs
+
+QualityMax platform tools (via qmax MCP server):
+  list/get projects, test cases, scripts, repos, crawl jobs
+  generate_test_code, run_test, run_tests_batch, check_test_status
+  start_crawl, crawl_results, review_repo, repo_coverage, create_pr
+  update_script, rollback_script, import_repo, import_document
+
+Synergy patterns — always combine both toolsets:
+  bash(git diff) → identify changed code → review_repo + repo_coverage → flag risk
+  read_file(src) → understand code → generate_test_code → bash(run locally)
+  start_crawl(url) → crawl_results → generate_test_code → run_tests_batch
+  bash(cat package.json) → detect framework → generate_test_code(framework=auto)
+  run_test → check_test_status → read_file(test output) → diagnose failure
+
+== STANDARD WORKFLOW ==
+
+For ANY QA request:
+  1. Orient  — list_projects if unclear; bash(git status); read_file key source files
+  2. Assess  — list_test_cases, repo_coverage, list_scripts to see current state
+  3. Act     — generate, run, review, crawl, patch — use BOTH toolsets
+  4. Verify  — check_test_status; bash to run locally; read actual test output
+  5. Report  — context-rich results, not raw dumps; highest-impact next action
+
+== QA METHODOLOGY ==
+
+Coverage axes — think through ALL for any feature:
+  Happy path · Error paths (network, invalid input, timeouts, 500s)
+  Boundary conditions (empty, max length, null, zero)
+  Auth boundaries (privilege escalation, token expiry, cross-tenant)
+  Concurrent access (race conditions, double-submit, idempotency)
+  State transitions (out-of-order, repeated, partial failure, rollback)
+
+Risk priority:
+  HIGH   → Auth, payments, data integrity, public API contracts
+  MEDIUM → Core user flows, admin ops, external integrations
+  LOW    → UI polish, rarely-used features
+
+== RULES ==
+
+NEVER guess project IDs, test names, script IDs, or execution results — always fetch.
+ALWAYS run generated tests immediately after creation to verify they pass.
+ALWAYS read actual failure output before suggesting a fix.
+NEVER say "I'll do X" without doing X in the same response.
+PROACTIVELY flag coverage gaps even when not asked.
+
+== OUTPUT ==
+
+Test runs:    "12 passed, 3 failed — [failures with root cause + suggested fix]"
+Coverage:     "73% overall; auth module 41% — highest risk, recommend targeting first"
+Code review:  CRITICAL / HIGH / MEDIUM, each: what · why it matters · how to fix
+Crawl:        "47 scenarios found; 12 novel — here are the highest-value new ones"
+
+End every response with the single highest-impact next action.
+`
+
+// FindClaudeCode returns the path to the claude CLI binary, or "" if not installed.
+func FindClaudeCode() string {
+	if path, err := exec.LookPath("claude"); err == nil {
+		return path
+	}
+	for _, p := range []string{
+		"/usr/local/bin/claude",
+		"/opt/homebrew/bin/claude",
+		filepath.Join(os.Getenv("HOME"), ".local/bin/claude"),
+		filepath.Join(os.Getenv("HOME"), ".claude/local/claude"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// NewCCAgent creates a CC subprocess orchestrator.
+// modelID is passed as --model to the claude CLI (empty = CC's default).
+// effort is "low" | "medium" | "high" (empty defaults to "high").
+func NewCCAgent(claudeBin, modelID, effort string, sctx *SessionContext) *CCAgent {
+	if effort == "" {
+		effort = "high"
+	}
+	return &CCAgent{claudeBin: claudeBin, modelID: modelID, effort: effort, sctx: sctx}
+}
+
+// writeMCPConfig writes a temp JSON file that tells CC where to find our MCP server.
+// The file is written once per qmax session and reused for all turns.
+func (a *CCAgent) writeMCPConfig() error {
+	self, err := os.Executable()
+	if err != nil {
+		self = "qmax-code"
+	}
+
+	env := map[string]string{}
+	if a.sctx.ProjectID > 0 {
+		env["QMAX_PROJECT_ID"] = strconv.Itoa(a.sctx.ProjectID)
+	}
+
+	config := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"qmax": map[string]interface{}{
+				"command": self,
+				"args":    []string{"serve", "--mcp"},
+				"env":     env,
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// Use PID to avoid conflicts when multiple qmax-code instances run in parallel.
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("qmax-mcp-%d.json", os.Getpid()))
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return err
+	}
+
+	a.mu.Lock()
+	a.mcpConfigPath = path
+	a.mu.Unlock()
+	return nil
+}
+
+// Run executes one conversation turn through a CC subprocess.
+// CC's subscription handles inference; qmax handles tools via MCP.
+func (a *CCAgent) Run(userMsg string, term *Terminal) (string, error) {
+	a.mu.Lock()
+	if a.mcpConfigPath == "" {
+		a.mu.Unlock()
+		if err := a.writeMCPConfig(); err != nil {
+			return "", fmt.Errorf("MCP config: %w", err)
+		}
+		a.mu.Lock()
+	}
+	ccSessionID := a.ccSessionID
+	mcpPath := a.mcpConfigPath
+	a.mu.Unlock()
+
+	systemPrompt := ccQASystemPrompt + effortDirective(a.effort)
+
+	args := []string{
+		"--print", userMsg,
+		"--output-format", "stream-json",
+		"--append-system-prompt", systemPrompt,
+		"--mcp-config", mcpPath,
+	}
+	if a.modelID != "" {
+		args = append(args, "--model", a.modelID)
+	}
+	if ccSessionID != "" {
+		args = append(args, "--resume", ccSessionID)
+	}
+
+	cmd := exec.Command(a.claudeBin, args...)
+	cmd.Stderr = os.Stderr // CC's own errors and status messages
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("start claude: %w", err)
+	}
+
+	result := a.parseStream(stdout, term)
+
+	if err := cmd.Wait(); err != nil {
+		// CC exits non-zero on soft errors (e.g. tool failure) but still produces output.
+		// Only fail hard if we got nothing at all.
+		if result == "" {
+			return "", fmt.Errorf("claude exited with error: %w", err)
+		}
+	}
+	return result, nil
+}
+
+// Cleanup removes the temp MCP config file.
+func (a *CCAgent) Cleanup() {
+	a.mu.Lock()
+	path := a.mcpConfigPath
+	a.mu.Unlock()
+	if path != "" {
+		_ = os.Remove(path)
+	}
+}
+
+// --- stream-json parsing ---
+
+// ccEvent is a single line from CC's --output-format stream-json output.
+type ccEvent struct {
+	Type      string       `json:"type"`
+	Subtype   string       `json:"subtype,omitempty"`
+	SessionID string       `json:"session_id,omitempty"`
+	Message   *ccEventMsg  `json:"message,omitempty"`
+	Result    string       `json:"result,omitempty"`
+	IsError   bool         `json:"is_error,omitempty"`
+}
+
+type ccEventMsg struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"` // string | []ccBlock
+}
+
+type ccBlock struct {
+	Type      string                 `json:"type"`
+	Text      string                 `json:"text,omitempty"`
+	ID        string                 `json:"id,omitempty"`
+	Name      string                 `json:"name,omitempty"`
+	Input     map[string]interface{} `json:"input,omitempty"`
+	ToolUseID string                 `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage        `json:"content,omitempty"` // tool_result content
+}
+
+// parseStream reads CC's NDJSON output and renders it in the terminal.
+// Returns the full text of the final response.
+func (a *CCAgent) parseStream(stdout interface{ Read([]byte) (int, error) }, term *Terminal) string {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+
+	var finalResult string
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event ccEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+
+		switch event.Type {
+		case "system":
+			if event.Subtype == "init" && event.SessionID != "" {
+				a.mu.Lock()
+				a.ccSessionID = event.SessionID
+				a.mu.Unlock()
+			}
+
+		case "assistant":
+			if event.Message == nil {
+				continue
+			}
+			blocks := parseCCBlocks(event.Message.Content)
+			for _, block := range blocks {
+				switch block.Type {
+				case "text":
+					if block.Text != "" {
+						term.StreamText(block.Text)
+					}
+				case "tool_use":
+					displayName := stripMCPPrefix(block.Name)
+					a.mu.Lock()
+					a.lastToolName = displayName
+					a.mu.Unlock()
+					term.PrintToolIcon(displayName)
+					term.PrintToolStart(displayName, block.Input)
+				}
+			}
+
+		case "user":
+			// User events during an agentic loop carry tool_result blocks.
+			if event.Message == nil {
+				continue
+			}
+			blocks := parseCCBlocks(event.Message.Content)
+			for _, block := range blocks {
+				if block.Type == "tool_result" {
+					a.mu.Lock()
+					toolName := a.lastToolName
+					a.mu.Unlock()
+					content := extractToolResultText(block.Content)
+					term.PrintToolResult(toolName, truncateStr(content, 200))
+				}
+			}
+
+		case "result":
+			finalResult = event.Result
+			if event.IsError && event.Result != "" {
+				term.PrintError("CC error: " + event.Result)
+			}
+		}
+	}
+
+	term.FinishMarkdown(finalResult)
+	return finalResult
+}
+
+// parseCCBlocks unmarshals a CC message content field (string or []block).
+func parseCCBlocks(raw json.RawMessage) []ccBlock {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	// Try array form first
+	var blocks []ccBlock
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		return blocks
+	}
+
+	// Fall back to plain string (rare but possible in older CC versions)
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil && text != "" {
+		return []ccBlock{{Type: "text", Text: text}}
+	}
+	return nil
+}
+
+// effortDirective returns a system-prompt suffix that tunes response thoroughness.
+func effortDirective(effort string) string {
+	switch strings.ToLower(effort) {
+	case "low":
+		return "\n\nEFFORT: LOW — Be concise. Surface only the highest-severity issues. Skip exhaustive enumeration."
+	case "medium":
+		return "\n\nEFFORT: MEDIUM — Balance thoroughness with brevity. Cover main risk axes; skip minor cosmetic issues."
+	default: // "high" or unset
+		return "\n\nEFFORT: HIGH — Be exhaustive. Explore all coverage axes, flag every risk, leave no stone unturned."
+	}
+}
+
+// stripMCPPrefix removes the "mcp__<server>__" prefix CC adds to MCP tool names.
+// CC turns "list_projects" into "mcp__qmax__list_projects" internally.
+func stripMCPPrefix(name string) string {
+	// prefix pattern: mcp__<server>__<tool>
+	const pfx = "mcp__"
+	if !strings.HasPrefix(name, pfx) {
+		return name
+	}
+	rest := name[len(pfx):]
+	if idx := strings.Index(rest, "__"); idx != -1 {
+		return rest[idx+2:]
+	}
+	return name
+}
+
+// extractToolResultText pulls the text content out of a tool_result content block.
+func extractToolResultText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	// Can be a string or []{"type":"text","text":"..."} array
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		var sb strings.Builder
+		for _, b := range blocks {
+			sb.WriteString(b.Text)
+		}
+		return sb.String()
+	}
+	return string(raw)
+}

--- a/codex_agent.go
+++ b/codex_agent.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// CodexAgent orchestrates an OpenAI Codex CLI subprocess for LLM inference.
+// Inference runs through the user's ChatGPT/OpenAI subscription — no OpenAI
+// API tokens consumed by qmax-code. qmax tools are served via the same MCP
+// server used for CC mode.
+//
+// Per-message flow:
+//  1. qmax-code writes ~/.codex/config.json with the qmax MCP server entry
+//  2. qmax-code spawns: codex --quiet --full-auto "msg"
+//  3. Codex picks up the MCP config and spawns qmax-code serve --mcp
+//  4. Codex uses qmax tools natively, runs on OpenAI subscription
+//  5. qmax-code streams Codex's stdout to the terminal
+//
+// Unlike CCAgent, Codex does not expose a rich stream-json format, so output
+// is captured as plain text. History is managed by qmax-code itself (passed
+// as context in the system/user turn) since Codex has no --resume equivalent.
+type CodexAgent struct {
+	codexBin string
+	modelID  string // "" = codex default; otherwise passed as --model
+	effort   string // "low" | "medium" | "high"
+	sctx     *SessionContext
+	history  []codexTurn // conversation history managed on our side
+	mu       sync.Mutex
+}
+
+type codexTurn struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// FindCodex returns the path to the codex CLI binary, or "" if not installed.
+func FindCodex() string {
+	if path, err := exec.LookPath("codex"); err == nil {
+		return path
+	}
+	for _, p := range []string{
+		"/usr/local/bin/codex",
+		"/opt/homebrew/bin/codex",
+		filepath.Join(os.Getenv("HOME"), ".local/bin/codex"),
+		filepath.Join(os.Getenv("HOME"), ".npm-global/bin/codex"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+// NewCodexAgent creates a Codex subprocess orchestrator.
+// modelID is passed as --model to the codex CLI (empty = codex default).
+// effort is "low" | "medium" | "high" (empty defaults to "high").
+func NewCodexAgent(bin, modelID, effort string, sctx *SessionContext) *CodexAgent {
+	if effort == "" {
+		effort = "high"
+	}
+	return &CodexAgent{codexBin: bin, modelID: modelID, effort: effort, sctx: sctx}
+}
+
+// writeMCPConfig writes the qmax MCP server into ~/.codex/config.json
+// so Codex picks it up for every invocation.
+func (a *CodexAgent) writeMCPConfig() error {
+	self, err := os.Executable()
+	if err != nil {
+		self = "qmax-code"
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0700); err != nil {
+		return err
+	}
+
+	cfgPath := filepath.Join(codexDir, "config.json")
+
+	// Merge with existing config rather than overwriting it.
+	existing := map[string]interface{}{}
+	if data, err := os.ReadFile(cfgPath); err == nil {
+		_ = json.Unmarshal(data, &existing)
+	}
+
+	mcpServers, _ := existing["mcpServers"].(map[string]interface{})
+	if mcpServers == nil {
+		mcpServers = map[string]interface{}{}
+	}
+
+	env := map[string]string{}
+	if a.sctx.ProjectID > 0 {
+		env["QMAX_PROJECT_ID"] = fmt.Sprintf("%d", a.sctx.ProjectID)
+	}
+
+	mcpServers["qmax"] = map[string]interface{}{
+		"command": self,
+		"args":    []string{"serve", "--mcp"},
+		"env":     env,
+	}
+	existing["mcpServers"] = mcpServers
+
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(cfgPath, data, 0600)
+}
+
+// codexQASystemPrompt is embedded in the initial prompt to Codex, since
+// Codex does not support an --append-system-prompt flag like CC does.
+const codexQASystemPrompt = `You are QMax, an elite QA engineer integrated with the QualityMax platform
+via the "qmax" MCP server. Apply the same methodology as a senior engineer:
+always fetch real data before claims, run tests after generating them, diagnose
+failures before suggesting fixes, and flag coverage gaps proactively.
+
+Coverage axes: happy path, error/exception paths, boundary conditions,
+auth boundaries, concurrent access, state transitions.
+
+Risk priority: HIGH (auth, payments, data integrity), MEDIUM (core flows,
+integrations), LOW (UI polish, rarely-used features).
+
+Never guess project IDs, test names, or execution results — always use a tool.
+End each response with the next highest-impact action.
+
+`
+
+// Run executes one conversation turn through a Codex subprocess.
+func (a *CodexAgent) Run(userMsg string, term *Terminal) (string, error) {
+	// Build the full prompt: QA system prompt + conversation history + current message.
+	prompt := a.buildPrompt(userMsg)
+
+	args := []string{
+		"--quiet",
+		"--full-auto", // no approval prompts for tool calls
+	}
+	if a.modelID != "" {
+		args = append(args, "--model", a.modelID)
+	}
+	args = append(args, prompt)
+
+	cmd := exec.Command(a.codexBin, args...)
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("start codex: %w", err)
+	}
+
+	// Stream stdout lines to terminal.
+	var sb strings.Builder
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Skip Codex's internal status lines (they usually start with special chars).
+		if !isCodexStatusLine(line) {
+			term.StreamText(line + "\n")
+			sb.WriteString(line)
+			sb.WriteByte('\n')
+		}
+	}
+
+	if err := cmd.Wait(); err != nil && sb.Len() == 0 {
+		return "", fmt.Errorf("codex exited with error: %w", err)
+	}
+
+	result := strings.TrimSpace(sb.String())
+	term.FinishMarkdown(result)
+
+	// Add to our local history for context on subsequent turns.
+	a.mu.Lock()
+	a.history = append(a.history,
+		codexTurn{Role: "user", Content: userMsg},
+		codexTurn{Role: "assistant", Content: result},
+	)
+	// Keep last 10 turns (20 messages) to stay within Codex's context.
+	if len(a.history) > 20 {
+		a.history = a.history[len(a.history)-20:]
+	}
+	a.mu.Unlock()
+
+	return result, nil
+}
+
+// buildPrompt constructs a full prompt including conversation history and effort level.
+func (a *CodexAgent) buildPrompt(userMsg string) string {
+	a.mu.Lock()
+	history := a.history
+	a.mu.Unlock()
+
+	systemPrompt := codexQASystemPrompt + effortDirective(a.effort) + "\n\n"
+
+	if len(history) == 0 {
+		// First turn: include the system prompt.
+		return systemPrompt + userMsg
+	}
+
+	// Subsequent turns: include compressed history.
+	var sb strings.Builder
+	sb.WriteString(systemPrompt)
+	sb.WriteString("[Previous conversation]\n")
+	for _, turn := range history {
+		role := "User"
+		if turn.Role == "assistant" {
+			role = "Assistant"
+		}
+		content := turn.Content
+		if len(content) > 500 {
+			content = content[:500] + "..."
+		}
+		fmt.Fprintf(&sb, "%s: %s\n\n", role, content)
+	}
+	sb.WriteString("[Current message]\n")
+	sb.WriteString(userMsg)
+	return sb.String()
+}
+
+// ClearHistory resets conversation history (used when the user types /clear).
+func (a *CodexAgent) ClearHistory() {
+	a.mu.Lock()
+	a.history = nil
+	a.mu.Unlock()
+}
+
+// Cleanup is a no-op for CodexAgent (no temp files to remove).
+func (a *CodexAgent) Cleanup() {}
+
+// isCodexStatusLine returns true for Codex CLI status/spinner output lines
+// that should not be passed to the terminal renderer.
+func isCodexStatusLine(line string) bool {
+	if line == "" {
+		return false
+	}
+	// Codex may emit ANSI-cleared lines or control sequences.
+	if strings.HasPrefix(line, "\r") || strings.HasPrefix(line, "\033") {
+		return true
+	}
+	return false
+}

--- a/codex_agent.go
+++ b/codex_agent.go
@@ -27,12 +27,13 @@ import (
 // is captured as plain text. History is managed by qmax-code itself (passed
 // as context in the system/user turn) since Codex has no --resume equivalent.
 type CodexAgent struct {
-	codexBin string
-	modelID  string // "" = codex default; otherwise passed as --model
-	effort   string // "low" | "medium" | "high"
-	sctx     *SessionContext
-	history  []codexTurn // conversation history managed on our side
-	mu       sync.Mutex
+	codexBin       string
+	modelID        string // "" = codex default; otherwise passed as --model
+	effort         string // "low" | "medium" | "high"
+	permissionMode string // "standard" (Codex prompts per-action) | "unattended" (--full-auto)
+	sctx           *SessionContext
+	history        []codexTurn // conversation history managed on our side
+	mu             sync.Mutex
 }
 
 type codexTurn struct {
@@ -61,11 +62,23 @@ func FindCodex() string {
 // NewCodexAgent creates a Codex subprocess orchestrator.
 // modelID is passed as --model to the codex CLI (empty = codex default).
 // effort is "low" | "medium" | "high" (empty defaults to "high").
-func NewCodexAgent(bin, modelID, effort string, sctx *SessionContext) *CodexAgent {
+// permissionMode is "standard" or "unattended" — Codex has no allowlist primitive,
+// so Standard relies on Codex's own approval flow (works for read-mostly tasks
+// in interactive runs) and Unattended adds --full-auto.
+func NewCodexAgent(bin, modelID, effort, permissionMode string, sctx *SessionContext) *CodexAgent {
 	if effort == "" {
 		effort = "high"
 	}
-	return &CodexAgent{codexBin: bin, modelID: modelID, effort: effort, sctx: sctx}
+	if permissionMode == "" {
+		permissionMode = "standard"
+	}
+	return &CodexAgent{
+		codexBin:       bin,
+		modelID:        modelID,
+		effort:         effort,
+		permissionMode: permissionMode,
+		sctx:           sctx,
+	}
 }
 
 // writeMCPConfig writes the qmax MCP server into ~/.codex/config.json
@@ -142,7 +155,10 @@ func (a *CodexAgent) Run(userMsg string, term *Terminal) (string, error) {
 
 	args := []string{
 		"--quiet",
-		"--full-auto", // no approval prompts for tool calls
+	}
+	if a.permissionMode == "unattended" {
+		// Equivalent to CC's --dangerously-skip-permissions. Only with explicit consent.
+		args = append(args, "--full-auto")
 	}
 	if a.modelID != "" {
 		args = append(args, "--model", a.modelID)

--- a/config.go
+++ b/config.go
@@ -41,6 +41,20 @@ type Config struct {
 	// Effort controls how thorough the CLI agent should be: "low", "medium", "high".
 	// Injected into the system prompt on every turn.
 	Effort string `json:"effort,omitempty"`
+
+	// OrchPermissionMode records the autonomy level the user consented to for
+	// CC/Codex backends:
+	//   ""           = no consent yet; activation will prompt
+	//   "standard"   = curated allowlist auto-approved (reads, test runners,
+	//                  qmax MCP tools); edits and destructive shell still gated
+	//   "unattended" = --dangerously-skip-permissions / --full-auto, full autonomy
+	// Persistence avoids re-prompting once chosen; user can revoke via /orch.
+	OrchPermissionMode string `json:"orch_permission_mode,omitempty"`
+
+	// OrchGlobalInstall records that the user opted into writing the qmax MCP
+	// entry into the CLI's global config (~/.claude/settings.json or
+	// ~/.codex/config.json). False = use a per-session temp config only.
+	OrchGlobalInstall bool `json:"orch_global_install,omitempty"`
 }
 
 const qmaxCodeConfigDir = ".qmax-code"

--- a/config.go
+++ b/config.go
@@ -26,6 +26,21 @@ type Config struct {
 	OllamaURL        string `json:"ollama_url,omitempty"`         // e.g. "https://user:pass@llm.qualitymax.io"
 	OllamaModel      string `json:"ollama_model,omitempty"`       // e.g. "gemma3:4b-it-q4_K_M" (chat)
 	OllamaAgentModel string `json:"ollama_agent_model,omitempty"` // e.g. "gemma3:12b-it-q4_K_M" (tools, heavier tasks)
+
+	// Backend selects the LLM inference backend.
+	//   ""  / "api" → Anthropic API directly (default, requires ANTHROPIC_API_KEY)
+	//   "cc"        → Claude Code CLI subprocess (uses CC subscription, no API key needed)
+	//   "codex"     → OpenAI Codex CLI subprocess (uses OpenAI subscription, no API key needed)
+	// In both CLI modes qmax tools are served to the CLI via an embedded MCP server.
+	Backend string `json:"backend,omitempty"`
+
+	// ModelOverride is the specific model ID selected via the /orch TUI picker.
+	// Empty means "let the CLI pick its default". Used with CC and Codex backends.
+	ModelOverride string `json:"model_override,omitempty"`
+
+	// Effort controls how thorough the CLI agent should be: "low", "medium", "high".
+	// Injected into the system prompt on every turn.
+	Effort string `json:"effort,omitempty"`
 }
 
 const qmaxCodeConfigDir = ".qmax-code"

--- a/config_command.go
+++ b/config_command.go
@@ -92,6 +92,26 @@ func printConfig() {
 	} else {
 		fmt.Println("    ollama_url        = (not set)")
 	}
+	backend := cfg.Backend
+	if backend == "" {
+		backend = "api"
+	}
+	fmt.Printf("    backend           = %q", backend)
+	switch backend {
+	case "cc":
+		if bin := FindClaudeCode(); bin != "" {
+			fmt.Printf("  (claude found: %s)", bin)
+		} else {
+			fmt.Print("  (WARNING: claude binary not found in PATH)")
+		}
+	case "codex":
+		if bin := FindCodex(); bin != "" {
+			fmt.Printf("  (codex found: %s)", bin)
+		} else {
+			fmt.Print("  (WARNING: codex binary not found in PATH)")
+		}
+	}
+	fmt.Println()
 }
 
 // setConfigField writes the given value into the Config. Empty value
@@ -155,6 +175,14 @@ func setConfigField(key, value string) error {
 
 	case "ollama_agent_model":
 		cfg.OllamaAgentModel = value
+
+	case "backend":
+		switch value {
+		case "", "api", "cc", "codex":
+			cfg.Backend = value
+		default:
+			return fmt.Errorf("invalid backend %q; allowed: api, cc, codex", value)
+		}
 
 	default:
 		return fmt.Errorf("unknown config key %q", key)

--- a/consent.go
+++ b/consent.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// orchConsentResult is what activateBackend gets back from the consent prompt.
+type orchConsentResult struct {
+	Proceed        bool   // user said yes; false means cancel activation
+	PermissionMode string // "standard" | "unattended"
+	GlobalInstall  bool   // ok to write into ~/.claude/settings.json or ~/.codex/config.json
+}
+
+// promptOrchConsent shows the autonomy + global-install dialog the first time
+// a CLI backend is activated. If the user already chose persistently
+// (cfg.OrchPermissionMode / cfg.OrchGlobalInstall) we skip the prompt.
+//
+// Conductor's safety model: the user is the principal. We never sneak privilege
+// escalation behind a backend switch. Mode choices are explicit and persisted.
+func promptOrchConsent(cfg *Config, backend string) orchConsentResult {
+	cliName := "Claude Code"
+	globalConfigPath := "~/.claude/settings.json"
+	if backend == "codex" {
+		cliName = "Codex"
+		globalConfigPath = "~/.codex/config.json"
+	}
+
+	res := orchConsentResult{
+		PermissionMode: cfg.OrchPermissionMode,
+		GlobalInstall:  cfg.OrchGlobalInstall,
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+
+	// First prompt: autonomy level. Skip if previously chosen.
+	if res.PermissionMode == "" {
+		fmt.Println()
+		fmt.Printf("  Activating %s backend.\n", cliName)
+		fmt.Println()
+		fmt.Println("  Pick how much autonomy to grant:")
+		fmt.Println()
+		fmt.Println("   [1] Standard   — auto-approves reads, search, git status/diff, common")
+		fmt.Println("                    test runners (go test, pytest, npm test, cargo test…)")
+		fmt.Println("                    and qmax tools. Won't edit files or run destructive")
+		fmt.Println("                    shell commands without asking.   (recommended)")
+		fmt.Println()
+		fmt.Println("   [2] Unattended — full --dangerously-skip-permissions. Anything goes:")
+		fmt.Println("                    edit files, run any shell command, push commits.")
+		fmt.Println("                    Use only on trusted projects.")
+		fmt.Println()
+		fmt.Println("   [N] Cancel     — keep current backend.")
+		fmt.Println()
+		fmt.Print("  Choice [1/2/N, default 1]: ")
+		line, _ := reader.ReadString('\n')
+		ans := strings.ToLower(strings.TrimSpace(line))
+		switch ans {
+		case "", "1", "standard", "s":
+			res.PermissionMode = "standard"
+		case "2", "unattended", "u", "y", "yes":
+			res.PermissionMode = "unattended"
+			fmt.Println()
+			fmt.Print("  ⚠ Unattended grants full shell + file-edit access. Confirm? [y/N]: ")
+			line, _ := reader.ReadString('\n')
+			ans2 := strings.ToLower(strings.TrimSpace(line))
+			if ans2 != "y" && ans2 != "yes" {
+				fmt.Println("  Cancelled.")
+				return orchConsentResult{Proceed: false}
+			}
+		default:
+			fmt.Println("  Cancelled.")
+			return orchConsentResult{Proceed: false}
+		}
+	}
+
+	// Second prompt: global install. Only ask if not previously consented and not already done.
+	if !res.GlobalInstall && !IsOrchSetupDone(backend) {
+		fmt.Println()
+		fmt.Printf("  Optional: register qmax tools globally in %s\n", globalConfigPath)
+		fmt.Printf("  so they appear in every `%s` session, not just qmax-code.\n", strings.ToLower(cliName))
+		fmt.Println()
+		fmt.Print("  Install globally? [y/N]: ")
+		line, _ := reader.ReadString('\n')
+		ans := strings.ToLower(strings.TrimSpace(line))
+		res.GlobalInstall = (ans == "y" || ans == "yes")
+	}
+
+	res.Proceed = true
+	return res
+}

--- a/context.go
+++ b/context.go
@@ -21,6 +21,7 @@ type SessionContext struct {
 	ProjectFile string      // name of .qmax.yml file if detected
 	API         *APIClient  // direct API client (standalone mode, no qmax CLI needed)
 	Auth        *AuthConfig // authentication credentials
+	Backend     string      // "" | "cc" | "codex" — active CLI inference backend
 }
 
 // QMaxConfig mirrors the qmax CLI config (~/.qamax/config.json).

--- a/error_reporting.go
+++ b/error_reporting.go
@@ -2,12 +2,25 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 )
 
 const bugsinkDSN = "https://4a5a87da918c49d997ca431b1e666fc5@bugs.qualitymax.io/5"
+
+// Privacy promise (mirrors privacy policy): qmax-code never sends prompt content,
+// file contents, LLM responses, or shell output to Bugsink. Only structural
+// metadata (backend, status_code, model, input_len, image_count, …) is captured.
+//
+// telemetryDeniedTagPrefixes is the defense-in-depth filter: if a future code
+// path accidentally adds a tag whose name matches one of these prefixes, the
+// BeforeSend hook strips it before the event leaves the process.
+var telemetryDeniedTagPrefixes = []string{
+	"input", "prompt", "message", "content", "file", "output",
+	"response", "body", "text", "data",
+}
 
 // InitErrorReporting sets up Sentry/Bugsink error reporting.
 func InitErrorReporting() {
@@ -16,15 +29,63 @@ func InitErrorReporting() {
 		Release:          fmt.Sprintf("qmax-code@%s", Version),
 		Environment:      "production",
 		AttachStacktrace: true,
-		// Don't send in debug/dev mode
-		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-			return event
-		},
+		BeforeSend:       sanitizeEvent,
 	})
 	if err != nil {
 		// Silently fail — error reporting is best-effort
 		return
 	}
+}
+
+// sanitizeEvent is the last-line filter before any event leaves the process.
+// Strips tags that look like user content even if upstream code accidentally
+// added them. Truncates exception messages and breadcrumbs to bounded length
+// to avoid leaking large blobs (e.g. echoed-back prompt content in a 4KB
+// Anthropic API error body).
+func sanitizeEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
+	if event == nil {
+		return nil
+	}
+
+	// Filter tags by deny-then-allow.
+	clean := make(map[string]string, len(event.Tags))
+	for k, v := range event.Tags {
+		lk := strings.ToLower(k)
+		denied := false
+		for _, d := range telemetryDeniedTagPrefixes {
+			if lk == d || strings.HasPrefix(lk, d+"_") || strings.HasPrefix(lk, d+".") {
+				denied = true
+				break
+			}
+		}
+		if denied {
+			continue
+		}
+		// Cap tag value length defensively (Sentry limit is 200; we cap at 256).
+		if len(v) > 256 {
+			v = v[:256] + "…"
+		}
+		clean[k] = v
+	}
+	event.Tags = clean
+
+	// Cap exception messages to 1 KiB so a large Anthropic error body can't
+	// smuggle prompt content through the message field.
+	for i, ex := range event.Exception {
+		if len(ex.Value) > 1024 {
+			event.Exception[i].Value = ex.Value[:1024] + " …[truncated]"
+		}
+	}
+
+	// Cap breadcrumb messages similarly and drop any data payloads.
+	for i, bc := range event.Breadcrumbs {
+		if len(bc.Message) > 256 {
+			event.Breadcrumbs[i].Message = bc.Message[:256] + "…"
+		}
+		event.Breadcrumbs[i].Data = nil
+	}
+
+	return event
 }
 
 // FlushErrorReporting flushes pending events before exit.

--- a/input.go
+++ b/input.go
@@ -16,6 +16,10 @@ type SlashMenuItem struct {
 
 var slashMenuItems = []SlashMenuItem{
 	{"/help", "Show help"},
+	{"/orch", "Model + effort picker (CC / Codex / API)"},
+	{"/cc", "Switch to Claude Code backend"},
+	{"/codex", "Switch to Codex CLI backend"},
+	{"/api", "Switch to direct Anthropic API"},
 	{"/connect", "Log in to QualityMax (browser)"},
 	{"/disconnect", "Log out"},
 	{"/status", "Auth + session info"},

--- a/main.go
+++ b/main.go
@@ -189,7 +189,17 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  Or switch backend: qmax-code config set backend api")
 			os.Exit(1)
 		}
-		anthropicKey = "__cc_mode__" // skip Anthropic key gate below
+		consent := promptOrchConsent(appConfig, "cc")
+		if !consent.Proceed {
+			fmt.Fprintln(os.Stderr, "  CC backend not activated. Falling back to direct API.")
+			cliBackend = ""
+			appConfig.Backend = ""
+		} else {
+			appConfig.OrchPermissionMode = consent.PermissionMode
+			appConfig.OrchGlobalInstall = consent.GlobalInstall
+			_ = appConfig.Save()
+			anthropicKey = "__cc_mode__" // skip Anthropic key gate below
+		}
 	} else if cliBackend == "codex" {
 		codexBin := FindCodex()
 		if codexBin == "" {
@@ -198,7 +208,17 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  Or switch backend: qmax-code config set backend api")
 			os.Exit(1)
 		}
-		anthropicKey = "__codex_mode__" // skip Anthropic key gate below
+		consent := promptOrchConsent(appConfig, "codex")
+		if !consent.Proceed {
+			fmt.Fprintln(os.Stderr, "  Codex backend not activated. Falling back to direct API.")
+			cliBackend = ""
+			appConfig.Backend = ""
+		} else {
+			appConfig.OrchPermissionMode = consent.PermissionMode
+			appConfig.OrchGlobalInstall = consent.GlobalInstall
+			_ = appConfig.Save()
+			anthropicKey = "__codex_mode__" // skip Anthropic key gate below
+		}
 	}
 
 	// If connected but missing Anthropic key, prompt for it (skipped in CLI backend modes).
@@ -275,23 +295,24 @@ func main() {
 		agent.ollamaMode = OllamaModeFull // default to full when configured
 	}
 
-	// Initialize the CLI agent and run one-time global MCP setup if needed.
+	// Build the CLI agent if a CLI backend was selected and consented to above.
+	// Global MCP install (~/.claude/settings.json or ~/.codex/config.json) is
+	// performed only when the user opted into it during the consent prompt.
 	switch cliBackend {
 	case "cc":
-		if !IsOrchSetupDone("cc") {
+		if appConfig.OrchGlobalInstall && !IsOrchSetupDone("cc") {
 			if res, err := SetupCCIntegration(); err == nil && !res.AlreadyHadMCP {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
-				fmt.Println("  Claude Code now has qmax tools in every session.")
 			}
 		}
-		cliAgent = NewCCAgent(FindClaudeCode(), appConfig.ModelOverride, appConfig.Effort, ctx)
+		cliAgent = NewCCAgent(FindClaudeCode(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, ctx)
 	case "codex":
-		if !IsOrchSetupDone("codex") {
+		if appConfig.OrchGlobalInstall && !IsOrchSetupDone("codex") {
 			if res, err := SetupCodexIntegration(); err == nil && !res.AlreadyHadMCP {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
 			}
 		}
-		ca := NewCodexAgent(FindCodex(), appConfig.ModelOverride, appConfig.Effort, ctx)
+		ca := NewCodexAgent(FindCodex(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, ctx)
 		if err := ca.writeMCPConfig(); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not write Codex MCP config: %v\n", err)
 		}
@@ -596,24 +617,33 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				}
 			}
 
+			// Consent gate: required before activating CC/Codex (autonomous shell + edits).
+			if result.Backend != "" {
+				consent := promptOrchConsent(cfg, result.Backend)
+				if !consent.Proceed {
+					term.PrintSystem("Backend not changed.")
+					continue
+				}
+				cfg.OrchPermissionMode = consent.PermissionMode
+				cfg.OrchGlobalInstall = consent.GlobalInstall
+				if consent.GlobalInstall && !IsOrchSetupDone(result.Backend) {
+					RunOrchSetup(result.Backend, term)
+				}
+			}
+
 			// Tear down current CLI agent.
 			if cliAgent != nil {
 				cliAgent.Cleanup()
 				cliAgent = nil
 			}
 
-			// One-time autosetup: write qmax into the CLI's global MCP config.
-			if result.Backend != "" && !IsOrchSetupDone(result.Backend) {
-				RunOrchSetup(result.Backend, term)
-			}
-
 			// Spin up the new agent with selected model + effort.
 			switch result.Backend {
 			case "cc":
-				cliAgent = NewCCAgent(FindClaudeCode(), result.ModelID, result.Effort, agent.config.Context)
+				cliAgent = NewCCAgent(FindClaudeCode(), result.ModelID, result.Effort, cfg.OrchPermissionMode, agent.config.Context)
 				term.PrintSystem(fmt.Sprintf("Backend: Claude Code  model: %s  effort: %s", result.ModelID, result.Effort))
 			case "codex":
-				ca := NewCodexAgent(FindCodex(), result.ModelID, result.Effort, agent.config.Context)
+				ca := NewCodexAgent(FindCodex(), result.ModelID, result.Effort, cfg.OrchPermissionMode, agent.config.Context)
 				if err := ca.writeMCPConfig(); err != nil {
 					term.PrintSystem(fmt.Sprintf("Warning: Codex MCP config: %v", err))
 				}
@@ -667,13 +697,20 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 					term.PrintSystem("  https://claude.ai/download")
 					continue
 				}
-				if !IsOrchSetupDone("cc") {
+				consent := promptOrchConsent(cfg, "cc")
+				if !consent.Proceed {
+					term.PrintSystem("Backend not changed.")
+					continue
+				}
+				cfg.OrchPermissionMode = consent.PermissionMode
+				cfg.OrchGlobalInstall = consent.GlobalInstall
+				if consent.GlobalInstall && !IsOrchSetupDone("cc") {
 					RunOrchSetup("cc", term)
 				}
-				cliAgent = NewCCAgent(bin, cfg.ModelOverride, cfg.Effort, agent.config.Context)
+				cliAgent = NewCCAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, agent.config.Context)
 				cfg.Backend = "cc"
 				_ = cfg.Save()
-				term.PrintSystem(fmt.Sprintf("Backend → Claude Code (%s) — qmax tools globally registered", bin))
+				term.PrintSystem(fmt.Sprintf("Backend → Claude Code (%s) · %s mode", bin, cfg.OrchPermissionMode))
 
 			case "codex":
 				bin := FindCodex()
@@ -682,17 +719,24 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 					term.PrintSystem("  npm install -g @openai/codex")
 					continue
 				}
-				if !IsOrchSetupDone("codex") {
+				consent := promptOrchConsent(cfg, "codex")
+				if !consent.Proceed {
+					term.PrintSystem("Backend not changed.")
+					continue
+				}
+				cfg.OrchPermissionMode = consent.PermissionMode
+				cfg.OrchGlobalInstall = consent.GlobalInstall
+				if consent.GlobalInstall && !IsOrchSetupDone("codex") {
 					RunOrchSetup("codex", term)
 				}
-				ca := NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, agent.config.Context)
+				ca := NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, agent.config.Context)
 				if err := ca.writeMCPConfig(); err != nil {
 					term.PrintSystem(fmt.Sprintf("Warning: MCP config: %v", err))
 				}
 				cliAgent = ca
 				cfg.Backend = "codex"
 				_ = cfg.Save()
-				term.PrintSystem(fmt.Sprintf("Backend → Codex (%s) — qmax tools globally registered", bin))
+				term.PrintSystem(fmt.Sprintf("Backend → Codex (%s) · %s mode", bin, cfg.OrchPermissionMode))
 
 			default:
 				cfg.Backend = ""

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.10.0"
+var Version = "1.12.0"
 
 const Name = "qmax-code"
 
@@ -31,6 +31,7 @@ func main() {
 	professional := flag.Bool("professional", false, "Disable cat personality, be direct and professional")
 	quiet := flag.Bool("q", false, "Quiet mode — no banner, minimal output (for CI)")
 	showVersion := flag.Bool("version", false, "Show version")
+	backendFlag := flag.String("backend", "", "Orchestration backend: cc, codex, or api (overrides saved config)")
 	flag.Parse()
 	_ = quiet // reserved for future CI mode
 
@@ -43,6 +44,17 @@ func main() {
 	InitErrorReporting()
 	defer FlushErrorReporting()
 	defer RecoverPanic()
+
+	// Handle "serve --mcp" subcommand: start MCP server for Claude Code integration.
+	// CC spawns this automatically when qmax-code is listed as an MCP server.
+	if len(os.Args) > 1 && os.Args[1] == "serve" {
+		if len(os.Args) > 2 && os.Args[2] == "--mcp" {
+			RunMCPServer()
+			return
+		}
+		fmt.Fprintln(os.Stderr, "Usage: qmax-code serve --mcp")
+		os.Exit(2)
+	}
 
 	// Handle "config" subcommand — lets users change persisted settings
 	// without hand-editing ~/.qmax-code/config.json.
@@ -99,6 +111,21 @@ func main() {
 		appConfig.Professional = true
 	}
 
+	// --backend flag overrides saved config for this session only.
+	if *backendFlag != "" {
+		switch *backendFlag {
+		case "cc", "codex", "api", "":
+			if *backendFlag == "api" {
+				appConfig.Backend = ""
+			} else {
+				appConfig.Backend = *backendFlag
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "Error: --backend must be cc, codex, or api\n")
+			os.Exit(2)
+		}
+	}
+
 	// Resolve model: CLI flag > saved config > "auto"
 	effectiveModel := *model
 	if effectiveModel == "" {
@@ -147,8 +174,35 @@ func main() {
 		}
 	}
 
-	// If connected but missing Anthropic key, prompt for it
-	if anthropicKey == "" {
+	// CLI backend mode: route all LLM inference through a local CLI subprocess.
+	// Neither an Anthropic API key nor an OpenAI key is required — the user's
+	// subscription (CC or OpenAI/Codex) covers inference.
+	// qmax tools are served to the CLI via the embedded MCP server.
+	var cliAgent CLIAgent
+	cliBackend := appConfig.Backend // "cc" | "codex" | "" (API)
+
+	if cliBackend == "cc" {
+		claudeBin := FindClaudeCode()
+		if claudeBin == "" {
+			fmt.Fprintln(os.Stderr, "\nError: backend=cc but 'claude' CLI was not found.")
+			fmt.Fprintln(os.Stderr, "  Install Claude Code: https://claude.ai/download")
+			fmt.Fprintln(os.Stderr, "  Or switch backend: qmax-code config set backend api")
+			os.Exit(1)
+		}
+		anthropicKey = "__cc_mode__" // skip Anthropic key gate below
+	} else if cliBackend == "codex" {
+		codexBin := FindCodex()
+		if codexBin == "" {
+			fmt.Fprintln(os.Stderr, "\nError: backend=codex but 'codex' CLI was not found.")
+			fmt.Fprintln(os.Stderr, "  Install Codex CLI: npm install -g @openai/codex")
+			fmt.Fprintln(os.Stderr, "  Or switch backend: qmax-code config set backend api")
+			os.Exit(1)
+		}
+		anthropicKey = "__codex_mode__" // skip Anthropic key gate below
+	}
+
+	// If connected but missing Anthropic key, prompt for it (skipped in CLI backend modes).
+	if cliBackend == "" && anthropicKey == "" {
 		fmt.Println()
 		fmt.Println("  Anthropic API key needed (this powers the AI).")
 		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
@@ -163,9 +217,12 @@ func main() {
 		}
 	}
 
-	if anthropicKey == "" {
+	if cliBackend == "" && anthropicKey == "" {
 		fmt.Fprintln(os.Stderr, "\nError: Anthropic API key required.")
 		fmt.Fprintln(os.Stderr, "  export ANTHROPIC_API_KEY=sk-ant-...")
+		fmt.Fprintln(os.Stderr, "  Or use a CLI backend (no API key needed):")
+		fmt.Fprintln(os.Stderr, "    qmax-code config set backend cc      # Claude Code subscription")
+		fmt.Fprintln(os.Stderr, "    qmax-code config set backend codex   # OpenAI/Codex subscription")
 		os.Exit(1)
 	}
 
@@ -189,6 +246,7 @@ func main() {
 		ProjectFile: projectFile,
 		API:         apiClient,
 		Auth:        auth,
+		Backend:     appConfig.Backend,
 	}
 
 	// Build agent with smart model routing
@@ -215,6 +273,29 @@ func main() {
 	agent.ollama = NewOllamaClient(appConfig)
 	if agent.ollama != nil {
 		agent.ollamaMode = OllamaModeFull // default to full when configured
+	}
+
+	// Initialize the CLI agent and run one-time global MCP setup if needed.
+	switch cliBackend {
+	case "cc":
+		if !IsOrchSetupDone("cc") {
+			if res, err := SetupCCIntegration(); err == nil && !res.AlreadyHadMCP {
+				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
+				fmt.Println("  Claude Code now has qmax tools in every session.")
+			}
+		}
+		cliAgent = NewCCAgent(FindClaudeCode(), appConfig.ModelOverride, appConfig.Effort, ctx)
+	case "codex":
+		if !IsOrchSetupDone("codex") {
+			if res, err := SetupCodexIntegration(); err == nil && !res.AlreadyHadMCP {
+				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
+			}
+		}
+		ca := NewCodexAgent(FindCodex(), appConfig.ModelOverride, appConfig.Effort, ctx)
+		if err := ca.writeMCPConfig(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not write Codex MCP config: %v\n", err)
+		}
+		cliAgent = ca
 	}
 
 	// One-shot mode
@@ -267,7 +348,7 @@ func main() {
 	}
 
 	// Interactive REPL
-	runREPL(agent, *quiet)
+	runREPL(agent, cliAgent, *quiet)
 }
 
 // resolveModel expands shorthand model names to full model IDs.
@@ -284,9 +365,12 @@ func resolveModel(m string) string {
 	}
 }
 
-func runREPL(agent *Agent, quietMode bool) {
+func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 	term := NewTerminal()
 	defer term.Close()
+	if cliAgent != nil {
+		defer cliAgent.Cleanup()
+	}
 
 	// Session ID for this conversation
 	sessionID := generateSessionID()
@@ -481,8 +565,143 @@ func runREPL(agent *Agent, quietMode bool) {
 			continue
 		case input == "/set":
 			term.PrintError("Usage: /set <key> <value>")
-			term.PrintSystem("Keys: model, project, professional, autosave, budget, ollama")
+			term.PrintSystem("Keys: model, project, professional, autosave, budget, ollama, backend")
 			continue
+		case input == "/orch":
+			// Show the unified model + effort TUI picker and apply the selection instantly.
+			cfg := agent.appConfig
+			if cfg == nil {
+				term.PrintError("Config not loaded.")
+				continue
+			}
+
+			result := ShowModelPicker(cfg.Backend, cfg.ModelOverride, cfg.Effort)
+			if !result.Confirmed {
+				continue
+			}
+
+			// Validate the chosen CLI is actually installed.
+			switch result.Backend {
+			case "cc":
+				if FindClaudeCode() == "" {
+					term.PrintError("Claude Code ('claude') not found. Install it first.")
+					term.PrintSystem("  https://claude.ai/download")
+					continue
+				}
+			case "codex":
+				if FindCodex() == "" {
+					term.PrintError("Codex CLI ('codex') not found.")
+					term.PrintSystem("  npm install -g @openai/codex")
+					continue
+				}
+			}
+
+			// Tear down current CLI agent.
+			if cliAgent != nil {
+				cliAgent.Cleanup()
+				cliAgent = nil
+			}
+
+			// One-time autosetup: write qmax into the CLI's global MCP config.
+			if result.Backend != "" && !IsOrchSetupDone(result.Backend) {
+				RunOrchSetup(result.Backend, term)
+			}
+
+			// Spin up the new agent with selected model + effort.
+			switch result.Backend {
+			case "cc":
+				cliAgent = NewCCAgent(FindClaudeCode(), result.ModelID, result.Effort, agent.config.Context)
+				term.PrintSystem(fmt.Sprintf("Backend: Claude Code  model: %s  effort: %s", result.ModelID, result.Effort))
+			case "codex":
+				ca := NewCodexAgent(FindCodex(), result.ModelID, result.Effort, agent.config.Context)
+				if err := ca.writeMCPConfig(); err != nil {
+					term.PrintSystem(fmt.Sprintf("Warning: Codex MCP config: %v", err))
+				}
+				cliAgent = ca
+				term.PrintSystem(fmt.Sprintf("Backend: Codex  model: %s  effort: %s", result.ModelID, result.Effort))
+			default:
+				term.PrintSystem("Backend: Anthropic API (direct)")
+			}
+
+			cfg.Backend = result.Backend
+			cfg.ModelOverride = result.ModelID
+			cfg.Effort = result.Effort
+			agent.config.Context.Backend = result.Backend
+			_ = cfg.Save()
+			continue
+
+		case input == "/cc", input == "/codex", input == "/api":
+			// Instant backend switching — no restart needed.
+			cfg := agent.appConfig
+			if cfg == nil {
+				term.PrintError("Config not loaded.")
+				continue
+			}
+
+			var wantBackend string
+			switch input {
+			case "/cc":
+				wantBackend = "cc"
+			case "/codex":
+				wantBackend = "codex"
+			case "/api":
+				wantBackend = ""
+			}
+
+			// If same backend requested, turn it off (toggle behaviour).
+			if cfg.Backend == wantBackend && wantBackend != "" {
+				wantBackend = ""
+			}
+
+			// Tear down current CLI agent.
+			if cliAgent != nil {
+				cliAgent.Cleanup()
+				cliAgent = nil
+			}
+
+			switch wantBackend {
+			case "cc":
+				bin := FindClaudeCode()
+				if bin == "" {
+					term.PrintError("'claude' CLI not found. Install Claude Code first.")
+					term.PrintSystem("  https://claude.ai/download")
+					continue
+				}
+				if !IsOrchSetupDone("cc") {
+					RunOrchSetup("cc", term)
+				}
+				cliAgent = NewCCAgent(bin, cfg.ModelOverride, cfg.Effort, agent.config.Context)
+				cfg.Backend = "cc"
+				_ = cfg.Save()
+				term.PrintSystem(fmt.Sprintf("Backend → Claude Code (%s) — qmax tools globally registered", bin))
+
+			case "codex":
+				bin := FindCodex()
+				if bin == "" {
+					term.PrintError("'codex' CLI not found.")
+					term.PrintSystem("  npm install -g @openai/codex")
+					continue
+				}
+				if !IsOrchSetupDone("codex") {
+					RunOrchSetup("codex", term)
+				}
+				ca := NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, agent.config.Context)
+				if err := ca.writeMCPConfig(); err != nil {
+					term.PrintSystem(fmt.Sprintf("Warning: MCP config: %v", err))
+				}
+				cliAgent = ca
+				cfg.Backend = "codex"
+				_ = cfg.Save()
+				term.PrintSystem(fmt.Sprintf("Backend → Codex (%s) — qmax tools globally registered", bin))
+
+			default:
+				cfg.Backend = ""
+				_ = cfg.Save()
+				term.PrintSystem("Backend → Anthropic API (direct)")
+			}
+			agent.config.Context.Backend = cfg.Backend
+			continue
+
 		case input == "/ollama":
 			// Cycle through modes: off → chat → full → off
 			cfg := agent.appConfig
@@ -557,10 +776,17 @@ func runREPL(agent *Agent, quietMode bool) {
 		// Detect image file paths dragged/pasted into input
 		cleanInput, images := DetectAndLoadImages(input)
 
-		// Run through the LLM agent with streaming
+		// Run through the LLM agent with streaming.
+		// CC mode: delegate entirely to Claude Code subprocess (uses CC subscription).
+		// Normal mode: use direct Anthropic API.
 		var llmResult string
 		var err error
-		if len(images) > 0 {
+		if cliAgent != nil {
+			if len(images) > 0 {
+				term.PrintSystem("Note: image attachments are not supported in CLI backend mode.")
+			}
+			llmResult, err = cliAgent.Run(cleanInput, term)
+		} else if len(images) > 0 {
 			names := make([]string, len(images))
 			for i, img := range images {
 				names[i] = img.FileName
@@ -726,6 +952,10 @@ Commands:
   /project <id>  Set the active project
   /context       Show current session context
   /cost          Show session token usage and estimated cost
+  /orch          Cycle orchestration backend: off → CC → Codex → off
+  /cc            Switch to Claude Code backend (CC subscription, no API tokens)
+  /codex         Switch to Codex CLI backend (OpenAI subscription, no API tokens)
+  /api           Switch back to direct Anthropic API
   /ollama        Toggle Ollama on/off (self-hosted LLM for chat)
   /config        Show current config settings
   /keys          Set API keys (interactive menu)
@@ -747,6 +977,9 @@ Config examples:
   /set budget 100000        Set max token budget warning
   /set ollama on            Enable self-hosted LLM for chat (saves API costs)
   /set ollama off           Disable Ollama, use Claude for all calls
+  /set backend cc           Use Claude Code subscription (no API key needed)
+  /set backend codex        Use OpenAI Codex subscription (no API key needed)
+  /set backend api          Use Anthropic API directly (default)
 
 Shortcuts:
   Ctrl+C         Cancel current operation (double-tap to exit)
@@ -895,6 +1128,34 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 		}
 		return // no config persistence needed — runtime toggle
 
+	case "backend":
+		// /set backend cc|codex|api — persist backend choice.
+		// For live switching use /cc, /codex, or /api instead.
+		switch strings.ToLower(value) {
+		case "cc":
+			if bin := FindClaudeCode(); bin == "" {
+				term.PrintError("'claude' CLI not found. Install Claude Code first.")
+				term.PrintSystem("  https://claude.ai/download")
+				return
+			}
+			cfg.Backend = "cc"
+			term.PrintSystem("Backend set to CC. Use /cc to switch live, or restart to apply.")
+		case "codex":
+			if bin := FindCodex(); bin == "" {
+				term.PrintError("'codex' CLI not found.")
+				term.PrintSystem("  npm install -g @openai/codex")
+				return
+			}
+			cfg.Backend = "codex"
+			term.PrintSystem("Backend set to Codex. Use /codex to switch live, or restart to apply.")
+		case "", "api":
+			cfg.Backend = ""
+			term.PrintSystem("Backend set to Anthropic API. Restart or use /api to switch live.")
+		default:
+			term.PrintError("Valid backends: cc, codex, api")
+			return
+		}
+
 	case "anthropic-key", "anthropic_key":
 		// Save Anthropic API key to OS keychain
 		os.Setenv("ANTHROPIC_API_KEY", value)
@@ -908,7 +1169,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 
 	default:
 		term.PrintError(fmt.Sprintf("Unknown config key: %s", key))
-		term.PrintSystem("Keys: model, project, professional, autosave, budget, apikey")
+		term.PrintSystem("Keys: model, project, professional, autosave, budget, apikey, backend")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -845,7 +845,18 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		}
 		if err != nil {
 			term.PrintError(err.Error())
-			CaptureError(err, map[string]interface{}{"input": truncateStr(input, 100)})
+			// Telemetry policy: never capture prompt content, file content, or model
+			// output. Only structural metadata that helps diagnose without revealing
+			// what the user was working on.
+			backendTag := "api"
+			if cliAgent != nil {
+				backendTag = agent.config.Context.Backend
+			}
+			CaptureError(err, map[string]interface{}{
+				"backend":      backendTag,
+				"input_len":    fmt.Sprintf("%d", len(input)),
+				"image_count":  fmt.Sprintf("%d", len(images)),
+			})
 			autoSave() // save even on error — preserves context
 			continue
 		}

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+)
+
+// RunMCPServer starts an MCP (Model Context Protocol) server over stdin/stdout.
+// CC spawns this as a subprocess when qmax-code is configured as an MCP server:
+//
+//	qmax-code serve --mcp
+//
+// The server exposes all qmax tools to Claude Code so CC can call them via
+// its native tool-use mechanism — no Anthropic API tokens consumed.
+func RunMCPServer() {
+	auth := LoadAuth()
+	var apiClient *APIClient
+	if auth != nil && auth.IsAuthenticated() {
+		apiClient = NewAPIClient(auth)
+	}
+
+	appConfig := LoadQMaxCodeConfig()
+	sctx := &SessionContext{
+		QMaxCfg:   loadQMaxConfig(),
+		QMaxBin:   discoverQMaxBinary(),
+		API:       apiClient,
+		Auth:      auth,
+		ProjectID: appConfig.DefaultProject,
+	}
+
+	// Project ID override: CCAgent writes the active project into the MCP env.
+	if pid, err := strconv.Atoi(os.Getenv("QMAX_PROJECT_ID")); err == nil && pid > 0 {
+		sctx.ProjectID = pid
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1 MiB — tool results can be verbose
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var req mcpRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+
+		// JSON-RPC notifications have no id and require no response.
+		if req.ID == nil {
+			continue
+		}
+
+		_ = encoder.Encode(dispatchMCPRequest(req, sctx))
+	}
+}
+
+// --- JSON-RPC / MCP types ---
+
+type mcpRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      interface{}     `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type mcpResponse struct {
+	JSONRPC string      `json:"jsonrpc"`
+	ID      interface{} `json:"id,omitempty"`
+	Result  interface{} `json:"result,omitempty"`
+	Error   *mcpRPCErr  `json:"error,omitempty"`
+}
+
+type mcpRPCErr struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpToolDef struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	InputSchema map[string]interface{} `json:"inputSchema"`
+}
+
+type mcpCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments"`
+}
+
+// --- Request dispatcher ---
+
+func dispatchMCPRequest(req mcpRequest, sctx *SessionContext) mcpResponse {
+	switch req.Method {
+	case "initialize":
+		return mcpOK(req.ID, map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo":      map[string]interface{}{"name": "qmax-code", "version": Version},
+		})
+
+	case "tools/list":
+		return mcpOK(req.ID, map[string]interface{}{"tools": buildMCPToolList()})
+
+	case "tools/call":
+		var params mcpCallParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return mcpErr(req.ID, -32602, "invalid params: "+err.Error())
+		}
+		result := ExecuteTool(params.Name, params.Arguments, sctx, context.Background())
+		return mcpOK(req.ID, map[string]interface{}{
+			"content": []map[string]interface{}{{"type": "text", "text": result}},
+			"isError": false,
+		})
+
+	default:
+		return mcpErr(req.ID, -32601, "method not found: "+req.Method)
+	}
+}
+
+func mcpOK(id interface{}, result interface{}) mcpResponse {
+	return mcpResponse{JSONRPC: "2.0", ID: id, Result: result}
+}
+
+func mcpErr(id interface{}, code int, msg string) mcpResponse {
+	return mcpResponse{JSONRPC: "2.0", ID: id, Error: &mcpRPCErr{Code: code, Message: msg}}
+}
+
+// buildMCPToolList converts qmax ToolDefs to MCP format.
+// The only structural difference is camelCase inputSchema vs Anthropic's input_schema.
+func buildMCPToolList() []mcpToolDef {
+	defs := BuildToolDefs()
+	out := make([]mcpToolDef, len(defs))
+	for i, d := range defs {
+		out[i] = mcpToolDef{
+			Name:        d.Name,
+			Description: d.Description,
+			InputSchema: d.InputSchema,
+		}
+	}
+	return out
+}

--- a/setup_orch.go
+++ b/setup_orch.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// OrchSetupResult describes what autosetup did so the caller can display it.
+type OrchSetupResult struct {
+	MCPWritten    bool
+	MCPPath       string
+	AlreadyHadMCP bool
+}
+
+// SetupCCIntegration writes the qmax MCP server into ~/.claude/settings.json
+// so Claude Code picks up qmax tools in EVERY session — not just when spawned
+// by qmax-code. This gives CC full bidirectional capability inheritance:
+//
+//   - CC gets all qmax QA tools (list, run, generate, crawl, review…)
+//   - When qmax-code is the host, CC's own tools (bash, file ops, web) are
+//     also fully active and the system prompt instructs CC to use both.
+func SetupCCIntegration() (*OrchSetupResult, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	claudeDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(claudeDir, 0700); err != nil {
+		return nil, err
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+	return writeMCPEntry(settingsPath)
+}
+
+// SetupCodexIntegration writes the qmax MCP server into ~/.codex/config.json
+// so Codex picks up qmax tools whenever the user invokes `codex` directly,
+// in addition to when qmax-code spawns it.
+func SetupCodexIntegration() (*OrchSetupResult, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0700); err != nil {
+		return nil, err
+	}
+
+	cfgPath := filepath.Join(codexDir, "config.json")
+	return writeMCPEntry(cfgPath)
+}
+
+// writeMCPEntry merges the qmax MCP entry into a JSON config file.
+// Existing keys are preserved; only the "qmax" entry under "mcpServers" is
+// added or updated.
+func writeMCPEntry(path string) (*OrchSetupResult, error) {
+	self, err := os.Executable()
+	if err != nil {
+		self = "qmax-code"
+	}
+
+	// Load existing config (may not exist yet).
+	cfg := map[string]interface{}{}
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &cfg)
+	}
+
+	// Navigate / create the mcpServers map.
+	mcpServers, _ := cfg["mcpServers"].(map[string]interface{})
+	if mcpServers == nil {
+		mcpServers = map[string]interface{}{}
+	}
+
+	alreadyHad := false
+	if existing, ok := mcpServers["qmax"]; ok && existing != nil {
+		alreadyHad = true
+	}
+
+	mcpServers["qmax"] = map[string]interface{}{
+		"command": self,
+		"args":    []string{"serve", "--mcp"},
+	}
+	cfg["mcpServers"] = mcpServers
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return nil, err
+	}
+
+	return &OrchSetupResult{
+		MCPWritten:    true,
+		MCPPath:       path,
+		AlreadyHadMCP: alreadyHad,
+	}, nil
+}
+
+// RunOrchSetup runs the one-time integration setup for the chosen backend,
+// printing progress to the terminal.
+func RunOrchSetup(backend string, term *Terminal) {
+	switch backend {
+	case "cc":
+		term.PrintSystem("Setting up Claude Code integration…")
+		res, err := SetupCCIntegration()
+		if err != nil {
+			term.PrintError(fmt.Sprintf("CC setup failed: %v", err))
+			return
+		}
+		if res.AlreadyHadMCP {
+			term.PrintSystem(fmt.Sprintf("qmax MCP entry updated in %s", res.MCPPath))
+		} else {
+			term.PrintSystem(fmt.Sprintf("qmax MCP entry added to %s", res.MCPPath))
+		}
+		term.PrintSystem("Claude Code now has qmax tools in EVERY session (not just when spawned by qmax-code).")
+		term.PrintSystem("Run `claude` directly and qmax QA tools will be available automatically.")
+
+	case "codex":
+		term.PrintSystem("Setting up Codex integration…")
+		res, err := SetupCodexIntegration()
+		if err != nil {
+			term.PrintError(fmt.Sprintf("Codex setup failed: %v", err))
+			return
+		}
+		if res.AlreadyHadMCP {
+			term.PrintSystem(fmt.Sprintf("qmax MCP entry updated in %s", res.MCPPath))
+		} else {
+			term.PrintSystem(fmt.Sprintf("qmax MCP entry added to %s", res.MCPPath))
+		}
+		term.PrintSystem("Codex now has qmax tools in every session.")
+	}
+}
+
+// IsOrchSetupDone returns true if the qmax MCP entry already exists in the
+// CLI's config file. Used to skip the setup banner on subsequent launches.
+func IsOrchSetupDone(backend string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+
+	var cfgPath string
+	switch backend {
+	case "cc":
+		cfgPath = filepath.Join(home, ".claude", "settings.json")
+	case "codex":
+		cfgPath = filepath.Join(home, ".codex", "config.json")
+	default:
+		return true
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		return false
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return false
+	}
+
+	mcpServers, _ := cfg["mcpServers"].(map[string]interface{})
+	if mcpServers == nil {
+		return false
+	}
+	_, exists := mcpServers["qmax"]
+	return exists
+}

--- a/terminal.go
+++ b/terminal.go
@@ -203,22 +203,36 @@ func (t *Terminal) PrintBanner(version string, ctx *SessionContext) {
 		fmt.Printf("  %s▸ Project #%d active%s\n", colorGreen, ctx.ProjectID, colorReset)
 	}
 
-	if ctx.API != nil {
-		fmt.Printf("  %s▸ Mode: standalone (direct API)%s\n", colorGreen, colorReset)
+	switch ctx.Backend {
+	case "cc":
+		fmt.Printf("  %s▸ Backend: Claude Code (CC subscription — no API tokens)%s\n", colorGreen, colorReset)
 		if ctx.Auth != nil && ctx.Auth.Email != "" {
-			fmt.Printf("  %s▸ Logged in as: %s%s\n", colorGreen, ctx.Auth.Email, colorReset)
+			fmt.Printf("  %s▸ QualityMax: %s%s\n", colorGreen, ctx.Auth.Email, colorReset)
 		}
-		fmt.Printf("  %s▸ API: %s%s\n", colorDim, ctx.Auth.GetCloudURL(), colorReset)
-	} else if ctx.QMaxBin != "" {
-		fmt.Printf("  %s▸ qmax CLI: %s%s\n", colorGreen, ctx.QMaxBin, colorReset)
-		if ctx.QMaxCfg.Email != "" {
-			fmt.Printf("  %s▸ Logged in as: %s%s\n", colorGreen, ctx.QMaxCfg.Email, colorReset)
+	case "codex":
+		fmt.Printf("  %s▸ Backend: Codex CLI (OpenAI subscription — no API tokens)%s\n", colorGreen, colorReset)
+		if ctx.Auth != nil && ctx.Auth.Email != "" {
+			fmt.Printf("  %s▸ QualityMax: %s%s\n", colorGreen, ctx.Auth.Email, colorReset)
 		}
-		if ctx.QMaxCfg.CloudURL != "" {
-			fmt.Printf("  %s▸ API: %s%s\n", colorDim, ctx.QMaxCfg.CloudURL, colorReset)
+	default:
+		// API mode — show direct API or qmax CLI connection status.
+		if ctx.API != nil {
+			fmt.Printf("  %s▸ Mode: standalone (direct API)%s\n", colorGreen, colorReset)
+			if ctx.Auth != nil && ctx.Auth.Email != "" {
+				fmt.Printf("  %s▸ Logged in as: %s%s\n", colorGreen, ctx.Auth.Email, colorReset)
+			}
+			fmt.Printf("  %s▸ API: %s%s\n", colorDim, ctx.Auth.GetCloudURL(), colorReset)
+		} else if ctx.QMaxBin != "" {
+			fmt.Printf("  %s▸ qmax CLI: %s%s\n", colorGreen, ctx.QMaxBin, colorReset)
+			if ctx.QMaxCfg.Email != "" {
+				fmt.Printf("  %s▸ Logged in as: %s%s\n", colorGreen, ctx.QMaxCfg.Email, colorReset)
+			}
+			if ctx.QMaxCfg.CloudURL != "" {
+				fmt.Printf("  %s▸ API: %s%s\n", colorDim, ctx.QMaxCfg.CloudURL, colorReset)
+			}
+		} else {
+			fmt.Printf("  %s▸ Not connected%s — type %s/connect%s to log in\n", colorYellow, colorReset, colorBold, colorReset)
 		}
-	} else {
-		fmt.Printf("  %s▸ Not connected%s — type %s/connect%s to log in\n", colorYellow, colorReset, colorBold, colorReset)
 	}
 
 	fmt.Printf("  %sType /help for commands or just tell me what to test. 🐾%s\n\n", colorDim, colorReset)

--- a/tui_backend.go
+++ b/tui_backend.go
@@ -1,0 +1,463 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+var (
+	pickerBox = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color("238")).
+			Padding(0, 1)
+
+	pickerSectionHeader = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("242")).
+				PaddingTop(1)
+
+	pickerRowSelected = lipgloss.NewStyle().
+				Background(lipgloss.Color("237")).
+				Bold(true)
+
+	pickerRowNormal = lipgloss.NewStyle()
+
+	pickerIcon = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("69"))   // blue — Claude ✦
+
+	pickerIconCodex = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("107"))  // green — Codex ⊗
+
+	pickerIconAPI = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("242"))  // grey — Direct ○
+
+	pickerLabel = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("252"))
+
+	pickerLabelSel = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("255")).
+			Bold(true)
+
+	pickerBadgeNew = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("0")).
+			Background(lipgloss.Color("214")).
+			Bold(true).
+			PaddingLeft(1).PaddingRight(1)
+
+	pickerBadgeCurrent = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("82")).
+				Bold(true)
+
+	pickerBadgeStar = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("214"))
+
+	pickerBadgeExt = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("242"))
+
+	pickerShortcut = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240"))
+
+	pickerDivider = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("237"))
+
+	effortLabelActive = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("0")).
+				Background(lipgloss.Color("69")).
+				Bold(true).
+				PaddingLeft(2).PaddingRight(2)
+
+	effortLabelInactive = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("242")).
+				PaddingLeft(2).PaddingRight(2)
+
+	pickerFooter = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("240")).
+			PaddingTop(1)
+
+	pickerStatusBar = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("252")).
+			Background(lipgloss.Color("236")).
+			PaddingLeft(1).PaddingRight(1)
+
+	pickerStatusIcon = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("69")).
+				Background(lipgloss.Color("236")).
+				Bold(true)
+
+	pickerStatusEffort = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("214")).
+				Background(lipgloss.Color("236")).
+				Bold(true)
+)
+
+// ─── Model catalogue ──────────────────────────────────────────────────────────
+
+type pickerEntry struct {
+	backend  string // "cc" | "codex" | ""
+	modelID  string // passed via --model to the CLI
+	label    string // display name
+	subLabel string // e.g. "1M ctx"
+	isNew    bool
+	isFav    bool    // ⭐ default model for this backend
+	external bool    // ↗ opens to external provider
+	shortcut byte    // '1'..'9','0'  (0 = no shortcut)
+}
+
+var ccModels = []pickerEntry{
+	{backend: "cc", modelID: "claude-opus-4-7",        label: "Opus 4.7",    subLabel: "1M ctx", isNew: true, shortcut: '1'},
+	{backend: "cc", modelID: "claude-opus-4-7",        label: "Opus 4.7",                        isNew: true, shortcut: '2'},
+	{backend: "cc", modelID: "claude-opus-4-6",        label: "Opus 4.6",    subLabel: "1M ctx",              shortcut: '3'},
+	{backend: "cc", modelID: "claude-sonnet-4-6",      label: "Sonnet 4.6",                       isFav: true, shortcut: '4'},
+	{backend: "cc", modelID: "claude-haiku-4-5-20251001", label: "Haiku 4.5",                     shortcut: '5'},
+}
+
+var codexModels = []pickerEntry{
+	{backend: "codex", modelID: "gpt-5.5",             label: "GPT-5.5",     isNew: true,  external: true, shortcut: '6'},
+	{backend: "codex", modelID: "o4-mini",             label: "o4-mini",                   external: true, isFav: true, shortcut: '7'},
+	{backend: "codex", modelID: "o3",                  label: "o3",                        external: true, shortcut: '8'},
+	{backend: "codex", modelID: "o3-mini",             label: "o3-mini",                   external: true, shortcut: '9'},
+	{backend: "codex", modelID: "gpt-4o",              label: "GPT-4o",                    external: true, shortcut: '0'},
+}
+
+var apiModels = []pickerEntry{
+	{backend: "", modelID: "auto",              label: "auto",     subLabel: "haiku→sonnet routing", isFav: true},
+	{backend: "", modelID: ModelSonnet,         label: "Sonnet 4.6"},
+	{backend: "", modelID: ModelOpus,           label: "Opus 4.6"},
+	{backend: "", modelID: ModelHaiku,          label: "Haiku 4.5"},
+}
+
+var effortLevels = []string{"low", "medium", "high"}
+
+// ─── Bubbletea model ──────────────────────────────────────────────────────────
+
+// ModelPickerResult is returned after the TUI closes.
+type ModelPickerResult struct {
+	Backend   string // "cc" | "codex" | ""
+	ModelID   string // specific model, or "" for default
+	Effort    string // "low" | "medium" | "high"
+	Confirmed bool
+}
+
+type modelPickerModel struct {
+	// All rows in order: cc entries, codex entries, api entries.
+	allEntries []pickerEntry
+	cursor     int    // index into allEntries
+	effort     string // "low" | "medium" | "high"
+	effortFocus bool  // Tab switches focus between list and effort bar
+
+	// Current selection (what was active when the picker opened)
+	currentBackend string
+	currentModelID string
+
+	cancelled bool
+	chosen    *pickerEntry
+}
+
+func newModelPickerModel(currentBackend, currentModelID, effort string) modelPickerModel {
+	entries := make([]pickerEntry, 0, len(ccModels)+len(codexModels)+len(apiModels))
+	entries = append(entries, ccModels...)
+	entries = append(entries, codexModels...)
+	entries = append(entries, apiModels...)
+
+	// Start cursor on the active entry.
+	cursor := 0
+	for i, e := range entries {
+		if e.backend == currentBackend && (e.modelID == currentModelID || currentModelID == "") && e.isFav {
+			cursor = i
+		}
+		if e.backend == currentBackend && e.modelID == currentModelID {
+			cursor = i
+		}
+	}
+
+	if effort == "" {
+		effort = "high"
+	}
+
+	return modelPickerModel{
+		allEntries:     entries,
+		cursor:         cursor,
+		effort:         effort,
+		currentBackend: currentBackend,
+		currentModelID: currentModelID,
+	}
+}
+
+func (m modelPickerModel) Init() tea.Cmd { return nil }
+
+func (m modelPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case msg.String() == "ctrl+c", msg.String() == "esc", msg.String() == "q":
+			m.cancelled = true
+			return m, tea.Quit
+
+		case msg.String() == "tab":
+			m.effortFocus = !m.effortFocus
+
+		case !m.effortFocus && (msg.String() == "up" || msg.String() == "k"):
+			if m.cursor > 0 {
+				m.cursor--
+			}
+
+		case !m.effortFocus && (msg.String() == "down" || msg.String() == "j"):
+			if m.cursor < len(m.allEntries)-1 {
+				m.cursor++
+			}
+
+		case m.effortFocus && (msg.String() == "left" || msg.String() == "h"):
+			for i, e := range effortLevels {
+				if e == m.effort && i > 0 {
+					m.effort = effortLevels[i-1]
+					break
+				}
+			}
+
+		case m.effortFocus && (msg.String() == "right" || msg.String() == "l"):
+			for i, e := range effortLevels {
+				if e == m.effort && i < len(effortLevels)-1 {
+					m.effort = effortLevels[i+1]
+					break
+				}
+			}
+
+		case msg.String() == "enter", msg.String() == " ":
+			if !m.effortFocus {
+				e := m.allEntries[m.cursor]
+				m.chosen = &e
+			}
+			return m, tea.Quit
+
+		default:
+			// Number shortcuts 1-9, 0
+			k := msg.String()
+			if len(k) == 1 {
+				ch := k[0]
+				for i, e := range m.allEntries {
+					if e.shortcut == ch {
+						m.cursor = i
+						ee := m.allEntries[i]
+						m.chosen = &ee
+						return m, tea.Quit
+					}
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m modelPickerModel) View() string {
+	ccInstalled := FindClaudeCode() != ""
+	codexInstalled := FindCodex() != ""
+
+	var b strings.Builder
+
+	// ── Claude Code section ──────────────────────────────────────────
+	sectionIcon := pickerIcon.Render("✦")
+	sectionLabel := "Claude Code"
+	if !ccInstalled {
+		sectionLabel += pickerBadgeExt.Render("  not installed")
+	}
+	b.WriteString(pickerSectionHeader.Render(fmt.Sprintf("%s  %s", sectionIcon, sectionLabel)))
+	b.WriteByte('\n')
+
+	for i, e := range m.allEntries {
+		if e.backend != "cc" {
+			continue
+		}
+		b.WriteString(m.renderRow(i, e, "cc"))
+		b.WriteByte('\n')
+	}
+
+	// ── Divider ─────────────────────────────────────────────────────
+	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+	b.WriteByte('\n')
+
+	// ── Codex section ────────────────────────────────────────────────
+	sectionIcon2 := pickerIconCodex.Render("⊗")
+	sectionLabel2 := "Codex"
+	if !codexInstalled {
+		sectionLabel2 += pickerBadgeExt.Render("  not installed")
+	}
+	b.WriteString(pickerSectionHeader.Render(fmt.Sprintf("%s  %s", sectionIcon2, sectionLabel2)))
+	b.WriteByte('\n')
+
+	for i, e := range m.allEntries {
+		if e.backend != "codex" {
+			continue
+		}
+		b.WriteString(m.renderRow(i, e, "codex"))
+		b.WriteByte('\n')
+	}
+
+	// ── Divider ─────────────────────────────────────────────────────
+	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+	b.WriteByte('\n')
+
+	// ── Direct API section ───────────────────────────────────────────
+	sectionIcon3 := pickerIconAPI.Render("○")
+	b.WriteString(pickerSectionHeader.Render(fmt.Sprintf("%s  Direct API", sectionIcon3)))
+	b.WriteByte('\n')
+
+	for i, e := range m.allEntries {
+		if e.backend != "" {
+			continue
+		}
+		b.WriteString(m.renderRow(i, e, ""))
+		b.WriteByte('\n')
+	}
+
+	// ── Effort bar ───────────────────────────────────────────────────
+	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+	b.WriteByte('\n')
+	b.WriteString(m.renderEffortBar())
+	b.WriteByte('\n')
+
+	// ── Footer ───────────────────────────────────────────────────────
+	hint := "↑↓ navigate  ·  1-9 jump  ·  Tab effort  ·  Enter confirm  ·  Esc"
+	b.WriteString(pickerFooter.Render(hint))
+	b.WriteByte('\n')
+
+	// ── Status bar ───────────────────────────────────────────────────
+	b.WriteString(m.renderStatusBar())
+
+	return pickerBox.Render(b.String())
+}
+
+func (m modelPickerModel) renderRow(idx int, e pickerEntry, backend string) string {
+	isCursor := idx == m.cursor
+	isCurrent := e.backend == m.currentBackend && (e.modelID == m.currentModelID || (m.currentModelID == "" && e.isFav))
+
+	// Cursor indicator
+	cursor := "  "
+	if isCursor {
+		cursor = pickerBadgeStar.Render("▶ ")
+	}
+
+	// Provider icon
+	var icon string
+	switch backend {
+	case "cc":
+		icon = pickerIcon.Render("✦")
+	case "codex":
+		icon = pickerIconCodex.Render("⊗")
+	default:
+		icon = pickerIconAPI.Render("○")
+	}
+
+	// Label
+	label := e.label
+	if e.subLabel != "" {
+		label += "  " + pickerBadgeExt.Render(e.subLabel)
+	}
+	if isCursor {
+		label = pickerLabelSel.Render(e.label)
+		if e.subLabel != "" {
+			label += "  " + pickerBadgeExt.Render(e.subLabel)
+		}
+	} else {
+		label = pickerLabel.Render(label)
+	}
+
+	// Right-side badges
+	var badges []string
+	if e.isNew {
+		badges = append(badges, pickerBadgeNew.Render("NEW"))
+	}
+	if isCurrent {
+		badges = append(badges, pickerBadgeCurrent.Render("✓"))
+	}
+	if e.isFav && !isCurrent {
+		badges = append(badges, pickerBadgeStar.Render("⭐"))
+	}
+	if e.external {
+		badges = append(badges, pickerBadgeExt.Render("↗"))
+	}
+
+	// Shortcut
+	sc := "  "
+	if e.shortcut != 0 {
+		sc = pickerShortcut.Render(fmt.Sprintf("%c ", e.shortcut))
+	}
+
+	right := strings.Join(badges, " ")
+	row := fmt.Sprintf("%s%s  %-20s  %-16s %s", cursor, icon, label, right, sc)
+
+	if isCursor {
+		return pickerRowSelected.Render(row)
+	}
+	return pickerRowNormal.Render(row)
+}
+
+func (m modelPickerModel) renderEffortBar() string {
+	focusMark := ""
+	if m.effortFocus {
+		focusMark = pickerBadgeStar.Render("▶ ")
+	} else {
+		focusMark = "  "
+	}
+
+	var parts []string
+	for _, lvl := range effortLevels {
+		label := strings.Title(lvl) //nolint:staticcheck
+		if lvl == m.effort {
+			parts = append(parts, effortLabelActive.Render(label))
+		} else {
+			parts = append(parts, effortLabelInactive.Render(label))
+		}
+	}
+
+	hint := ""
+	if m.effortFocus {
+		hint = pickerFooter.Render("  ←→ adjust")
+	}
+	return fmt.Sprintf("%sEffort  %s%s", focusMark, strings.Join(parts, " "), hint)
+}
+
+func (m modelPickerModel) renderStatusBar() string {
+	cur := m.allEntries[m.cursor]
+	var icon string
+	switch cur.backend {
+	case "cc":
+		icon = pickerStatusIcon.Render("✦")
+	case "codex":
+		icon = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("107")).
+			Background(lipgloss.Color("236")).
+			Bold(true).Render("⊗")
+	default:
+		icon = pickerStatusIcon.Render("○")
+	}
+	effort := pickerStatusEffort.Render(strings.Title(m.effort)) //nolint:staticcheck
+	label := pickerStatusBar.Render(fmt.Sprintf("  %s  %s  ▌ %s effort  ", icon, cur.label, effort))
+	return label
+}
+
+// ─── Public entry point ───────────────────────────────────────────────────────
+
+// ShowModelPicker opens the unified model + effort TUI.
+// Returns the result; Confirmed=false means the user cancelled.
+func ShowModelPicker(currentBackend, currentModelID, effort string) ModelPickerResult {
+	m := newModelPickerModel(currentBackend, currentModelID, effort)
+	p := tea.NewProgram(m)
+	result, err := p.Run()
+	if err != nil {
+		return ModelPickerResult{Confirmed: false}
+	}
+	final := result.(modelPickerModel)
+	if final.cancelled || final.chosen == nil {
+		return ModelPickerResult{Confirmed: false}
+	}
+	return ModelPickerResult{
+		Backend:   final.chosen.backend,
+		ModelID:   final.chosen.modelID,
+		Effort:    final.effort,
+		Confirmed: true,
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an interop mode that lets qmax-code use the user's installed Claude Code or Codex CLI as the LLM backend (subprocess + embedded MCP server, Conductor-style — user is the principal, no API token handling, no wire proxying).
- Ships a model + effort TUI picker (`/orch`), instant `/cc` `/codex` `/api` switching, and a consent-first activation flow with three tiers: Standard (curated allowlist for reads, test runners, qmax tools), Unattended (`--dangerously-skip-permissions`), or Cancel.
- Hardens telemetry: removes prompt content from Bugsink captures, redacts API error bodies, adds a `BeforeSend` sanitizer that strips any tag whose name matches prompt-shaped prefixes — the privacy non-interception promise is now enforced in code.

## Test plan

- [ ] Standalone direct-API mode still works with no behavior changes
- [ ] `/orch` opens the TUI picker; `1-9,0` shortcuts jump to models; Tab toggles effort focus
- [ ] First `/cc` activation prompts for Standard/Unattended consent; declined consent falls back to API mode without breaking startup
- [ ] Standard mode auto-approves Read/Grep/git status/test runners/qmax tools without per-action prompts; refuses Edit/Write
- [ ] Unattended mode requires the second confirmation, then runs `claude --dangerously-skip-permissions`
- [ ] Consent persists in `~/.qmax-code/config.json` (no re-prompt next session); global install only writes to `~/.claude/settings.json` after explicit yes
- [ ] Bugsink captures contain no `input`/`prompt`/`message`/`content` tags and no Anthropic error body content

🤖 Generated with [Claude Code](https://claude.com/claude-code)