### PR TITLE
feat(sessions): opt-in prompt + /set cloudsync for cloud session sync

### DIFF
--- a/cloud_session.go
+++ b/cloud_session.go
@@ -1,9 +1,46 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"time"
 )
+
+// promptCloudSyncConsent asks the user once whether they want sessions synced
+// to the QualityMax cloud. The answer is persisted in cfg so the prompt never
+// appears again. Returns true if the user opted in.
+func promptCloudSyncConsent(cfg *Config) bool {
+	fmt.Println()
+	fmt.Println("  ┌─ Cloud session sync ──────────────────────────────────────────┐")
+	fmt.Println("  │  qmax-code can sync your sessions to the QualityMax cloud so  │")
+	fmt.Println("  │  the agent remembers past conversations across restarts.       │")
+	fmt.Println("  │                                                                │")
+	fmt.Println("  │  You can change this any time with:  /set cloudsync true|false │")
+	fmt.Println("  └────────────────────────────────────────────────────────────────┘")
+	fmt.Println()
+	fmt.Print("  Enable cloud session sync? [Y/n]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	ans := strings.ToLower(strings.TrimSpace(line))
+
+	enabled := ans == "" || ans == "y" || ans == "yes"
+
+	v := enabled
+	cfg.CloudSync = &v
+	_ = cfg.Save()
+
+	if enabled {
+		fmt.Println("  Cloud session sync enabled.")
+	} else {
+		fmt.Println("  Cloud session sync disabled.")
+	}
+	fmt.Println()
+	return enabled
+}
 
 // cloudSessionTracker manages the lifecycle of a cloud-tracked agent session.
 // Zero value is ready to use — no initialisation needed.

--- a/cloud_session.go
+++ b/cloud_session.go
@@ -25,20 +25,26 @@ func promptCloudSyncConsent(cfg *Config) bool {
 
 	reader := bufio.NewReader(os.Stdin)
 	line, _ := reader.ReadString('\n')
-	ans := strings.ToLower(strings.TrimSpace(line))
 
-	enabled := ans == "" || ans == "y" || ans == "yes"
-
-	v := enabled
-	cfg.CloudSync = &v
-	_ = cfg.Save()
-
+	enabled := applyCloudSyncChoice(cfg, line)
 	if enabled {
 		fmt.Println("  Cloud session sync enabled.")
 	} else {
 		fmt.Println("  Cloud session sync disabled.")
 	}
 	fmt.Println()
+	return enabled
+}
+
+// applyCloudSyncChoice parses a raw answer line, updates cfg.CloudSync, and
+// persists it. Extracted from promptCloudSyncConsent so it can be unit-tested
+// without touching stdin/stdout.
+func applyCloudSyncChoice(cfg *Config, line string) bool {
+	ans := strings.ToLower(strings.TrimSpace(line))
+	enabled := ans == "" || ans == "y" || ans == "yes"
+	v := enabled
+	cfg.CloudSync = &v
+	_ = cfg.Save()
 	return enabled
 }
 

--- a/cloud_session_test.go
+++ b/cloud_session_test.go
@@ -1,9 +1,89 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 )
+
+// ---- applyCloudSyncChoice ----
+
+func TestApplyCloudSyncChoice_YesVariants(t *testing.T) {
+	for _, line := range []string{"y\n", "Y\n", "yes\n", "YES\n", "\n", "  \n"} {
+		withTempHome(t)
+		cfg := defaultConfig()
+		got := applyCloudSyncChoice(cfg, line)
+		if !got {
+			t.Errorf("applyCloudSyncChoice(%q): got false, want true", line)
+		}
+		if cfg.CloudSync == nil || !*cfg.CloudSync {
+			t.Errorf("applyCloudSyncChoice(%q): cfg.CloudSync not set to true", line)
+		}
+	}
+}
+
+func TestApplyCloudSyncChoice_NoVariants(t *testing.T) {
+	for _, line := range []string{"n\n", "N\n", "no\n", "NO\n"} {
+		withTempHome(t)
+		cfg := defaultConfig()
+		got := applyCloudSyncChoice(cfg, line)
+		if got {
+			t.Errorf("applyCloudSyncChoice(%q): got true, want false", line)
+		}
+		if cfg.CloudSync == nil || *cfg.CloudSync {
+			t.Errorf("applyCloudSyncChoice(%q): cfg.CloudSync not set to false", line)
+		}
+	}
+}
+
+func TestApplyCloudSyncChoice_PersistsToDisk(t *testing.T) {
+	withTempHome(t)
+	cfg := defaultConfig()
+	applyCloudSyncChoice(cfg, "y\n")
+
+	loaded := LoadQMaxCodeConfig()
+	if loaded.CloudSync == nil || !*loaded.CloudSync {
+		t.Error("CloudSync=true not persisted to disk")
+	}
+}
+
+// ---- Config.CloudSync JSON round-trip ----
+
+func TestConfigCloudSync_NilOmittedFromJSON(t *testing.T) {
+	cfg := &Config{}
+	data, _ := json.Marshal(cfg)
+	var m map[string]interface{}
+	_ = json.Unmarshal(data, &m)
+	if _, ok := m["cloud_sync"]; ok {
+		t.Errorf("expected cloud_sync omitted when nil, got key in JSON: %s", data)
+	}
+}
+
+func TestConfigCloudSync_TruePersistedAndLoaded(t *testing.T) {
+	withTempHome(t)
+	v := true
+	cfg := defaultConfig()
+	cfg.CloudSync = &v
+	_ = cfg.Save()
+
+	loaded := LoadQMaxCodeConfig()
+	if loaded.CloudSync == nil || !*loaded.CloudSync {
+		t.Error("CloudSync true did not survive Save/Load round-trip")
+	}
+}
+
+func TestConfigCloudSync_FalsePersistedAndLoaded(t *testing.T) {
+	withTempHome(t)
+	v := false
+	cfg := defaultConfig()
+	cfg.CloudSync = &v
+	_ = cfg.Save()
+
+	loaded := LoadQMaxCodeConfig()
+	if loaded.CloudSync == nil || *loaded.CloudSync {
+		t.Error("CloudSync false did not survive Save/Load round-trip")
+	}
+}
 
 // ---- cloudSessionTracker.Start ----
 

--- a/config.go
+++ b/config.go
@@ -58,6 +58,11 @@ type Config struct {
 	// Theme selects the terminal color scheme.
 	// Available: historic, ocean, neon, ember, aurora (dark) or paper, sky, sparkling, radiance, goldenhour (light). Empty defaults to "historic".
 	Theme string `json:"theme,omitempty"`
+
+	// CloudSync controls whether sessions are synced to the QualityMax cloud.
+	// nil = not asked yet (prompt fires on the next eligible session).
+	// true = opted in, false = opted out.
+	CloudSync *bool `json:"cloud_sync,omitempty"`
 }
 
 const qmaxCodeConfigDir = ".qmax-code"

--- a/config_command.go
+++ b/config_command.go
@@ -102,6 +102,15 @@ func printConfig() {
 		theme = "historic"
 	}
 	fmt.Printf("    theme             = %q  (available: historic, ocean, neon, ember, aurora, paper, sky, sparkling, radiance, goldenhour)\n", theme)
+	cloudSync := "not set (will prompt on next eligible session)"
+	if cfg.CloudSync != nil {
+		if *cfg.CloudSync {
+			cloudSync = "enabled"
+		} else {
+			cloudSync = "disabled"
+		}
+	}
+	fmt.Printf("    cloud_sync        = %s\n", cloudSync)
 	fmt.Printf("    backend           = %q", backend)
 	switch backend {
 	case "cc":
@@ -205,6 +214,17 @@ func setConfigField(key, value string) error {
 			}
 		}
 		cfg.Theme = value
+
+	case "cloud_sync":
+		if value == "" {
+			cfg.CloudSync = nil
+		} else {
+			b, err := parseConfigBool(value)
+			if err != nil {
+				return err
+			}
+			cfg.CloudSync = &b
+		}
 
 	default:
 		return fmt.Errorf("unknown config key %q", key)

--- a/config_command_test.go
+++ b/config_command_test.go
@@ -182,6 +182,70 @@ func TestSetConfigField_ThemePersistsToDisk(t *testing.T) {
 	}
 }
 
+func TestSetConfigField_CloudSyncHappyPath(t *testing.T) {
+	withTempHome(t)
+
+	if err := setConfigField("cloud_sync", "true"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	loaded := LoadQMaxCodeConfig()
+	if loaded.CloudSync == nil || !*loaded.CloudSync {
+		t.Error("expected CloudSync=true after setConfigField(cloud_sync, true)")
+	}
+
+	if err := setConfigField("cloud_sync", "false"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	loaded = LoadQMaxCodeConfig()
+	if loaded.CloudSync == nil || *loaded.CloudSync {
+		t.Error("expected CloudSync=false after setConfigField(cloud_sync, false)")
+	}
+}
+
+func TestSetConfigField_CloudSyncBoolForms(t *testing.T) {
+	withTempHome(t)
+
+	for _, v := range []string{"true", "yes", "1", "on"} {
+		if err := setConfigField("cloud_sync", v); err != nil {
+			t.Errorf("setConfigField(cloud_sync, %q) unexpected error: %v", v, err)
+		}
+		loaded := LoadQMaxCodeConfig()
+		if loaded.CloudSync == nil || !*loaded.CloudSync {
+			t.Errorf("expected CloudSync=true for value %q", v)
+		}
+	}
+	for _, v := range []string{"false", "no", "0", "off"} {
+		if err := setConfigField("cloud_sync", v); err != nil {
+			t.Errorf("setConfigField(cloud_sync, %q) unexpected error: %v", v, err)
+		}
+		loaded := LoadQMaxCodeConfig()
+		if loaded.CloudSync == nil || *loaded.CloudSync {
+			t.Errorf("expected CloudSync=false for value %q", v)
+		}
+	}
+}
+
+func TestSetConfigField_CloudSyncUnsetClearsToNil(t *testing.T) {
+	withTempHome(t)
+
+	_ = setConfigField("cloud_sync", "true")
+	if err := setConfigField("cloud_sync", ""); err != nil {
+		t.Fatalf("unset should not error: %v", err)
+	}
+	loaded := LoadQMaxCodeConfig()
+	if loaded.CloudSync != nil {
+		t.Errorf("expected CloudSync=nil after unset, got %v", *loaded.CloudSync)
+	}
+}
+
+func TestSetConfigField_CloudSyncRejectsInvalidValue(t *testing.T) {
+	withTempHome(t)
+
+	if err := setConfigField("cloud_sync", "maybe"); err == nil {
+		t.Error("expected error for invalid cloud_sync value")
+	}
+}
+
 func TestParseConfigBool_KnownValues(t *testing.T) {
 	trueVals := []string{"true", "yes", "1", "on"}
 	falseVals := []string{"false", "no", "0", "off", ""}

--- a/main.go
+++ b/main.go
@@ -417,9 +417,26 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 	// Cloud session tracking — created once when projectID is known.
 	var tracker cloudSessionTracker
 	startCloudSession := func() {
-		tracker.Start(agent.config.Context.API, agent.config.Context.ProjectID, agent.config.Model)
+		api := agent.config.Context.API
+		projectID := agent.config.Context.ProjectID
+		if api == nil || projectID == 0 {
+			return
+		}
+		cfg := agent.appConfig
+		// First eligible session: ask the user once and persist their choice.
+		if cfg != nil && cfg.CloudSync == nil {
+			promptCloudSyncConsent(cfg)
+		}
+		if cfg == nil || cfg.CloudSync == nil || !*cfg.CloudSync {
+			return
+		}
+		tracker.Start(api, projectID, agent.config.Model)
 	}
 	completeCloudSession := func() {
+		cfg := agent.appConfig
+		if cfg == nil || cfg.CloudSync == nil || !*cfg.CloudSync {
+			return
+		}
 		tracker.Complete(agent.config.Context.API, agent.usage.TotalTokens(), sessionSummary(agent.history))
 	}
 
@@ -1223,6 +1240,15 @@ func printConfigInfo(cfg *Config, term *Terminal) {
 	fmt.Printf("  %-20s %d\n", "Default project:", cfg.DefaultProject)
 	fmt.Printf("  %-20s %v\n", "Professional:", cfg.Professional)
 	fmt.Printf("  %-20s %v\n", "Auto-save:", cfg.AutoSave)
+	cloudSyncVal := "not set (will prompt)"
+	if cfg.CloudSync != nil {
+		if *cfg.CloudSync {
+			cloudSyncVal = "enabled"
+		} else {
+			cloudSyncVal = "disabled"
+		}
+	}
+	fmt.Printf("  %-20s %s\n", "Cloud sync:", cloudSyncVal)
 	fmt.Printf("  %-20s %d\n", "Token budget:", cfg.MaxTokenBudget)
 	if cfg.OllamaURL != "" {
 		fmt.Printf("  %-20s %s\n", "Ollama URL:", maskURL(cfg.OllamaURL))
@@ -1237,7 +1263,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 	parts := strings.Fields(input)
 	if len(parts) < 3 {
 		term.PrintError("Usage: /set <key> <value>")
-		term.PrintSystem("Keys: model, project, professional, autosave, budget")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloudsync, budget")
 		return
 	}
 	key := strings.ToLower(parts[1])
@@ -1291,6 +1317,21 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 		case "false", "0", "no", "off":
 			cfg.AutoSave = false
 			term.PrintSystem("Auto-save disabled.")
+		default:
+			term.PrintError("Value must be true or false.")
+			return
+		}
+
+	case "cloudsync":
+		switch strings.ToLower(value) {
+		case "true", "1", "yes", "on":
+			v := true
+			cfg.CloudSync = &v
+			term.PrintSystem("Cloud session sync enabled.")
+		case "false", "0", "no", "off":
+			v := false
+			cfg.CloudSync = &v
+			term.PrintSystem("Cloud session sync disabled.")
 		default:
 			term.PrintError("Value must be true or false.")
 			return


### PR DESCRIPTION
## Summary

- Instead of silently syncing sessions, the user is asked **once** on the first session where they're logged in and have a project set
- Answer is persisted in `~/.qmax-code/config.json` as `cloud_sync: true|false` — never prompted again
- Default answer is **Y** (Enter to accept), so it's low-friction for users who want it
- Can be changed at any time via `/set cloudsync true|false`
- `/config` shows the current state: `enabled / disabled / not set (will prompt)`

## What changed

| File | Change |
|---|---|
| `config.go` | `CloudSync *bool` field (`nil` = not asked, `true/false` = decided) |
| `cloud_session.go` | `promptCloudSyncConsent()` — one-time y/n prompt with box UI, persists choice |
| `main.go` | `startCloudSession` runs prompt on first eligible call; `completeCloudSession` respects opt-out; `/set cloudsync`; `/config` display |

## Test plan

- [x] `go test ./...` — full suite clean
- [ ] Fresh config: start with a project set → prompt appears on first message
- [ ] Answer N → no further syncing, `/config` shows `disabled`
- [ ] Answer Y → sessions sync, `/config` shows `enabled`  
- [ ] `/set cloudsync false` → disables mid-session
- [ ] Existing users with `cloud_sync` already in config → no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)