### PR TITLE
chore: bump version to 1.15.4

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.15.3"
+var Version = "1.16.0"
 
 const Name = "qmax-code"
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.0"
+var Version = "1.15.4"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps version from 1.15.3 → 1.15.4 (patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)