### PR TITLE
feat(sessions): sync sessions to cloud on start and exit

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -370,6 +370,37 @@ func (c *APIClient) ListAgentSessions(ctx context.Context, projectID, limit int)
 	return c.get(ctx, fmt.Sprintf("/api/agent-sessions?project_id=%d&limit=%d", projectID, limit))
 }
 
+// CreateAgentSession opens a new cloud-tracked session and returns its UUID.
+// Returns "" on failure or when the project ID is unknown.
+func (c *APIClient) CreateAgentSession(ctx context.Context, projectID int, model string) string {
+	body := map[string]interface{}{
+		"project_id": projectID,
+		"model":      model,
+	}
+	resp := c.post(ctx, "/api/agent-sessions", body)
+	var r struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal([]byte(resp), &r); err != nil {
+		return ""
+	}
+	return r.SessionID
+}
+
+// CompleteAgentSession finalises a cloud session with status, token count, and summary.
+// Errors are silently dropped — cloud sync failure must not block local operation.
+func (c *APIClient) CompleteAgentSession(ctx context.Context, cloudID string, totalTokens int, summary string) {
+	body := map[string]interface{}{
+		"status":       "complete",
+		"total_tokens": totalTokens,
+		"ended_at":     time.Now().UTC().Format(time.RFC3339),
+	}
+	if summary != "" {
+		body["summary"] = summary
+	}
+	c.patch(ctx, "/api/agent-sessions/"+cloudID, body)
+}
+
 // --- Script operations ---
 
 func (c *APIClient) GetScript(ctx context.Context, scriptID int) string {
@@ -664,6 +695,22 @@ func (c *APIClient) put(ctx context.Context, path string, body interface{}) stri
 		reqBody = bytes.NewReader(data)
 	}
 	req, err := http.NewRequestWithContext(ctx, "PUT", c.BaseURL+path, reqBody)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return c.doRequest(req)
+}
+
+func (c *APIClient) patch(ctx context.Context, path string, body interface{}) string {
+	var reqBody io.Reader
+	if body != nil {
+		data, _ := json.Marshal(body)
+		reqBody = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, "PATCH", c.BaseURL+path, reqBody)
 	if err != nil {
 		return jsonError(err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -414,6 +415,30 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 	agent.logger = NewLogger(sessionID)
 	defer agent.logger.Close()
 
+	// Cloud session tracking — created once when projectID is known.
+	var cloudSessionID string
+	startCloudSession := func() {
+		api := agent.config.Context.API
+		projectID := agent.config.Context.ProjectID
+		if api == nil || projectID == 0 || cloudSessionID != "" {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cloudSessionID = api.CreateAgentSession(ctx, projectID, agent.config.Model)
+	}
+
+	completeCloudSession := func() {
+		api := agent.config.Context.API
+		if api == nil || cloudSessionID == "" {
+			return
+		}
+		summary := sessionSummary(agent.history)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		api.CompleteAgentSession(ctx, cloudSessionID, agent.usage.TotalTokens(), summary)
+	}
+
 	// Graceful interrupt handling
 	var (
 		sigMu       sync.Mutex
@@ -428,6 +453,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 
 	saveAndExit := func() {
 		_ = SaveSession(sessionID, agent.history, agent.config.Context.ProjectID, agent.usage, agent.config.Model)
+		completeCloudSession()
 		fmt.Fprintf(os.Stderr, "Session %s saved.\n", sessionID)
 	}
 
@@ -928,6 +954,9 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 
 		// Detect image file paths dragged/pasted into input
 		cleanInput, images := DetectAndLoadImages(input)
+
+		// Ensure a cloud session exists for this conversation (no-op after first call).
+		startCloudSession()
 
 		// Run through the LLM agent with streaming.
 		// Start the queue reader so the user can type the next prompt while

--- a/session.go
+++ b/session.go
@@ -241,6 +241,44 @@ func ListSessions(limit int) ([]SessionSummary, error) {
 	return summaries, nil
 }
 
+// sessionSummary builds a short human-readable summary from the conversation
+// history to upload with cloud sessions. It takes the first user message as the
+// topic and appends the turn count.
+func sessionSummary(history []Message) string {
+	if len(history) == 0 {
+		return ""
+	}
+	var firstUser string
+	turns := 0
+	for _, m := range history {
+		if m.Role == "user" {
+			turns++
+			if firstUser == "" {
+				switch v := m.Content.(type) {
+				case string:
+					firstUser = v
+				case []interface{}:
+					for _, block := range v {
+						if b, ok := block.(map[string]interface{}); ok && b["type"] == "text" {
+							if t, ok := b["text"].(string); ok {
+								firstUser = t
+								break
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(firstUser) > 200 {
+		firstUser = firstUser[:200] + "…"
+	}
+	if firstUser == "" {
+		return fmt.Sprintf("%d turns", turns)
+	}
+	return fmt.Sprintf("%s  [%d turns]", firstUser, turns)
+}
+
 // CleanupOldSessions removes sessions older than sessionTTL.
 // Called on startup to prevent unbounded disk growth.
 func CleanupOldSessions() int {


### PR DESCRIPTION
## Summary
- On the first user prompt, `POST /api/agent-sessions` opens a cloud-tracked session (project ID + model recorded)
- On exit (SIGTERM, SIGINT ×2, `/quit`), `PATCH /api/agent-sessions/:id` finalises it with `status=complete`, `total_tokens`, and a short summary
- `sessionSummary()` extracts the first user message (≤200 chars) + turn count as the session topic — this feeds into `loadPriorSessions()` so future sessions get meaningful context
- Added `patch()` HTTP helper to `APIClient` alongside the existing `put()`
- Cloud sync is best-effort with a 5 s timeout; failures are silent and never block local operation

## How it works end-to-end
```
session start → POST /api/agent-sessions → cloud UUID stored
  ↓ each turn: local SaveSession() to ~/.qmax-code/sessions/
session end   → PATCH /api/agent-sessions/:id  status=complete
  ↓
next session  → loadPriorSessions() → GET /api/agent-sessions → injects summaries into system prompt
```

## Test plan
- [ ] Start `qmax-code` with a project set, send one message, type `/quit` — verify session appears in `GET /api/agent-sessions?project_id=X`
- [ ] `status` is `complete`, `total_tokens` > 0, `summary` contains the first user message
- [ ] Session without a project ID (project=0) skips cloud create silently
- [ ] Kill process with SIGTERM — cloud session is completed via `saveAndExit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)