### PR TITLE
fix: sweep orphaned MCP config files left by crashed instances

### DIFF
--- a/cc_agent.go
+++ b/cc_agent.go
@@ -296,6 +296,30 @@ func (a *CCAgent) Cleanup() {
 	}
 }
 
+// cleanupStaleMCPConfigs removes qmax-mcp-<pid>.json files left in the OS
+// temp dir by previous qmax-code instances that crashed before their Cleanup()
+// could run. Safe to call on every startup — skips files whose PID is alive.
+func cleanupStaleMCPConfigs() {
+	pattern := filepath.Join(os.TempDir(), "qmax-mcp-*.json")
+	matches, err := filepath.Glob(pattern)
+	if err != nil || len(matches) == 0 {
+		return
+	}
+	for _, path := range matches {
+		base := filepath.Base(path) // "qmax-mcp-12345.json"
+		// Extract PID: strip "qmax-mcp-" prefix and ".json" suffix.
+		inner := strings.TrimPrefix(base, "qmax-mcp-")
+		inner = strings.TrimSuffix(inner, ".json")
+		pid, err := strconv.Atoi(inner)
+		if err != nil {
+			continue
+		}
+		if !pidAlive(pid) {
+			_ = os.Remove(path)
+		}
+	}
+}
+
 // --- stream-json parsing ---
 
 // ccEvent is a single line from CC's --output-format stream-json output.

--- a/main.go
+++ b/main.go
@@ -376,6 +376,9 @@ func main() {
 		fmt.Printf("[cleanup] Removed %d old sessions\n", removed)
 	}
 
+	// Sweep orphaned MCP config files left by crashed previous instances.
+	cleanupStaleMCPConfigs()
+
 	// Interactive REPL
 	runREPL(agent, cliAgent, *quiet)
 }

--- a/pid_unix.go
+++ b/pid_unix.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+// pidAlive reports whether a process with the given PID is running.
+// Uses signal 0: no signal is sent but the kernel validates the PID.
+func pidAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
+}

--- a/pid_windows.go
+++ b/pid_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+)
+
+// pidAlive reports whether a process with the given PID is running.
+// On Windows, OpenProcess is not directly accessible from pure Go without
+// cgo; os.FindProcess always succeeds, so we attempt a no-op signal as a
+// proxy. If the process handle is invalid the call errors out.
+func pidAlive(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Release the handle immediately — we only needed the existence check.
+	_ = p.Release()
+	// os.FindProcess on Windows always succeeds (returns a handle even for
+	// dead PIDs), so we conservatively return true to avoid false-positive
+	// deletions. The file is tiny; leaking it on Windows is acceptable.
+	return true
+}


### PR DESCRIPTION
## Summary

`CCAgent.Cleanup()` removes `qmax-mcp-<pid>.json` from the OS temp dir on graceful shutdown, but if the process crashes or is SIGKILL'd before the deferred `Cleanup()` runs, the file is left behind indefinitely. With many crash/restart cycles, these accumulate.

**Fix**: `cleanupStaleMCPConfigs()` is called at startup alongside `CleanupOldSessions()`. It globs `qmax-mcp-*.json` in the temp dir, extracts the PID from each filename, and removes any file whose owning process is no longer alive (signal-0 probe on Unix; conservatively skipped on Windows where `FindProcess` always succeeds regardless of liveness).

Platform split:
- `pid_unix.go` — `syscall.Signal(0)` via `os.Process.Signal`
- `pid_windows.go` — conservative `return true` (files are tiny; a missed cleanup on Windows is acceptable vs. a false-positive deletion)

## Test plan

- [x] `go build ./...` — clean (Unix + cross-compile to windows checked via build tags)
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)