### PR TITLE
fix: correct import_document endpoint URL and field name

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -335,13 +335,13 @@ func (c *APIClient) ImportRepo(ctx context.Context, url string, projectID int, c
 
 func (c *APIClient) ImportDocument(ctx context.Context, projectID int, text, sourceName string) string {
 	body := map[string]interface{}{
-		"project_id": projectID,
-		"content":    text,
+		"project_id":   projectID,
+		"text_content": text,
 	}
 	if sourceName != "" {
 		body["source_name"] = sourceName
 	}
-	return c.post(ctx, "/api/test-cases/import-from-document", body)
+	return c.post(ctx, "/api/import/document/text", body)
 }
 
 // --- PR operations ---


### PR DESCRIPTION
## Summary

- **Root cause**: Backend refactored document import routes. The old endpoint `POST /api/test-cases/import-from-document` no longer exists — calling it returns `HTTP 405 Method Not Allowed`.
- **Fix 1**: Update endpoint from `/api/test-cases/import-from-document` → `/api/import/document/text`
- **Fix 2**: Rename request body field from `"content"` → `"text_content"` to match `DocumentTextImportRequest` in the backend

## Reproduction

Before this fix, any call to `import_document` (MCP tool or API) returns:
```json
{"error": "HTTP 405: Method Not Allowed"}
```

## Test plan

- [ ] Call `import_document` with a project ID and sample text — confirm test cases are extracted and saved
- [ ] Verify `source_name` optional field still passes through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)