### PR TITLE
chore: bump version to 1.15.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.14.1"
+var Version = "1.15.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps `var Version` from `1.14.1` → `1.15.0` in `main.go`
- Marks the release of all features merged in PR #59 (Ollama runtime switcher, session history readback, security audit PR hook)

## Test plan
- [ ] `qmax --version` outputs `1.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)