### PR TITLE
chore: bump version to 1.15.1

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.15.0"
+var Version = "1.15.1"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps `var Version` from `1.15.0` → `1.15.1`
- Marks the release of cloud session sync (PR #61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)