### PR TITLE
chore: bump version to 1.15.5

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.15.4"
+var Version = "1.15.5"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bump version to 1.15.5 following fix(codex) PR #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)