### PR TITLE
fix(sessions): start cloud sync at startup and fix /set keys list

### DIFF
--- a/main.go
+++ b/main.go
@@ -510,6 +510,9 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 	var inputHistory []string
 	var lastCtrlC time.Time
 
+	// Prompt consent and open cloud session at startup (idempotent — safe to call again later).
+	startCloudSession()
+
 	for {
 		var input string
 
@@ -649,8 +652,8 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			printConfigInfo(agent.appConfig, term)
 			continue
 		case input == "/set":
-			term.PrintError("Usage: /set <key> <value>")
-			term.PrintSystem("Keys: model, project, professional, autosave, budget, ollama, backend, theme")
+			handleSetCommand(input, agent, term)
+			startCloudSession()
 			continue
 
 		case input == "/queue":
@@ -908,6 +911,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			continue
 		case strings.HasPrefix(input, "/set "):
 			handleSetCommand(input, agent, term)
+			startCloudSession()
 			continue
 		case input == "/keys":
 			handleKeys(agent, term)
@@ -1182,7 +1186,7 @@ Commands:
   /keys          Set API keys (interactive menu)
   /screenshot    Capture a screenshot and analyze it
   /paste         Paste from clipboard (image or text)
-  /set <k> <v>   Update config (model, project, professional, autosave, budget, ollama)
+  /set <k> <v>   Update config (model, project, professional, autosave, cloudsync, budget, ollama)
   /save          Save current session
   /sessions      List recent sessions
   /resume [id]   Resume a session (default: last)
@@ -1196,6 +1200,8 @@ Config examples:
   /set professional true    Disable cat personality
   /set autosave false       Disable auto-save on exit
   /set budget 100000        Set max token budget warning
+  /set cloudsync true       Enable cloud session sync
+  /set cloudsync false      Disable cloud session sync
   /set ollama on            Enable self-hosted LLM for chat (saves API costs)
   /set ollama off           Disable Ollama, use Claude for all calls
   /set backend cc           Use Claude Code subscription (no API key needed)
@@ -1263,7 +1269,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 	parts := strings.Fields(input)
 	if len(parts) < 3 {
 		term.PrintError("Usage: /set <key> <value>")
-		term.PrintSystem("Keys: model, project, professional, autosave, cloudsync, budget")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloudsync, budget, apikey, ollama, backend, theme")
 		return
 	}
 	key := strings.ToLower(parts[1])
@@ -1437,7 +1443,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 
 	default:
 		term.PrintError(fmt.Sprintf("Unknown config key: %s", key))
-		term.PrintSystem("Keys: model, project, professional, autosave, budget, apikey, backend, theme")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloudsync, budget, apikey, ollama, backend, theme")
 		return
 	}
 


### PR DESCRIPTION
## Summary

- `startCloudSession()` was only called after the user typed their first message (inside the REPL loop). Moved a call to **before the loop** so the consent prompt and session creation happen immediately at launch.
- After `/set cloudsync on/true`, `startCloudSession()` is now called immediately so the **current session** is tracked without needing to restart.
- The outer `case input == "/set"` was a stale duplicate showing an outdated keys list (missing `cloudsync`, wrong extras). It now delegates to `handleSetCommand` so both the exact and prefixed `/set` cases always show a consistent, complete keys list.
- All error/usage messages and `/help` examples updated to include `cloudsync`.

## Test plan

- [ ] Start fresh with no config — verify consent prompt appears at launch (before first message)
- [ ] Start with `CloudSync: true` already in config — verify session is created at launch
- [ ] Type `/set` (no args) — verify keys list includes `cloudsync` and matches the full handler
- [ ] Type `/set cloudsync true` — verify syncing starts for the current session immediately
- [ ] Type `/help` — verify `cloudsync` appears in the command description and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)