### PR TITLE
fix(sessions): interactive keyboard picker for /sessions

### DIFF
--- a/main.go
+++ b/main.go
@@ -586,20 +586,26 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			sessions, err := ListSessions(10)
 			if err != nil || len(sessions) == 0 {
 				term.PrintSystem("No saved sessions.")
+				continue
+			}
+			chosenID, ok := ShowSessionPicker(sessions, sessionID)
+			if !ok {
+				continue
+			}
+			session, loadErr := LoadSession(chosenID)
+			if loadErr != nil {
+				term.PrintError(fmt.Sprintf("Cannot resume: %v", loadErr))
 			} else {
-				fmt.Println()
-				fmt.Printf("  %-10s  %-18s  %-6s  %-8s  %s\n", "ID", "Updated", "Turns", "Tokens", "Project")
-				fmt.Printf("  %-10s  %-18s  %-6s  %-8s  %s\n", "----------", "------------------", "------", "--------", "-------")
-				for _, s := range sessions {
-					marker := " "
-					if s.ID == sessionID {
-						marker = "*"
-					}
-					fmt.Printf(" %s%-10s  %-18s  %-6d  %-8d  #%d\n",
-						marker, s.ID, s.UpdatedAt.Format("2006-01-02 15:04"), s.Turns, s.Tokens, s.ProjectID)
+				sanitizeSessionMessages(session.Messages)
+				agent.history = session.Messages
+				agent.usage = session.Usage
+				sessionID = session.ID
+				if session.ProjectID > 0 {
+					agent.config.Context.ProjectID = session.ProjectID
 				}
-				fmt.Println()
-				term.PrintSystem("Resume with: /resume <id>")
+				term.SetSessionPrompt(sessionID)
+				term.PrintSystem(fmt.Sprintf("Resumed session %s (%d turns, project #%d)",
+					session.ID, session.Turns, session.ProjectID))
 			}
 			continue
 		case input == "/save":

--- a/tui_backend.go
+++ b/tui_backend.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -591,4 +592,146 @@ func ShowModelPicker(currentBackend, currentModelID, effort string) ModelPickerR
 		Effort:    final.effort,
 		Confirmed: true,
 	}
+}
+
+// ─── Session picker ───────────────────────────────────────────────────────────
+
+type sessionPickerModel struct {
+	sessions    []SessionSummary
+	cursor      int
+	activeID    string
+	confirmed   bool
+	cancelled   bool
+}
+
+func newSessionPickerModel(sessions []SessionSummary, activeID string) sessionPickerModel {
+	cursor := 0
+	for i, s := range sessions {
+		if s.ID == activeID {
+			cursor = i
+			break
+		}
+	}
+	return sessionPickerModel{sessions: sessions, cursor: cursor, activeID: activeID}
+}
+
+func (m sessionPickerModel) Init() tea.Cmd { return nil }
+
+func (m sessionPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.sessions)-1 {
+				m.cursor++
+			}
+		case "enter", " ":
+			m.confirmed = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m sessionPickerModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(pickerSectionHeader.Render("Saved Sessions"))
+	b.WriteByte('\n')
+
+	now := time.Now()
+	for i, s := range m.sessions {
+		isCursor := i == m.cursor
+		isActive := s.ID == m.activeID
+
+		arrow := "  "
+		if isCursor {
+			arrow = pickerBadgeStar.Render("▶ ")
+		}
+
+		ago := formatAgo(now.Sub(s.UpdatedAt))
+		meta := fmt.Sprintf("%s  %2d turns  %s", ago, s.Turns, formatTokens(s.Tokens))
+		if s.ProjectID > 0 {
+			meta += fmt.Sprintf("  #%d", s.ProjectID)
+		}
+
+		var idLabel, metaLabel string
+		if isCursor {
+			idLabel = pickerLabelSel.Render(fmt.Sprintf("%-10s", s.ID))
+			metaLabel = menuDescSelSty.Render(meta)
+		} else {
+			idLabel = pickerLabel.Render(fmt.Sprintf("%-10s", s.ID))
+			metaLabel = pickerFooter.Render(meta)
+		}
+
+		badge := ""
+		if isActive {
+			badge = "  " + pickerBadgeCurrent.Render("active")
+		}
+
+		row := fmt.Sprintf("%s%s  %s%s", arrow, idLabel, metaLabel, badge)
+		if isCursor {
+			b.WriteString(pickerRowSelected.Render(row))
+		} else {
+			b.WriteString(pickerRowNormal.Render(row))
+		}
+		b.WriteByte('\n')
+	}
+
+	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+	b.WriteByte('\n')
+	b.WriteString(pickerFooter.Render("↑↓ navigate  ·  Enter resume  ·  Esc cancel"))
+	b.WriteByte('\n')
+
+	return pickerBox.Render(b.String())
+}
+
+func formatAgo(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now   "
+	case d < time.Hour:
+		return fmt.Sprintf("%2dm ago    ", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%2dh ago    ", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%2dd ago    ", int(d.Hours()/24))
+	}
+}
+
+func formatTokens(n int) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM tok", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fk tok", float64(n)/1_000)
+	default:
+		return fmt.Sprintf("%d tok", n)
+	}
+}
+
+// ShowSessionPicker opens the interactive session picker TUI.
+// Returns the selected session ID and whether the user confirmed.
+func ShowSessionPicker(sessions []SessionSummary, activeID string) (string, bool) {
+	if len(sessions) == 0 {
+		return "", false
+	}
+	m := newSessionPickerModel(sessions, activeID)
+	p := tea.NewProgram(m)
+	result, err := p.Run()
+	if err != nil {
+		return "", false
+	}
+	final := result.(sessionPickerModel)
+	if final.cancelled || !final.confirmed {
+		return "", false
+	}
+	return final.sessions[final.cursor].ID, true
 }


### PR DESCRIPTION
## Summary
- `/sessions` previously printed a static table and required the user to manually type `/resume <id>` — no keyboard navigation was possible
- Now opens a bubbletea TUI picker matching the UX of `/theme` and `/orch`: ↑↓ to navigate, Enter to resume, Esc/q to cancel
- The currently active session is highlighted with an `active` badge; cursor starts on it
- Selecting a session resumes it immediately (same logic as `/resume <id>`)
- `/resume <id>` still works as before for scripted use

## Test plan
- [ ] Run `qmax-code`, type `/sessions` — picker should open with arrow-key navigation
- [ ] Press Enter on a session — should resume and update the prompt
- [ ] Press Esc — should cancel and return to prompt with no change
- [ ] With a single session, picker should show it and work normally
- [ ] With no sessions, should still print "No saved sessions." and not open picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)