### PR TITLE
fix(sessions): fix consent prompt invisible due to readline raw-mode conflict

### DIFF
--- a/cloud_session.go
+++ b/cloud_session.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 )
@@ -12,7 +10,10 @@ import (
 // promptCloudSyncConsent asks the user once whether they want sessions synced
 // to the QualityMax cloud. The answer is persisted in cfg so the prompt never
 // appears again. Returns true if the user opted in.
-func promptCloudSyncConsent(cfg *Config) bool {
+//
+// readLine must use the active readline instance (e.g. term.ReadConsent) so
+// that it works correctly when readline already owns the terminal in raw mode.
+func promptCloudSyncConsent(cfg *Config, readLine func() (string, error)) bool {
 	fmt.Println()
 	fmt.Println("  ┌─ Cloud session sync ──────────────────────────────────────────┐")
 	fmt.Println("  │  qmax-code can sync your sessions to the QualityMax cloud so  │")
@@ -23,8 +24,7 @@ func promptCloudSyncConsent(cfg *Config) bool {
 	fmt.Println()
 	fmt.Print("  Enable cloud session sync? [Y/n]: ")
 
-	reader := bufio.NewReader(os.Stdin)
-	line, _ := reader.ReadString('\n')
+	line, _ := readLine()
 
 	enabled := applyCloudSyncChoice(cfg, line)
 	if enabled {

--- a/main.go
+++ b/main.go
@@ -425,7 +425,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		cfg := agent.appConfig
 		// First eligible session: ask the user once and persist their choice.
 		if cfg != nil && cfg.CloudSync == nil {
-			promptCloudSyncConsent(cfg)
+			promptCloudSyncConsent(cfg, term.ReadConsent)
 		}
 		if cfg == nil || cfg.CloudSync == nil || !*cfg.CloudSync {
 			return

--- a/terminal.go
+++ b/terminal.go
@@ -229,6 +229,18 @@ func (t *Terminal) ReadLine() (string, error) {
 	return t.rl.Readline()
 }
 
+// ReadConsent temporarily clears the readline prompt and reads one line.
+// Used for consent questions that print their own prompt text via fmt, avoiding
+// the raw-mode conflict that arises when using bufio.NewReader(os.Stdin) while
+// readline already owns the terminal.
+func (t *Terminal) ReadConsent() (string, error) {
+	saved := t.currentPrompt
+	t.rl.SetPrompt("")
+	line, err := t.rl.Readline()
+	t.rl.SetPrompt(saved)
+	return line, err
+}
+
 // PrintBanner shows the startup banner — fun, geeky, and cat-themed.
 func (t *Terminal) PrintBanner(version string, ctx *SessionContext) {
 	// Pick Max's mood based on context


### PR DESCRIPTION
## Summary
- `promptCloudSyncConsent` was using `bufio.NewReader(os.Stdin)` after `readline` had already taken ownership of stdin in raw mode — the consent box printed but user input was silently swallowed, so the prompt appeared invisible or non-interactive
- Added `Terminal.ReadConsent()` which temporarily clears the readline prompt and reads through readline's own mechanism, avoiding the conflict
- Threaded it through as a `func() (string, error)` arg to `promptCloudSyncConsent` so `applyCloudSyncChoice` (unit-tested separately) is unchanged

## Test plan
- [ ] Start `qmax-code` with a logged-in account and a project set, and `cloud_sync` not yet in `~/.qmax-code/config.json` — consent box should appear and accept Y/n input correctly
- [ ] Repeat via `/set cloudsync` path
- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)