### PR TITLE
fix(test): update TestThemeNames_Order to cover all 10 themes

### DIFF
--- a/theme_test.go
+++ b/theme_test.go
@@ -3,7 +3,7 @@ package main
 import "testing"
 
 func TestThemeNames_Order(t *testing.T) {
-	want := []string{"historic", "ocean", "neon", "ember", "aurora"}
+	want := []string{"historic", "ocean", "neon", "ember", "aurora", "paper", "sky", "sparkling", "radiance", "goldenhour"}
 	got := ThemeNames()
 	if len(got) != len(want) {
 		t.Fatalf("ThemeNames() length: got %d, want %d", len(got), len(want))


### PR DESCRIPTION
## Summary

- `TestThemeNames_Order` was written before the 5 light-terminal themes landed in #54 and still asserted a length of 5
- CI has been failing on `main` and the v1.14.1 release workflow since the merge: `got 10, want 5`
- Fix: expand the `want` slice to include `paper`, `sky`, `sparkling`, `radiance`, `goldenhour` — matching the current `ThemeNames()` return value

## Test plan

- [x] `go test ./...` passes locally after the change
- [ ] CI green on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)