### PR TITLE
feat: show model in session picker + harden memory safety

### DIFF
--- a/cc_agent.go
+++ b/cc_agent.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // CLIAgent is the interface implemented by both CCAgent (claude CLI) and
@@ -255,7 +257,13 @@ func (a *CCAgent) Run(userMsg string, term *Terminal) (string, error) {
 		args = append(args, "--resume", ccSessionID)
 	}
 
-	cmd := exec.Command(a.claudeBin, args...)
+	// 30-minute per-turn timeout prevents runaway CC processes from eating RAM
+	// indefinitely when working on large repos. CC exits non-zero on cancel;
+	// parseStream returns whatever it collected before the kill.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, a.claudeBin, args...)
 	cmd.Stderr = os.Stderr // CC's own errors and status messages
 
 	stdout, err := cmd.StdoutPipe()

--- a/session.go
+++ b/session.go
@@ -186,6 +186,7 @@ type SessionSummary struct {
 	Turns     int
 	Tokens    int
 	ProjectID int
+	Model     string
 }
 
 // ListSessions returns recent sessions sorted by update time (newest first).
@@ -224,6 +225,7 @@ func ListSessions(limit int) ([]SessionSummary, error) {
 			Turns:     s.Turns,
 			Tokens:    s.Usage.TotalTokens(),
 			ProjectID: s.ProjectID,
+			Model:     s.Model,
 		})
 	}
 

--- a/tools.go
+++ b/tools.go
@@ -1337,14 +1337,6 @@ func runShell(ctx context.Context, name string, args ...string) string {
 	return redactSensitive(stdout.String())
 }
 
-// truncateOutput limits output to maxLen characters.
-func truncateOutput(s string, maxLen int) string {
-	if len(s) <= maxLen {
-		return s
-	}
-	return s[:maxLen] + "\n... (truncated)"
-}
-
 // extractPlaywrightError parses Playwright test output and extracts the actual error
 // with line numbers, locator info, and expected/received values.
 func extractPlaywrightError(output string) string {

--- a/tools.go
+++ b/tools.go
@@ -15,6 +15,42 @@ import (
 	"time"
 )
 
+// limitWriter is an io.Writer that silently discards bytes once the cap is hit.
+// Use it as cmd.Stdout/Stderr to prevent unbounded memory growth from large
+// subprocess outputs. The cap is enforced at write time so the underlying
+// buffer never exceeds maxBytes.
+type limitWriter struct {
+	b      strings.Builder
+	n      int
+	maxN   int
+	capped bool
+}
+
+func newLimitWriter(maxBytes int) *limitWriter { return &limitWriter{maxN: maxBytes} }
+
+func (lw *limitWriter) Write(p []byte) (int, error) {
+	remaining := lw.maxN - lw.n
+	if remaining <= 0 {
+		lw.capped = true
+		return len(p), nil // discard; tell caller we consumed it
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+		lw.capped = true
+	}
+	n, err := lw.b.Write(p)
+	lw.n += n
+	return n, err
+}
+
+func (lw *limitWriter) String() string {
+	s := lw.b.String()
+	if lw.capped {
+		s += "\n... (output capped)"
+	}
+	return s
+}
+
 // --- input parsing helpers ---
 
 func parseInput(rawInput interface{}) map[string]interface{} {
@@ -990,9 +1026,12 @@ func runLocalTest(ctx context.Context, sctx *SessionContext, scriptID int, baseU
 	}
 
 	// 3. Run with timeout
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	// Cap buffers at the pipe level so a verbose test suite on a large repo
+	// cannot inflate our process memory before we get to truncate.
+	stdout := newLimitWriter(3 * 1024 * 1024) // 3 MB hard cap
+	stderr := newLimitWriter(512 * 1024)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	cmd.Dir = tmpDir
 
 	if baseURL != "" {
@@ -1006,11 +1045,11 @@ func runLocalTest(ctx context.Context, sctx *SessionContext, scriptID int, baseU
 	// 4. Build result
 	passed := runErr == nil
 	output := redactSensitive(stdout.String())
-	if stderr.Len() > 0 {
+	if stderr.n > 0 {
 		output += "\n--- stderr ---\n" + redactSensitive(stderr.String())
 	}
 
-	// Trim output if too long
+	// Trim output if too long (display budget)
 	if len(output) > 5000 {
 		output = output[:2000] + "\n...\n" + output[len(output)-2000:]
 	}
@@ -1254,15 +1293,16 @@ func runQMax(sctx *SessionContext, ctx context.Context, args ...string) string {
 		return fmt.Sprintf(`{"error": "qmax CLI not found. %s"}`, formatQMaxInstallHint())
 	}
 	cmd := exec.CommandContext(ctx, binary, args...)
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdout := newLimitWriter(512 * 1024) // 512 KB — qmax JSON responses are small
+	stderr := newLimitWriter(64 * 1024)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() != nil {
 			return `{"error": "cancelled"}`
 		}
-		if stderr.Len() > 0 {
+		if stderr.n > 0 {
 			return fmt.Sprintf(`{"error": %q}`, redactSensitive(stderr.String()))
 		}
 		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
@@ -1278,9 +1318,10 @@ func runQMax(sctx *SessionContext, ctx context.Context, args ...string) string {
 // runShell executes a shell command with output limits.
 func runShell(ctx context.Context, name string, args ...string) string {
 	cmd := exec.CommandContext(ctx, name, args...)
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+	stdout := newLimitWriter(8000) // match the display budget
+	stderr := newLimitWriter(4000)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() != nil {
@@ -1288,12 +1329,12 @@ func runShell(ctx context.Context, name string, args ...string) string {
 		}
 		combined := stdout.String() + stderr.String()
 		if combined != "" {
-			return truncateOutput(redactSensitive(combined), 8000)
+			return redactSensitive(combined)
 		}
 		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
 	}
 
-	return truncateOutput(redactSensitive(stdout.String()), 8000)
+	return redactSensitive(stdout.String())
 }
 
 // truncateOutput limits output to maxLen characters.

--- a/tui_backend.go
+++ b/tui_backend.go
@@ -657,7 +657,7 @@ func (m sessionPickerModel) View() string {
 		}
 
 		ago := formatAgo(now.Sub(s.UpdatedAt))
-		meta := fmt.Sprintf("%s  %2d turns  %s", ago, s.Turns, formatTokens(s.Tokens))
+		meta := fmt.Sprintf("%s  %2d turns  %s  %s", ago, s.Turns, formatTokens(s.Tokens), formatModelShort(s.Model))
 		if s.ProjectID > 0 {
 			meta += fmt.Sprintf("  #%d", s.ProjectID)
 		}
@@ -704,6 +704,37 @@ func formatAgo(d time.Duration) string {
 	default:
 		return fmt.Sprintf("%2dd ago    ", int(d.Hours()/24))
 	}
+}
+
+// formatModelShort condenses a model ID like "claude-sonnet-4-6" → "sonnet-4.6".
+// Returns "cc" when empty (CC chose the model automatically).
+func formatModelShort(model string) string {
+	if model == "" {
+		return "cc"
+	}
+	s := strings.TrimPrefix(model, "claude-")
+	// Strip trailing 8-digit date suffix (e.g. "-20251022")
+	if idx := strings.LastIndex(s, "-"); idx > 0 {
+		if suffix := s[idx+1:]; len(suffix) == 8 {
+			allDigits := true
+			for _, c := range suffix {
+				if c < '0' || c > '9' {
+					allDigits = false
+					break
+				}
+			}
+			if allDigits {
+				s = s[:idx]
+			}
+		}
+	}
+	// Replace remaining dashes in version segment with dots: sonnet-4-6 → sonnet-4.6
+	// Only the last two segments (major.minor) get dotted.
+	parts := strings.Split(s, "-")
+	if len(parts) >= 3 {
+		s = strings.Join(parts[:len(parts)-2], "-") + "-" + parts[len(parts)-2] + "." + parts[len(parts)-1]
+	}
+	return s
 }
 
 func formatTokens(n int) string {


### PR DESCRIPTION
## Summary

- **Session picker UX**: each saved session now shows the backend model (e.g. `sonnet-4.6`, `opus-4.7`, `cc` when CC chose automatically). Model is stored in `Session` already — this just threads it through `SessionSummary` and the picker view.
- **`limitWriter` type**: a capped `io.Writer` that silently discards bytes once the limit is reached, preventing subprocess output from inflating process memory before we get to truncate. Used in place of raw `strings.Builder` / `bytes.Buffer` for all subprocess stdout/stderr.
- **`runQMax`**: had **zero output limit** — could buffer unlimited qmax CLI output. Fixed: 512 KB cap enforced at the pipe.
- **`runShell`**: previously buffered full output then trimmed at 8 KB. Now capped at 8 KB at write time.
- **`runLocalTest`**: `bytes.Buffer` was unbounded until after `cmd.Run()`. Now capped at 3 MB stdout / 512 KB stderr at the pipe level, before the display trim.
- **CC subprocess timeout**: `exec.CommandContext` with a 30-minute per-turn deadline. Prevents a CC process walking a large monorepo from running indefinitely and accumulating 40+ GB of context in the CC process's memory.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `formatModelShort` spot-checked for all current model ID formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)