### PR TITLE
feat(orch): instant runtime switcher — Anthropic API models ↔ Ollama on AWS

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -54,16 +54,18 @@ func (m OllamaMode) String() string {
 
 // Agent is the LLM-powered QA orchestration engine.
 type Agent struct {
-	config     AgentConfig
-	appConfig  *Config // persistent user preferences
-	history    []Message
-	tools      []ToolDef
-	client     *http.Client
-	usage      TokenUsage
-	cancel     context.CancelFunc // cancel the current streaming request
-	logger     *Logger
-	ollama     *OllamaClient // optional self-hosted LLM
-	ollamaMode OllamaMode    // off, chat, or full
+	config          AgentConfig
+	appConfig       *Config // persistent user preferences
+	history         []Message
+	tools           []ToolDef
+	client          *http.Client
+	usage           TokenUsage
+	cancel          context.CancelFunc // cancel the current streaming request
+	logger          *Logger
+	ollama          *OllamaClient // optional self-hosted LLM
+	ollamaMode      OllamaMode    // off, chat, or full
+	priorSessions   string        // cached prior-session summaries from backend
+	sessionsFetched bool          // true once loadPriorSessions has run
 }
 
 // Message represents a conversation message.
@@ -894,6 +896,50 @@ func (a *Agent) extractText(content interface{}) string {
 	return strings.Join(parts, "\n")
 }
 
+// loadPriorSessions fetches recent AI-summarized session history from the backend
+// for the active project and caches it. Called once per agent lifetime.
+func (a *Agent) loadPriorSessions() {
+	if a.sessionsFetched {
+		return
+	}
+	a.sessionsFetched = true
+
+	api := a.config.Context.API
+	projectID := a.config.Context.ProjectID
+	if api == nil || projectID <= 0 {
+		return
+	}
+
+	resp := api.ListAgentSessions(context.Background(), projectID, 3)
+
+	var data struct {
+		Sessions []struct {
+			AgentType string `json:"agent_type"`
+			Status    string `json:"status"`
+			CreatedAt string `json:"created_at"`
+			Summary   string `json:"summary"`
+		} `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(resp), &data); err != nil || len(data.Sessions) == 0 {
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n## Prior Sessions (this project)\n")
+	for _, s := range data.Sessions {
+		ts := s.CreatedAt
+		if len(ts) >= 10 {
+			ts = ts[:10]
+		}
+		summary := s.Summary
+		if summary == "" {
+			summary = "(no summary)"
+		}
+		sb.WriteString(fmt.Sprintf("- [%s] %s (%s): %s\n", ts, s.AgentType, s.Status, summary))
+	}
+	a.priorSessions = sb.String()
+}
+
 // buildSystemPrompt creates the system prompt with session context.
 func (a *Agent) buildSystemPrompt() string {
 	var prompt string
@@ -1054,6 +1100,12 @@ You MUST call list_projects first to get the slug. Never guess it.
 	}
 	if cloudURL != "" {
 		prompt += fmt.Sprintf("- QualityMax API: %s\n", cloudURL)
+	}
+
+	// Prior session history — lazy-loaded once from backend on first prompt.
+	a.loadPriorSessions()
+	if a.priorSessions != "" {
+		prompt += a.priorSessions
 	}
 
 	// Token budget warning

--- a/agent.go
+++ b/agent.go
@@ -910,7 +910,9 @@ func (a *Agent) loadPriorSessions() {
 		return
 	}
 
-	resp := api.ListAgentSessions(context.Background(), projectID, 3)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	resp := api.ListAgentSessions(ctx, projectID, 3)
 
 	var data struct {
 		Sessions []struct {

--- a/api_client.go
+++ b/api_client.go
@@ -364,6 +364,12 @@ func (c *APIClient) SecurityAuditPRCheck(ctx context.Context, repoSlug string, p
 	return c.post(ctx, "/api/security-audit/pr-check", body)
 }
 
+// --- Agent session history ---
+
+func (c *APIClient) ListAgentSessions(ctx context.Context, projectID, limit int) string {
+	return c.get(ctx, fmt.Sprintf("/api/agent-sessions?project_id=%d&limit=%d", projectID, limit))
+}
+
 // --- Script operations ---
 
 func (c *APIClient) GetScript(ctx context.Context, scriptID int) string {

--- a/api_client.go
+++ b/api_client.go
@@ -354,6 +354,16 @@ func (c *APIClient) CreatePR(ctx context.Context, repoID, projectID int) string 
 	return c.post(ctx, "/api/repositories/create-pr", body)
 }
 
+func (c *APIClient) SecurityAuditPRCheck(ctx context.Context, repoSlug string, prNumber int, baseSHA, headSHA string) string {
+	body := map[string]interface{}{
+		"repo_slug": repoSlug,
+		"pr_number": prNumber,
+		"base_sha":  baseSHA,
+		"head_sha":  headSHA,
+	}
+	return c.post(ctx, "/api/security-audit/pr-check", body)
+}
+
 // --- Script operations ---
 
 func (c *APIClient) GetScript(ctx context.Context, scriptID int) string {

--- a/main.go
+++ b/main.go
@@ -657,12 +657,40 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				continue
 			}
 
-			result := ShowModelPicker(cfg.Backend, cfg.ModelOverride, cfg.Effort)
+			// Determine the picker's "currentBackend" — include ollama as a backend value.
+			currentBackend := cfg.Backend
+			if agent.ollamaMode == OllamaModeFull {
+				currentBackend = "ollama"
+			}
+			result := ShowModelPicker(currentBackend, cfg.ModelOverride, cfg.Effort, cfg.OllamaURL, cfg.OllamaModel)
 			if !result.Confirmed {
 				continue
 			}
 
-			// Validate the chosen CLI is actually installed.
+			// ── Ollama selected ───────────────────────────────────────────────
+			if result.Backend == "ollama" {
+				if cfg.OllamaURL == "" || cfg.OllamaModel == "" {
+					term.PrintError("Ollama not configured. Set ollama_url and ollama_model first.")
+					term.PrintSystem("  qmax-code config set ollama_url https://llm2.qualitymax.io")
+					term.PrintSystem("  qmax-code config set ollama_model llama3.2:3b")
+					continue
+				}
+				if agent.ollama == nil {
+					agent.ollama = NewOllamaClient(cfg)
+				}
+				if cliAgent != nil {
+					cliAgent.Cleanup()
+					cliAgent = nil
+				}
+				agent.ollamaMode = OllamaModeFull
+				cfg.Backend = ""
+				agent.config.Context.Backend = ""
+				_ = cfg.Save()
+				term.PrintSystem(fmt.Sprintf("Backend: Ollama  model: %s  endpoint: %s", cfg.OllamaModel, maskURL(cfg.OllamaURL)))
+				continue
+			}
+
+			// ── Validate the chosen CLI is actually installed ─────────────────
 			switch result.Backend {
 			case "cc":
 				if FindClaudeCode() == "" {
@@ -692,11 +720,12 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				}
 			}
 
-			// Tear down current CLI agent.
+			// Tear down current CLI agent and disable Ollama if switching away from it.
 			if cliAgent != nil {
 				cliAgent.Cleanup()
 				cliAgent = nil
 			}
+			agent.ollamaMode = OllamaModeOff
 
 			// Spin up the new agent with selected model + effort.
 			switch result.Backend {
@@ -711,7 +740,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				cliAgent = ca
 				term.PrintSystem(fmt.Sprintf("Backend: Codex  model: %s  effort: %s", result.ModelID, result.Effort))
 			default:
-				term.PrintSystem("Backend: Anthropic API (direct)")
+				term.PrintSystem(fmt.Sprintf("Backend: Anthropic API  model: %s", result.ModelID))
 			}
 
 			cfg.Backend = result.Backend

--- a/theme_test.go
+++ b/theme_test.go
@@ -3,7 +3,7 @@ package main
 import "testing"
 
 func TestThemeNames_Order(t *testing.T) {
-	want := []string{"historic", "ocean", "neon", "ember", "aurora"}
+	want := []string{"historic", "ocean", "neon", "ember", "aurora", "paper", "sky", "sparkling", "radiance", "goldenhour"}
 	got := ThemeNames()
 	if len(got) != len(want) {
 		t.Fatalf("ThemeNames() length: got %d, want %d", len(got), len(want))

--- a/tools.go
+++ b/tools.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -748,7 +749,8 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 		return api.ImportDocument(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "text"), strVal(input, "source_name"))
 
 	case "create_pr":
-		return api.CreatePR(ctx, intVal(input, "repo_id", 0), intVal(input, "project_id", sctx.ProjectID))
+		prResp := api.CreatePR(ctx, intVal(input, "repo_id", 0), intVal(input, "project_id", sctx.ProjectID))
+		return chainSecurityAuditOnPR(ctx, api, sctx, prResp)
 
 	case "get_script":
 		return api.GetScript(ctx, intVal(input, "script_id", 0))
@@ -2379,4 +2381,83 @@ func callBackendVisionAnalysis(sctx *SessionContext, imageURL, prompt string) st
 		"[Vision analysis requires ANTHROPIC_API_KEY env var. "+
 		"Set it with: export ANTHROPIC_API_KEY=sk-ant-...]\n\n"+
 		"You can view the screenshot at the URL above to manually inspect the page.", imageURL)
+}
+
+// chainSecurityAuditOnPR fires a security audit PR check after create_pr succeeds
+// and appends the findings to the PR creation result so the agent can self-correct.
+func chainSecurityAuditOnPR(ctx context.Context, api *APIClient, sctx *SessionContext, prResp string) string {
+	// Parse pr_number from the create_pr response.
+	var prData map[string]interface{}
+	prNumber := 0
+	if err := json.Unmarshal([]byte(prResp), &prData); err == nil {
+		switch v := prData["pr_number"].(type) {
+		case float64:
+			prNumber = int(v)
+		case int:
+			prNumber = v
+		}
+		// Fall back to extracting from pr_url if pr_number is absent.
+		if prNumber == 0 {
+			if u, ok := prData["pr_url"].(string); ok {
+				parts := strings.Split(strings.TrimRight(u, "/"), "/")
+				if len(parts) > 0 {
+					if n, err := strconv.Atoi(parts[len(parts)-1]); err == nil {
+						prNumber = n
+					}
+				}
+			}
+		}
+	}
+	if prNumber == 0 {
+		return prResp // PR creation failed or response unparseable — return as-is
+	}
+
+	// Derive GitHub repo slug from the git remote URL.
+	repoSlug := ""
+	if sctx.GitInfo != nil {
+		repoSlug = repoSlugFromRemote(sctx.GitInfo.RemoteURL)
+	}
+	if repoSlug == "" {
+		return prResp // no remote URL — skip security check
+	}
+
+	// Collect git SHAs.
+	headSHA := gitSHA("HEAD")
+	baseSHA := gitSHA("origin/main")
+	if baseSHA == "" {
+		baseSHA = gitSHA("origin/master")
+	}
+
+	auditResp := api.SecurityAuditPRCheck(ctx, repoSlug, prNumber, baseSHA, headSHA)
+
+	// Combine both results for the agent.
+	return fmt.Sprintf("%s\n\n--- Security Audit PR Check ---\n%s", prResp, auditResp)
+}
+
+// repoSlugFromRemote extracts "owner/repo" from a git remote URL.
+// Handles https://github.com/owner/repo[.git] and git@github.com:owner/repo[.git].
+func repoSlugFromRemote(remoteURL string) string {
+	remoteURL = strings.TrimSuffix(remoteURL, ".git")
+	if strings.HasPrefix(remoteURL, "git@") {
+		// git@github.com:owner/repo
+		idx := strings.LastIndex(remoteURL, ":")
+		if idx >= 0 {
+			return remoteURL[idx+1:]
+		}
+	}
+	// https://github.com/owner/repo
+	parts := strings.SplitN(remoteURL, "github.com/", 2)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return ""
+}
+
+// gitSHA returns the resolved commit SHA for the given ref, or "" on error.
+func gitSHA(ref string) string {
+	out, err := exec.Command("git", "rev-parse", ref).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }

--- a/tools.go
+++ b/tools.go
@@ -2427,6 +2427,9 @@ func chainSecurityAuditOnPR(ctx context.Context, api *APIClient, sctx *SessionCo
 	if baseSHA == "" {
 		baseSHA = gitSHA("origin/master")
 	}
+	if baseSHA == "" {
+		return prResp // cannot determine base commit — skip security check
+	}
 
 	auditResp := api.SecurityAuditPRCheck(ctx, repoSlug, prNumber, baseSHA, headSHA)
 

--- a/tui_backend.go
+++ b/tui_backend.go
@@ -228,23 +228,34 @@ func newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, olla
 		effort = "high"
 	}
 
-	reachable := probeOllamaReachable(ollamaURL)
-
 	return modelPickerModel{
-		allEntries:      entries,
-		cursor:          cursor,
-		effort:          effort,
-		currentBackend:  currentBackend,
-		currentModelID:  currentModelID,
-		ollamaURL:       ollamaURL,
-		ollamaReachable: reachable,
+		allEntries:     entries,
+		cursor:         cursor,
+		effort:         effort,
+		currentBackend: currentBackend,
+		currentModelID: currentModelID,
+		ollamaURL:      ollamaURL,
 	}
 }
 
-func (m modelPickerModel) Init() tea.Cmd { return nil }
+type ollamaProbeMsg struct{ reachable bool }
+
+func (m modelPickerModel) Init() tea.Cmd {
+	if m.ollamaURL == "" {
+		return nil
+	}
+	rawURL := m.ollamaURL
+	return func() tea.Msg {
+		return ollamaProbeMsg{reachable: probeOllamaReachable(rawURL)}
+	}
+}
 
 func (m modelPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case ollamaProbeMsg:
+		m.ollamaReachable = msg.reachable
+		return m, nil
+
 	case tea.KeyMsg:
 		switch {
 		case msg.String() == "ctrl+c", msg.String() == "esc", msg.String() == "q":

--- a/tui_backend.go
+++ b/tui_backend.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -35,6 +37,12 @@ var (
 
 	pickerIconAPI = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("242"))  // grey — Direct ○
+
+	pickerIconOllama = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("71")) // green — Ollama ⬡
+
+	pickerDotGreen = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+	pickerDotRed   = lipgloss.NewStyle().Foreground(lipgloss.Color("160"))
 
 	pickerLabel = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("252"))
@@ -138,6 +146,27 @@ var apiModels = []pickerEntry{
 
 var effortLevels = []string{"low", "medium", "high"}
 
+// probeOllamaReachable returns true if the Ollama base URL responds within 2s.
+func probeOllamaReachable(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+	u, err := url.Parse(strings.TrimRight(rawURL, "/"))
+	if err != nil {
+		return false
+	}
+	// Strip credentials before logging; keep them for the actual request.
+	probe := *u
+	probe.Path = "/api/tags"
+	c := &http.Client{Timeout: 2 * time.Second}
+	resp, err := c.Get(probe.String())
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode < 500
+}
+
 // ─── Bubbletea model ──────────────────────────────────────────────────────────
 
 // ModelPickerResult is returned after the TUI closes.
@@ -149,25 +178,40 @@ type ModelPickerResult struct {
 }
 
 type modelPickerModel struct {
-	// All rows in order: cc entries, codex entries, api entries.
+	// All rows in order: cc entries, codex entries, api entries, ollama entries.
 	allEntries []pickerEntry
-	cursor     int    // index into allEntries
+	cursor     int  // index into allEntries
 	effort     string // "low" | "medium" | "high"
-	effortFocus bool  // Tab switches focus between list and effort bar
+	effortFocus bool   // Tab switches focus between list and effort bar
 
 	// Current selection (what was active when the picker opened)
 	currentBackend string
 	currentModelID string
 
+	// Ollama metadata
+	ollamaURL       string
+	ollamaReachable bool
+
 	cancelled bool
 	chosen    *pickerEntry
 }
 
-func newModelPickerModel(currentBackend, currentModelID, effort string) modelPickerModel {
-	entries := make([]pickerEntry, 0, len(ccModels)+len(codexModels)+len(apiModels))
+func newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, ollamaModel string) modelPickerModel {
+	entries := make([]pickerEntry, 0, len(ccModels)+len(codexModels)+len(apiModels)+1)
 	entries = append(entries, ccModels...)
 	entries = append(entries, codexModels...)
 	entries = append(entries, apiModels...)
+
+	// Append Ollama entry if configured.
+	if ollamaURL != "" && ollamaModel != "" {
+		entries = append(entries, pickerEntry{
+			backend:  "ollama",
+			modelID:  ollamaModel,
+			label:    ollamaModel,
+			subLabel: maskURL(ollamaURL),
+			isFav:    true,
+		})
+	}
 
 	// Start cursor on the active entry.
 	cursor := 0
@@ -184,12 +228,16 @@ func newModelPickerModel(currentBackend, currentModelID, effort string) modelPic
 		effort = "high"
 	}
 
+	reachable := probeOllamaReachable(ollamaURL)
+
 	return modelPickerModel{
-		allEntries:     entries,
-		cursor:         cursor,
-		effort:         effort,
-		currentBackend: currentBackend,
-		currentModelID: currentModelID,
+		allEntries:      entries,
+		cursor:          cursor,
+		effort:          effort,
+		currentBackend:  currentBackend,
+		currentModelID:  currentModelID,
+		ollamaURL:       ollamaURL,
+		ollamaReachable: reachable,
 	}
 }
 
@@ -319,6 +367,36 @@ func (m modelPickerModel) View() string {
 		b.WriteByte('\n')
 	}
 
+	// ── Ollama section ───────────────────────────────────────────────
+	hasOllama := false
+	for _, e := range m.allEntries {
+		if e.backend == "ollama" {
+			hasOllama = true
+			break
+		}
+	}
+	if hasOllama {
+		b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+		b.WriteByte('\n')
+		dot := pickerDotRed.Render("●")
+		reach := "unreachable"
+		if m.ollamaReachable {
+			dot = pickerDotGreen.Render("●")
+			reach = "reachable"
+		}
+		sectionLabelOllama := fmt.Sprintf("%s  Ollama  %s %s",
+			pickerIconOllama.Render("⬡"), dot, pickerBadgeExt.Render(reach))
+		b.WriteString(pickerSectionHeader.Render(sectionLabelOllama))
+		b.WriteByte('\n')
+		for i, e := range m.allEntries {
+			if e.backend != "ollama" {
+				continue
+			}
+			b.WriteString(m.renderRow(i, e, "ollama"))
+			b.WriteByte('\n')
+		}
+	}
+
 	// ── Effort bar ───────────────────────────────────────────────────
 	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
 	b.WriteByte('\n')
@@ -353,6 +431,8 @@ func (m modelPickerModel) renderRow(idx int, e pickerEntry, backend string) stri
 		icon = pickerIcon.Render("✦")
 	case "codex":
 		icon = pickerIconCodex.Render("⊗")
+	case "ollama":
+		icon = pickerIconOllama.Render("⬡")
 	default:
 		icon = pickerIconAPI.Render("○")
 	}
@@ -434,6 +514,8 @@ func (m modelPickerModel) renderStatusBar() string {
 		icon = pickerStatusIcon.Render("✦")
 	case "codex":
 		icon = pickerStatusIconCodex.Render("⊗")
+	case "ollama":
+		icon = pickerStatusBar.Render("⬡")
 	default:
 		icon = pickerStatusIcon.Render("○")
 	}
@@ -579,9 +661,11 @@ func ShowThemePicker(currentTheme string) (string, bool) {
 // ─── Public entry point ───────────────────────────────────────────────────────
 
 // ShowModelPicker opens the unified model + effort TUI.
+// ollamaURL and ollamaModel are the currently configured Ollama endpoint/model;
+// pass empty strings to hide the Ollama section.
 // Returns the result; Confirmed=false means the user cancelled.
-func ShowModelPicker(currentBackend, currentModelID, effort string) ModelPickerResult {
-	m := newModelPickerModel(currentBackend, currentModelID, effort)
+func ShowModelPicker(currentBackend, currentModelID, effort, ollamaURL, ollamaModel string) ModelPickerResult {
+	m := newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, ollamaModel)
 	p := tea.NewProgram(m)
 	result, err := p.Run()
 	if err != nil {


### PR DESCRIPTION
## Summary

Three features shipped together:

1. **Ollama runtime switcher** — model picker TUI gains an Ollama section with live reachability probe (green/red dot); switch between Anthropic API models and self-hosted Ollama on AWS in one keypress, no restart
2. **Prior session history injection** — agent lazily fetches the last 3 AI-summarized sessions from the backend on first message and injects them into the system prompt, giving continuity across conversations
3. **Security audit auto-chain** — `create_pr` tool automatically fires `/api/security-audit/pr-check` after a PR is created and appends findings to the response so the agent can self-correct before review

Implements [QUA-405](https://linear.app/quality-max/issue/QUA-405).

## What the picker looks like now

\`\`\`
╭──────────────────────────────────────────────────────╮
│                                                      │
│ ✦  Claude Code                                       │
│   ▶ ✦  Opus 4.7          NEW         1              │
│     ✦  Sonnet 4.6        ✓           4              │
│     ✦  Haiku 4.5                     5              │
│ ────────────────────────────────────────────────────  │
│ ○  Direct API                                        │
│     ○  auto              ⭐                          │
│     ○  Sonnet 4.6                                    │
│ ────────────────────────────────────────────────────  │
│ ⬡  Ollama  ● reachable                               │
│     ⬡  llama3.2:3b       ⭐  llm2.qualitymax.io     │
│ ────────────────────────────────────────────────────  │
│   Effort  [ Low ]  [ Medium ]  [ High ]              │
│ ↑↓ navigate · 1-9 jump · Tab effort · Enter · Esc   │
╰──────────────────────────────────────────────────────╯
\`\`\`

## Behaviour

**Ollama switcher:**
- `probeOllamaReachable()` fires a 2 s `GET /api/tags` when the picker opens — green `●` if reachable, red `●` if not
- Ollama section appears only when `ollama_url` + `ollama_model` are configured; hidden otherwise
- Selecting Ollama: sets `ollamaMode = OllamaModeFull`, tears down any active cliAgent, saves config
- Switching away: resets `ollamaMode = Off`, activates the chosen API/CC/Codex backend

**Session history:**
- `loadPriorSessions()` called once per agent lifetime on first `buildSystemPrompt()`
- Fetches last 3 sessions for the active project via `GET /api/agent-sessions?project_id=…&limit=3`
- Silently skipped if no project is set or API is unavailable

**Security audit chain:**
- `create_pr` tool parses `pr_number` (or extracts it from `pr_url`) from the CreatePR response
- Derives repo slug from git remote, collects `HEAD` and `origin/main` SHAs
- Calls `POST /api/security-audit/pr-check` and appends `--- Security Audit PR Check ---` to the tool result

## Files changed

| File | What changed |
|---|---|
| `tui_backend.go` | Ollama styles, `probeOllamaReachable`, dynamic Ollama entry, Ollama section in View, updated `ShowModelPicker` signature |
| `main.go` | REPL switcher handles `"ollama"` backend; `ollamaMode` reset when switching away |
| `agent.go` | `loadPriorSessions()` lazy fetch; injected in `buildSystemPrompt()` |
| `api_client.go` | `SecurityAuditPRCheck` and `ListAgentSessions` endpoints |
| `tools.go` | `chainSecurityAuditOnPR`; helpers `repoSlugFromRemote`, `gitSHA` |

## Test plan

- [ ] `go test ./...` passes
- [ ] `/orch` with Ollama unconfigured — no Ollama section shown
- [ ] `/orch` with `ollama_url` + `ollama_model` set, endpoint reachable — green dot, entry selectable
- [ ] Select Ollama → next prompt routes through local model
- [ ] Select Haiku while on Ollama → `ollamaMode` resets, Anthropic API used
- [ ] Endpoint unreachable — red dot shown, selecting it prints error
- [ ] First agent message appends prior session summaries to system prompt
- [ ] `create_pr` result includes `--- Security Audit PR Check ---` section

## Known follow-ups

- `probeOllamaReachable` blocks picker open for up to 2 s — should run async and update indicator
- `loadPriorSessions` uses `context.Background()` — add a short timeout
- `baseSHA` silently empty if neither `origin/main` nor `origin/master` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)