### PR TITLE
chore(release): bump version to 1.14.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.14.0"
+var Version = "1.14.1"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary

- Bumps `Version` to `1.14.1`
- Follows feat(themes) in #54 — 5 new light-terminal themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)