### PR TITLE
chore(release): bump version to 1.14.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.13.1"
+var Version = "1.14.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## 1.14.0

### New features
- **Session picker**: each saved session now shows the backend model (`sonnet-4.6`, `opus-4.7`, `cc` when CC chose automatically) (#50)

### Memory safety
- **`limitWriter`**: subprocess stdout/stderr are now capped at the pipe level — buffers can never grow past the limit before truncation (#50)
- **`runQMax`**: had zero output limit; now capped at 512 KB (#50)
- **`runShell`**: buffer capped at 8 KB at write time instead of after-the-fact (#50)
- **`runLocalTest`**: stdout capped at 3 MB, stderr at 512 KB (#50)
- **CC subprocess**: 30-minute per-turn timeout via `exec.CommandContext` (#50)
- **Codex subprocess**: same 30-minute per-turn timeout (#51)
- **Orphaned MCP configs**: startup sweep removes `qmax-mcp-<pid>.json` files left by crashed instances (#52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)