### PR TITLE
docs(readme): add FSL-1.1-ALv2 license badges + above-fold note

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@
 
 # qmax-code
 
+[![License: FSL-1.1-ALv2](https://img.shields.io/badge/license-FSL--1.1--ALv2-2ea44f.svg)](LICENSE)
+[![Future License: Apache 2.0](https://img.shields.io/badge/future%20license-Apache%202.0-blue.svg)](LICENSE)
+[![Made with Go](https://img.shields.io/badge/made%20with-Go-00ADD8.svg)](https://go.dev/)
+[![Announcement](https://img.shields.io/badge/announcement-2026--05--01-7c6cf0.svg)](https://qualitymax.io/blog/qmax-code-open-source)
+
 **AI-powered terminal agent for QualityMax.** Named after Max, the real cat who inspired it all.
 
 qmax-code is the LLM brain that orchestrates the open-source [`qmax`](https://github.com/Quality-Max/qmax-local-agent) CLI. It connects to the Claude API, understands your testing intent in natural language, and translates it into structured CLI operations — crawling sites, generating tests, running scripts, reviewing repos.
+
+> **License:** Source-available under the [Functional Source License (FSL-1.1-ALv2)](LICENSE) — created by [Sentry](https://fsl.software). Free for any non-competing use (internal use, modifications, contributions, education, research, professional services). Two years after each release, the code automatically converts to plain Apache 2.0. The "Other" tag GitHub shows in the sidebar is a quirk of its licensee detector — FSL isn't on the SPDX list.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

GitHub's licensee detector doesn't recognise FSL (returns \`spdx_id: NOASSERTION\`, sidebar shows \"License: Other\"). This PR adds visible license badges and a short blockquote so visitors see the license accurately above the fold without depending on the sidebar tag.

- \`License: FSL-1.1-ALv2\` badge linking to \`LICENSE\`
- \`Future License: Apache 2.0\` badge (the 2-year conversion clause)
- \`Made with Go\` badge
- \`Announcement: 2026-05-01\` badge linking to the qualitymax.io blog post
- One-line blockquote summarising what FSL allows (non-competing use, internal use, modifications, etc.) and noting why GitHub shows \"Other\" in the sidebar

## Test plan

- [ ] README renders the four shields.io badges in a row above the fold
- [ ] Each badge links to the right destination (LICENSE / go.dev / blog)
- [ ] Blockquote reads correctly + fsl.software link works
- [ ] No change to LICENSE itself