### PR TITLE
fix(codex): use exec subcommand with valid flags and upload session messages to cloud

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -401,6 +401,19 @@ func (c *APIClient) CompleteAgentSession(ctx context.Context, cloudID string, to
 	c.patch(ctx, "/api/agent-sessions/"+cloudID, body)
 }
 
+// UploadSessionMessages uploads the full conversation history to a cloud session.
+// Called alongside CompleteAgentSession so the cloud has complete context for
+// cross-session recall. Errors are silently dropped.
+func (c *APIClient) UploadSessionMessages(ctx context.Context, cloudID string, messages []Message) {
+	if len(messages) == 0 {
+		return
+	}
+	body := map[string]interface{}{
+		"messages": messages,
+	}
+	c.post(ctx, "/api/agent-sessions/"+cloudID+"/messages", body)
+}
+
 // --- Script operations ---
 
 func (c *APIClient) GetScript(ctx context.Context, scriptID int) string {

--- a/api_client.go
+++ b/api_client.go
@@ -401,17 +401,47 @@ func (c *APIClient) CompleteAgentSession(ctx context.Context, cloudID string, to
 	c.patch(ctx, "/api/agent-sessions/"+cloudID, body)
 }
 
+// maxSessionUploadBytes caps the serialized message payload to avoid server
+// rejection or excessive upload times on very long sessions.
+const maxSessionUploadBytes = 4 * 1024 * 1024 // 4 MiB
+
 // UploadSessionMessages uploads the full conversation history to a cloud session.
 // Called alongside CompleteAgentSession so the cloud has complete context for
-// cross-session recall. Errors are silently dropped.
+// cross-session recall. If the payload exceeds maxSessionUploadBytes, older
+// messages are trimmed. Errors are silently dropped.
 func (c *APIClient) UploadSessionMessages(ctx context.Context, cloudID string, messages []Message) {
 	if len(messages) == 0 {
 		return
 	}
+	msgs := trimMessagesToFit(messages, maxSessionUploadBytes)
 	body := map[string]interface{}{
-		"messages": messages,
+		"messages": msgs,
 	}
 	c.post(ctx, "/api/agent-sessions/"+cloudID+"/messages", body)
+}
+
+// trimMessagesToFit drops oldest messages until the JSON-encoded payload fits
+// within maxBytes. Returns the original slice if it already fits.
+func trimMessagesToFit(messages []Message, maxBytes int) []Message {
+	data, err := json.Marshal(messages)
+	if err != nil || len(data) <= maxBytes {
+		return messages
+	}
+	// Binary search for the largest suffix that fits.
+	lo, hi := 0, len(messages)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		d, _ := json.Marshal(messages[mid:])
+		if len(d) <= maxBytes {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	if lo >= len(messages) {
+		return messages[len(messages)-1:] // at minimum send the last message
+	}
+	return messages[lo:]
 }
 
 // --- Script operations ---

--- a/api_client_agent_session_test.go
+++ b/api_client_agent_session_test.go
@@ -175,6 +175,96 @@ func TestCompleteAgentSession_SilentOnServerError(t *testing.T) {
 
 // ---- patch() HTTP helper ----
 
+// ---- UploadSessionMessages ----
+
+func TestUploadSessionMessages_PostsToCorrectEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]interface{}
+
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	msgs := []Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "world"},
+	}
+	client.UploadSessionMessages(context.Background(), "sess-123", msgs)
+
+	if gotMethod != "POST" {
+		t.Errorf("method: got %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/agent-sessions/sess-123/messages" {
+		t.Errorf("path: got %q", gotPath)
+	}
+	if gotBody["messages"] == nil {
+		t.Error("body missing 'messages' key")
+	}
+}
+
+func TestUploadSessionMessages_SkipsWhenEmpty(t *testing.T) {
+	calls := 0
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	client.UploadSessionMessages(context.Background(), "sess-123", nil)
+	client.UploadSessionMessages(context.Background(), "sess-123", []Message{})
+
+	if calls != 0 {
+		t.Errorf("expected 0 HTTP calls for empty messages, got %d", calls)
+	}
+}
+
+// ---- trimMessagesToFit ----
+
+func TestTrimMessagesToFit_NoTrimWhenUnderLimit(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "hello"},
+	}
+	result := trimMessagesToFit(msgs, 1024*1024)
+	if len(result) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(result))
+	}
+}
+
+func TestTrimMessagesToFit_TrimsOldestMessages(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: strings.Repeat("A", 500)},
+		{Role: "assistant", Content: strings.Repeat("B", 500)},
+		{Role: "user", Content: strings.Repeat("C", 500)},
+		{Role: "assistant", Content: "short"},
+	}
+	// Set a tight limit that can only fit the last 2 messages
+	result := trimMessagesToFit(msgs, 600)
+	if len(result) >= len(msgs) {
+		t.Errorf("expected trimming, got %d messages (same as input)", len(result))
+	}
+	// Last message should always be preserved
+	last := result[len(result)-1]
+	if last.Content != "short" {
+		t.Errorf("last message should be preserved, got content %q", last.Content)
+	}
+}
+
+func TestTrimMessagesToFit_ReturnsAtLeastLastMessage(t *testing.T) {
+	msgs := []Message{
+		{Role: "user", Content: strings.Repeat("X", 10000)},
+		{Role: "assistant", Content: strings.Repeat("Y", 10000)},
+	}
+	// Impossibly small limit
+	result := trimMessagesToFit(msgs, 10)
+	if len(result) < 1 {
+		t.Error("should return at least 1 message")
+	}
+}
+
 func TestPatch_SendsPatchMethodWithAuthAndContentType(t *testing.T) {
 	var gotMethod, gotAuth, gotCT string
 	var gotBody map[string]interface{}

--- a/cloud_session.go
+++ b/cloud_session.go
@@ -72,8 +72,12 @@ func (t *cloudSessionTracker) Complete(api *APIClient, totalTokens int, summary 
 	if api == nil || t.cloudID == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	api.CompleteAgentSession(ctx, t.cloudID, totalTokens, summary)
-	api.UploadSessionMessages(ctx, t.cloudID, messages)
+	cancel()
+
+	// Separate timeout for message upload — payload can be large.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel2()
+	api.UploadSessionMessages(ctx2, t.cloudID, messages)
 }

--- a/cloud_session.go
+++ b/cloud_session.go
@@ -65,13 +65,15 @@ func (t *cloudSessionTracker) Start(api *APIClient, projectID int, model string)
 	t.cloudID = api.CreateAgentSession(ctx, projectID, model)
 }
 
-// Complete patches the cloud session as finished. No-op if Start was never
-// called successfully (cloudID is empty) or api is nil.
-func (t *cloudSessionTracker) Complete(api *APIClient, totalTokens int, summary string) {
+// Complete patches the cloud session as finished and uploads the full message
+// history. No-op if Start was never called successfully (cloudID is empty) or
+// api is nil.
+func (t *cloudSessionTracker) Complete(api *APIClient, totalTokens int, summary string, messages []Message) {
 	if api == nil || t.cloudID == "" {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	api.CompleteAgentSession(ctx, t.cloudID, totalTokens, summary)
+	api.UploadSessionMessages(ctx, t.cloudID, messages)
 }

--- a/cloud_session_test.go
+++ b/cloud_session_test.go
@@ -174,7 +174,7 @@ func TestCloudTracker_Complete_SkipsWhenCloudIDEmpty(t *testing.T) {
 	})
 
 	var tracker cloudSessionTracker // cloudID == ""
-	tracker.Complete(client, 500, "some summary")
+	tracker.Complete(client, 500, "some summary", nil)
 
 	if calls != 0 {
 		t.Errorf("expected no HTTP call when cloudID is empty, got %d", calls)
@@ -185,7 +185,7 @@ func TestCloudTracker_Complete_SkipsWhenAPIIsNil(t *testing.T) {
 	// Manually set cloudID to simulate a started session, then pass nil api.
 	tracker := cloudSessionTracker{cloudID: "cloud-abc"}
 	// Should not panic.
-	tracker.Complete(nil, 100, "summary")
+	tracker.Complete(nil, 100, "summary", nil)
 }
 
 func TestCloudTracker_Complete_PatchesWithCloudID(t *testing.T) {
@@ -197,7 +197,7 @@ func TestCloudTracker_Complete_PatchesWithCloudID(t *testing.T) {
 	})
 
 	tracker := cloudSessionTracker{cloudID: "cloud-abc"}
-	tracker.Complete(client, 200, "did stuff  [2 turns]")
+	tracker.Complete(client, 200, "did stuff  [2 turns]", nil)
 
 	if gotMethod != "PATCH" {
 		t.Errorf("method: got %q, want PATCH", gotMethod)
@@ -215,7 +215,7 @@ func TestCloudTracker_Complete_SilentOnServerError(t *testing.T) {
 
 	tracker := cloudSessionTracker{cloudID: "cloud-abc"}
 	// Must not panic or block.
-	tracker.Complete(client, 100, "summary")
+	tracker.Complete(client, 100, "summary", nil)
 }
 
 // ---- full Start → Complete lifecycle ----
@@ -233,9 +233,56 @@ func TestCloudTracker_StartThenComplete_UsesCorrectCloudID(t *testing.T) {
 
 	var tracker cloudSessionTracker
 	tracker.Start(client, 184, "claude-sonnet-4-6")
-	tracker.Complete(client, 750, "lifecycle test  [5 turns]")
+	tracker.Complete(client, 750, "lifecycle test  [5 turns]", nil)
 
 	if patchedID != "/api/agent-sessions/lifecycle-id" {
 		t.Errorf("Complete used wrong id: path %q", patchedID)
+	}
+}
+
+func TestCloudTracker_Complete_UploadsMessages(t *testing.T) {
+	var paths []string
+	var methods []string
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		methods = append(methods, r.Method)
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	msgs := []Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi there"},
+	}
+
+	tracker := cloudSessionTracker{cloudID: "cloud-xyz"}
+	tracker.Complete(client, 300, "test upload", msgs)
+
+	if len(paths) != 2 {
+		t.Fatalf("expected 2 HTTP calls (PATCH + POST), got %d", len(paths))
+	}
+	if methods[0] != "PATCH" {
+		t.Errorf("first call: got %s, want PATCH", methods[0])
+	}
+	if methods[1] != "POST" {
+		t.Errorf("second call: got %s, want POST", methods[1])
+	}
+	if paths[1] != "/api/agent-sessions/cloud-xyz/messages" {
+		t.Errorf("messages path: got %q, want /api/agent-sessions/cloud-xyz/messages", paths[1])
+	}
+}
+
+func TestCloudTracker_Complete_SkipsUploadWhenNoMessages(t *testing.T) {
+	calls := 0
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{}`))
+	})
+
+	tracker := cloudSessionTracker{cloudID: "cloud-xyz"}
+	tracker.Complete(client, 100, "empty session", nil)
+
+	// Only the PATCH to complete, no POST for messages
+	if calls != 1 {
+		t.Errorf("expected 1 HTTP call (PATCH only), got %d", calls)
 	}
 }

--- a/cloud_session_test.go
+++ b/cloud_session_test.go
@@ -221,12 +221,15 @@ func TestCloudTracker_Complete_SilentOnServerError(t *testing.T) {
 // ---- full Start → Complete lifecycle ----
 
 func TestCloudTracker_StartThenComplete_UsesCorrectCloudID(t *testing.T) {
-	var patchedID string
+	var patchedPath string
 	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/agent-sessions":
 			_, _ = w.Write([]byte(`{"session_id":"lifecycle-id"}`))
-		} else {
-			patchedID = r.URL.Path
+		case r.Method == "PATCH":
+			patchedPath = r.URL.Path
+			_, _ = w.Write([]byte(`{}`))
+		default:
 			_, _ = w.Write([]byte(`{}`))
 		}
 	})
@@ -235,8 +238,8 @@ func TestCloudTracker_StartThenComplete_UsesCorrectCloudID(t *testing.T) {
 	tracker.Start(client, 184, "claude-sonnet-4-6")
 	tracker.Complete(client, 750, "lifecycle test  [5 turns]", nil)
 
-	if patchedID != "/api/agent-sessions/lifecycle-id" {
-		t.Errorf("Complete used wrong id: path %q", patchedID)
+	if patchedPath != "/api/agent-sessions/lifecycle-id" {
+		t.Errorf("Complete used wrong id: path %q", patchedPath)
 	}
 }
 

--- a/codex_agent.go
+++ b/codex_agent.go
@@ -20,7 +20,7 @@ import (
 //
 // Per-message flow:
 //  1. qmax-code writes ~/.codex/config.json with the qmax MCP server entry
-//  2. qmax-code spawns: codex --quiet --full-auto "msg"
+//  2. qmax-code spawns: codex exec --json [--dangerously-bypass-approvals-and-sandbox] "msg"
 //  3. Codex picks up the MCP config and spawns qmax-code serve --mcp
 //  4. Codex uses qmax tools natively, runs on OpenAI subscription
 //  5. qmax-code streams Codex's stdout to the terminal
@@ -30,9 +30,9 @@ import (
 // as context in the system/user turn) since Codex has no --resume equivalent.
 type CodexAgent struct {
 	codexBin       string
-	modelID        string // "" = codex default; otherwise passed as --model
+	modelID        string // "" = codex default; otherwise passed as -m
 	effort         string // "low" | "medium" | "high"
-	permissionMode string // "standard" (Codex prompts per-action) | "unattended" (--full-auto)
+	permissionMode string // "standard" (Codex prompts per-action) | "unattended" (--dangerously-bypass-approvals-and-sandbox)
 	sctx           *SessionContext
 	history        []codexTurn // conversation history managed on our side
 	mu             sync.Mutex
@@ -62,11 +62,11 @@ func FindCodex() string {
 }
 
 // NewCodexAgent creates a Codex subprocess orchestrator.
-// modelID is passed as --model to the codex CLI (empty = codex default).
+// modelID is passed as -m to the codex CLI (empty = codex default).
 // effort is "low" | "medium" | "high" (empty defaults to "high").
 // permissionMode is "standard" or "unattended" — Codex has no allowlist primitive,
-// so Standard relies on Codex's own approval flow (works for read-mostly tasks
-// in interactive runs) and Unattended adds --full-auto.
+// so Standard relies on Codex's own sandbox policy and Unattended adds
+// --dangerously-bypass-approvals-and-sandbox.
 func NewCodexAgent(bin, modelID, effort, permissionMode string, sctx *SessionContext) *CodexAgent {
 	if effort == "" {
 		effort = "high"
@@ -155,15 +155,12 @@ func (a *CodexAgent) Run(userMsg string, term *Terminal) (string, error) {
 	// Build the full prompt: QA system prompt + conversation history + current message.
 	prompt := a.buildPrompt(userMsg)
 
-	args := []string{
-		"--quiet",
-	}
+	args := []string{"exec", "--json"}
 	if a.permissionMode == "unattended" {
-		// Equivalent to CC's --dangerously-skip-permissions. Only with explicit consent.
-		args = append(args, "--full-auto")
+		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}
 	if a.modelID != "" {
-		args = append(args, "--model", a.modelID)
+		args = append(args, "-m", a.modelID)
 	}
 	args = append(args, prompt)
 
@@ -181,17 +178,17 @@ func (a *CodexAgent) Run(userMsg string, term *Terminal) (string, error) {
 		return "", fmt.Errorf("start codex: %w", err)
 	}
 
-	// Stream stdout lines to terminal.
+	// Stream JSONL events from codex exec --json.
 	var sb strings.Builder
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 1<<20), 1<<20)
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		// Skip Codex's internal status lines (they usually start with special chars).
-		if !isCodexStatusLine(line) {
-			term.StreamText(line + "\n")
-			sb.WriteString(line)
+		text := extractCodexMessage(line)
+		if text != "" {
+			term.StreamText(text + "\n")
+			sb.WriteString(text)
 			sb.WriteByte('\n')
 		}
 	}
@@ -261,15 +258,22 @@ func (a *CodexAgent) ClearHistory() {
 // Cleanup is a no-op for CodexAgent (no temp files to remove).
 func (a *CodexAgent) Cleanup() {}
 
-// isCodexStatusLine returns true for Codex CLI status/spinner output lines
-// that should not be passed to the terminal renderer.
-func isCodexStatusLine(line string) bool {
-	if line == "" {
-		return false
+// extractCodexMessage parses a JSONL line from `codex exec --json` and returns
+// the assistant text if the event is an item.completed with type "agent_message".
+// Returns "" for all other event types (turn lifecycle, tool calls, etc.).
+func extractCodexMessage(line string) string {
+	var event struct {
+		Type string `json:"type"`
+		Item struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"item"`
 	}
-	// Codex may emit ANSI-cleared lines or control sequences.
-	if strings.HasPrefix(line, "\r") || strings.HasPrefix(line, "\033") {
-		return true
+	if json.Unmarshal([]byte(line), &event) != nil {
+		return ""
 	}
-	return false
+	if event.Type == "item.completed" && event.Item.Type == "agent_message" {
+		return event.Item.Text
+	}
+	return ""
 }

--- a/main.go
+++ b/main.go
@@ -437,7 +437,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		if cfg == nil || cfg.CloudSync == nil || !*cfg.CloudSync {
 			return
 		}
-		tracker.Complete(agent.config.Context.API, agent.usage.TotalTokens(), sessionSummary(agent.history))
+		tracker.Complete(agent.config.Context.API, agent.usage.TotalTokens(), sessionSummary(agent.history), agent.history)
 	}
 
 	// Graceful interrupt handling


### PR DESCRIPTION
## Summary
- **Fix codex CLI invocation**: replaced invalid `--quiet` / `--full-auto` / `--model` with `exec --json` / `--dangerously-bypass-approvals-and-sandbox` / `-m` to match the current Rust-based codex CLI
- **Parse JSONL output**: new `extractCodexMessage` replaces `isCodexStatusLine`, extracting `agent_message` text from `item.completed` events
- **Upload full session to cloud**: new `UploadSessionMessages` POSTs `[]Message` history to `/api/agent-sessions/{id}/messages` when cloud sync completes, enabling cross-session recall

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests for message upload (with and without messages)
- [ ] Manual: run `qmax-code` with codex backend, verify no `--quiet` error
- [ ] Manual: confirm cloud session includes messages after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)