### PR TITLE
fix(codex): add 30-minute per-turn subprocess timeout

### DIFF
--- a/codex_agent.go
+++ b/codex_agent.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 // CodexAgent orchestrates an OpenAI Codex CLI subprocess for LLM inference.
@@ -165,7 +167,10 @@ func (a *CodexAgent) Run(userMsg string, term *Terminal) (string, error) {
 	}
 	args = append(args, prompt)
 
-	cmd := exec.Command(a.codexBin, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, a.codexBin, args...)
 	cmd.Stderr = os.Stderr
 
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
## Summary

Mirrors the same fix applied to `CCAgent` in #50. `CodexAgent.Run` was using `exec.Command` with no timeout, meaning a Codex process walking a large monorepo could run indefinitely and accumulate memory without bound.

Changed to `exec.CommandContext` with a 30-minute per-turn deadline, consistent with the CC backend.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)