### PR TITLE
fix: rename cloudsync to cloud_sync and extract maxIterations constant

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -186,7 +186,7 @@ func (a *Agent) Run(prompt string) (string, error) {
 		Content: prompt,
 	})
 
-	for iterations := 0; iterations < 20; iterations++ {
+	for iterations := 0; iterations < maxIterations; iterations++ {
 		resp, err := a.callAPI()
 		if err != nil {
 			return "", fmt.Errorf("API call failed: %w", err)
@@ -213,8 +213,11 @@ func (a *Agent) Run(prompt string) (string, error) {
 }
 
 // compressHistory summarizes old messages when history gets too large.
-const maxHistoryTokens = 40000 // compress at 90% of ~45K practical limit
-const maxSessionMessages = 40  // hard limit — force compression after 40 messages (~20 turns)
+const (
+	maxHistoryTokens   = 40000 // compress at 90% of ~45K practical limit
+	maxSessionMessages = 40    // hard limit — force compression after 40 messages (~20 turns)
+	maxIterations      = 50
+)
 
 func (a *Agent) compressHistory() {
 	// Rough token estimate: 4 chars ≈ 1 token
@@ -371,7 +374,7 @@ func (a *Agent) RunStreaming(prompt string, term *Terminal) (string, error) {
 }
 
 func (a *Agent) runStreamingLoop(term *Terminal) (string, error) {
-	for iterations := 0; iterations < 20; iterations++ {
+	for iterations := 0; iterations < maxIterations; iterations++ {
 		// Sanitize + compress history before each API call
 		sanitizeSessionMessages(a.history)
 		a.compressHistory()

--- a/main.go
+++ b/main.go
@@ -1186,7 +1186,7 @@ Commands:
   /keys          Set API keys (interactive menu)
   /screenshot    Capture a screenshot and analyze it
   /paste         Paste from clipboard (image or text)
-  /set <k> <v>   Update config (model, project, professional, autosave, cloudsync, budget, ollama)
+  /set <k> <v>   Update config (model, project, professional, autosave, cloud_sync, budget, ollama)
   /save          Save current session
   /sessions      List recent sessions
   /resume [id]   Resume a session (default: last)
@@ -1200,8 +1200,8 @@ Config examples:
   /set professional true    Disable cat personality
   /set autosave false       Disable auto-save on exit
   /set budget 100000        Set max token budget warning
-  /set cloudsync true       Enable cloud session sync
-  /set cloudsync false      Disable cloud session sync
+  /set cloud_sync true       Enable cloud session sync
+  /set cloud_sync false      Disable cloud session sync
   /set ollama on            Enable self-hosted LLM for chat (saves API costs)
   /set ollama off           Disable Ollama, use Claude for all calls
   /set backend cc           Use Claude Code subscription (no API key needed)
@@ -1269,7 +1269,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 	parts := strings.Fields(input)
 	if len(parts) < 3 {
 		term.PrintError("Usage: /set <key> <value>")
-		term.PrintSystem("Keys: model, project, professional, autosave, cloudsync, budget, apikey, ollama, backend, theme")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, budget, apikey, ollama, backend, theme")
 		return
 	}
 	key := strings.ToLower(parts[1])
@@ -1443,7 +1443,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 
 	default:
 		term.PrintError(fmt.Sprintf("Unknown config key: %s", key))
-		term.PrintSystem("Keys: model, project, professional, autosave, cloudsync, budget, apikey, ollama, backend, theme")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, budget, apikey, ollama, backend, theme")
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Rename `/set cloudsync` to `/set cloud_sync` for consistent snake_case naming in help text and error messages
- Extract hardcoded iteration limit (`20`) to a `maxIterations = 50` constant, preventing silent truncation on complex multi-tool tasks

## Test plan
- [x] `go build` passes
- [x] `go test ./...` passes
- [ ] Verify `/set cloud_sync true` and `/set cloud_sync false` work as expected
- [ ] Confirm agent loop completes complex tasks without hitting the old 20-iteration cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)