### PR TITLE
chore(oss): contributor hygiene — ldflags, project ID, CoC, issue templates, prereqs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a reproducible bug in qmax-code
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. Run `qmax-code ...`
+2. Enter `...`
+3. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Actual behavior**
+What actually happened. Include any error output or stack traces.
+
+**Environment**
+- OS: [e.g. macOS 14, Ubuntu 22.04]
+- `qmax-code --version` output:
+- Anthropic model in use (if relevant):
+
+**Additional context**
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem or motivation**
+What problem does this solve, or what capability is missing?
+
+**Proposed solution**
+Describe what you'd like to see added or changed.
+
+**Alternatives considered**
+Any alternative approaches you've thought about.
+
+**Additional context**
+Any other context, screenshots, or examples.

--- a/.github/workflows/qamax-go.yml
+++ b/.github/workflows/qamax-go.yml
@@ -86,7 +86,7 @@ jobs:
         if: always()
         env:
           QAMAX_API_KEY: ${{ secrets.QAMAX_API_KEY }}
-          QAMAX_PROJECT_ID: ${{ vars.QAMAX_PROJECT_ID || '164' }}
+          QAMAX_PROJECT_ID: ${{ vars.QAMAX_PROJECT_ID }}
           # Bind all GitHub-context values to env vars so they cannot be
           # interpolated into the bash script body (defense against
           # ${{ }} expression injection — CodeQL js/actions-script-injection).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,14 @@ jobs:
       - name: Build all platforms
         run: |
           mkdir -p build
-          GOOS=darwin  GOARCH=amd64 go build -ldflags="-s -w" -o build/qmax-code-darwin-amd64 .
-          GOOS=darwin  GOARCH=arm64 go build -ldflags="-s -w" -o build/qmax-code-darwin-arm64 .
-          GOOS=linux   GOARCH=amd64 go build -ldflags="-s -w" -o build/qmax-code-linux-amd64 .
-          GOOS=linux   GOARCH=arm64 go build -ldflags="-s -w" -o build/qmax-code-linux-arm64 .
-          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o build/qmax-code-windows-amd64.exe .
-          GOOS=windows GOARCH=arm64 go build -ldflags="-s -w" -o build/qmax-code-windows-arm64.exe .
+          VERSION="${GITHUB_REF_NAME#v}"
+          LDFLAGS="-s -w -X main.Version=${VERSION}"
+          GOOS=darwin  GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o build/qmax-code-darwin-amd64 .
+          GOOS=darwin  GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o build/qmax-code-darwin-arm64 .
+          GOOS=linux   GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o build/qmax-code-linux-amd64 .
+          GOOS=linux   GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o build/qmax-code-linux-arm64 .
+          GOOS=windows GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o build/qmax-code-windows-amd64.exe .
+          GOOS=windows GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o build/qmax-code-windows-arm64.exe .
 
       - name: Create archives
         run: |

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in our project a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainers at **strazhnyk@gmail.com**. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to maintain confidentiality with regard to the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thanks for helping improve `qmax-code`.
 
+## Prerequisites
+
+- **Go 1.24+** — see `go.mod` for the exact version
+- **Anthropic API key** — set via `qmax-code config set anthropic_key <key>` or the `ANTHROPIC_API_KEY` env var; required for agent mode
+- **QualityMax account** — needed for cloud tools (test generation, crawl, repo review); run `qmax-code login` after [signing up](https://app.qualitymax.io). Most unit tests run without an account.
+
 ## Development
 
 Run the test suite before opening a PR:


### PR DESCRIPTION
## Summary

- **release.yml** — inject version from git tag via `-X main.Version` so released binaries always report the correct version; removes the process trap of forgetting to bump `main.go` before tagging
- **qamax-go.yml** — remove hardcoded `QAMAX_PROJECT_ID: '164'` default; external forks without the repo var now skip QualityMax reporting cleanly instead of accidentally targeting an internal project
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1; contact email set to strazhnyk@gmail.com
- **.github/ISSUE_TEMPLATE/** — bug report and feature request templates
- **CONTRIBUTING.md** — add Prerequisites section documenting Go version, Anthropic API key, and QualityMax account requirements

## Test plan
- [ ] Verify next tag-triggered release build reports correct version in `--version` output
- [ ] Confirm fork CI run without `QAMAX_PROJECT_ID` var skips reporting without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)