### PR TITLE
chore: bump version to 1.15.3

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.15.2"
+var Version = "1.15.3"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps version from 1.15.2 → 1.15.3
- Covers commits since last release: feat(sessions) opt-in cloud sync prompt + `/set cloudsync`, fix(sessions) startup sync + `/set keys` list

## Test plan
- [ ] CI passes
- [ ] `qmax-code --version` reports 1.15.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)