### PR TITLE
fix: write Codex MCP config as TOML

### DIFF
--- a/codex_agent.go
+++ b/codex_agent.go
@@ -19,7 +19,7 @@ import (
 // server used for CC mode.
 //
 // Per-message flow:
-//  1. qmax-code writes ~/.codex/config.json with the qmax MCP server entry
+//  1. qmax-code writes ~/.codex/config.toml with the qmax MCP server entry
 //  2. qmax-code spawns: codex exec --json [--dangerously-bypass-approvals-and-sandbox] "msg"
 //  3. Codex picks up the MCP config and spawns qmax-code serve --mcp
 //  4. Codex uses qmax tools natively, runs on OpenAI subscription
@@ -83,14 +83,9 @@ func NewCodexAgent(bin, modelID, effort, permissionMode string, sctx *SessionCon
 	}
 }
 
-// writeMCPConfig writes the qmax MCP server into ~/.codex/config.json
+// writeMCPConfig writes the qmax MCP server into ~/.codex/config.toml
 // so Codex picks it up for every invocation.
 func (a *CodexAgent) writeMCPConfig() error {
-	self, err := os.Executable()
-	if err != nil {
-		self = "qmax-code"
-	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -100,36 +95,14 @@ func (a *CodexAgent) writeMCPConfig() error {
 		return err
 	}
 
-	cfgPath := filepath.Join(codexDir, "config.json")
-
-	// Merge with existing config rather than overwriting it.
-	existing := map[string]interface{}{}
-	if data, err := os.ReadFile(cfgPath); err == nil {
-		_ = json.Unmarshal(data, &existing)
-	}
-
-	mcpServers, _ := existing["mcpServers"].(map[string]interface{})
-	if mcpServers == nil {
-		mcpServers = map[string]interface{}{}
-	}
-
 	env := map[string]string{}
 	if a.sctx.ProjectID > 0 {
 		env["QMAX_PROJECT_ID"] = fmt.Sprintf("%d", a.sctx.ProjectID)
 	}
 
-	mcpServers["qmax"] = map[string]interface{}{
-		"command": self,
-		"args":    []string{"serve", "--mcp"},
-		"env":     env,
-	}
-	existing["mcpServers"] = mcpServers
-
-	data, err := json.MarshalIndent(existing, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(cfgPath, data, 0600)
+	cfgPath := filepath.Join(codexDir, "config.toml")
+	_, err = writeCodexMCPEntry(cfgPath, env)
+	return err
 }
 
 // codexQASystemPrompt is embedded in the initial prompt to Codex, since

--- a/config.go
+++ b/config.go
@@ -52,7 +52,7 @@ type Config struct {
 
 	// OrchGlobalInstall records that the user opted into writing the qmax MCP
 	// entry into the CLI's global config (~/.claude/settings.json or
-	// ~/.codex/config.json). False = use a per-session temp config only.
+	// ~/.codex/config.toml). False = use a per-session temp config only.
 	OrchGlobalInstall bool `json:"orch_global_install,omitempty"`
 
 	// Theme selects the terminal color scheme.

--- a/consent.go
+++ b/consent.go
@@ -11,7 +11,7 @@ import (
 type orchConsentResult struct {
 	Proceed        bool   // user said yes; false means cancel activation
 	PermissionMode string // "standard" | "unattended"
-	GlobalInstall  bool   // ok to write into ~/.claude/settings.json or ~/.codex/config.json
+	GlobalInstall  bool   // ok to write into ~/.claude/settings.json or ~/.codex/config.toml
 }
 
 // promptOrchConsent shows the autonomy + global-install dialog the first time
@@ -25,7 +25,7 @@ func promptOrchConsent(cfg *Config, backend string) orchConsentResult {
 	globalConfigPath := "~/.claude/settings.json"
 	if backend == "codex" {
 		cliName = "Codex"
-		globalConfigPath = "~/.codex/config.json"
+		globalConfigPath = "~/.codex/config.toml"
 	}
 
 	res := orchConsentResult{

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func main() {
 	}
 
 	// Build the CLI agent if a CLI backend was selected and consented to above.
-	// Global MCP install (~/.claude/settings.json or ~/.codex/config.json) is
+	// Global MCP install (~/.claude/settings.json or ~/.codex/config.toml) is
 	// performed only when the user opted into it during the consent prompt.
 	switch cliBackend {
 	case "cc":
@@ -1022,9 +1022,9 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				backendTag = agent.config.Context.Backend
 			}
 			CaptureError(err, map[string]interface{}{
-				"backend":      backendTag,
-				"input_len":    fmt.Sprintf("%d", len(input)),
-				"image_count":  fmt.Sprintf("%d", len(images)),
+				"backend":     backendTag,
+				"input_len":   fmt.Sprintf("%d", len(input)),
+				"image_count": fmt.Sprintf("%d", len(images)),
 			})
 			autoSave() // save even on error — preserves context
 			continue

--- a/setup_orch.go
+++ b/setup_orch.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 )
+
+const qmaxMCPCommand = "qmax-code"
 
 // OrchSetupResult describes what autosetup did so the caller can display it.
 type OrchSetupResult struct {
@@ -36,7 +40,7 @@ func SetupCCIntegration() (*OrchSetupResult, error) {
 	return writeMCPEntry(settingsPath)
 }
 
-// SetupCodexIntegration writes the qmax MCP server into ~/.codex/config.json
+// SetupCodexIntegration writes the qmax MCP server into ~/.codex/config.toml
 // so Codex picks up qmax tools whenever the user invokes `codex` directly,
 // in addition to when qmax-code spawns it.
 func SetupCodexIntegration() (*OrchSetupResult, error) {
@@ -50,19 +54,14 @@ func SetupCodexIntegration() (*OrchSetupResult, error) {
 		return nil, err
 	}
 
-	cfgPath := filepath.Join(codexDir, "config.json")
-	return writeMCPEntry(cfgPath)
+	cfgPath := filepath.Join(codexDir, "config.toml")
+	return writeCodexMCPEntry(cfgPath, nil)
 }
 
 // writeMCPEntry merges the qmax MCP entry into a JSON config file.
 // Existing keys are preserved; only the "qmax" entry under "mcpServers" is
 // added or updated.
 func writeMCPEntry(path string) (*OrchSetupResult, error) {
-	self, err := os.Executable()
-	if err != nil {
-		self = "qmax-code"
-	}
-
 	// Load existing config (may not exist yet).
 	cfg := map[string]interface{}{}
 	if data, err := os.ReadFile(path); err == nil {
@@ -81,7 +80,7 @@ func writeMCPEntry(path string) (*OrchSetupResult, error) {
 	}
 
 	mcpServers["qmax"] = map[string]interface{}{
-		"command": self,
+		"command": qmaxMCPCommand,
 		"args":    []string{"serve", "--mcp"},
 	}
 	cfg["mcpServers"] = mcpServers
@@ -99,6 +98,123 @@ func writeMCPEntry(path string) (*OrchSetupResult, error) {
 		MCPPath:       path,
 		AlreadyHadMCP: alreadyHad,
 	}, nil
+}
+
+// writeCodexMCPEntry merges the qmax MCP entry into Codex's TOML config.
+func writeCodexMCPEntry(path string, env map[string]string) (*OrchSetupResult, error) {
+	data, _ := os.ReadFile(path)
+	alreadyHad := codexMCPEntryExists(string(data))
+	updated := upsertCodexMCPEntry(string(data), qmaxMCPCommand, env)
+
+	if err := os.WriteFile(path, []byte(updated), 0600); err != nil {
+		return nil, err
+	}
+
+	return &OrchSetupResult{
+		MCPWritten:    true,
+		MCPPath:       path,
+		AlreadyHadMCP: alreadyHad,
+	}, nil
+}
+
+func codexMCPEntryExists(config string) bool {
+	for _, line := range strings.Split(config, "\n") {
+		if strings.TrimSpace(line) == "[mcp_servers.qmax]" {
+			return true
+		}
+	}
+	return false
+}
+
+func upsertCodexMCPEntry(config, command string, env map[string]string) string {
+	lines := strings.Split(strings.ReplaceAll(config, "\r\n", "\n"), "\n")
+	out := make([]string, 0, len(lines)+8)
+
+	for i := 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != "[mcp_servers.qmax]" {
+			out = append(out, lines[i])
+			continue
+		}
+		for i+1 < len(lines) && !isTOMLTableHeader(lines[i+1]) {
+			i++
+		}
+	}
+
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+	if len(out) > 0 {
+		out = append(out, "")
+	}
+	out = append(out, renderCodexMCPEntry(command, env)...)
+	return strings.Join(out, "\n") + "\n"
+}
+
+func isTOMLTableHeader(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	return strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]")
+}
+
+func renderCodexMCPEntry(command string, env map[string]string) []string {
+	safeCommand, err := validateCodexMCPCommand(command)
+	if err != nil {
+		safeCommand = "qmax-code"
+	}
+
+	lines := []string{
+		"[mcp_servers.qmax]",
+		"command = " + tomlQuote(safeCommand),
+		`args = ["serve", "--mcp"]`,
+	}
+	if len(env) > 0 {
+		keys := make([]string, 0, len(env))
+		for k := range env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		parts := make([]string, 0, len(keys))
+		for _, k := range keys {
+			parts = append(parts, tomlQuote(k)+" = "+tomlQuote(env[k]))
+		}
+		lines = append(lines, "env = { "+strings.Join(parts, ", ")+" }")
+	}
+	return lines
+}
+
+func validateCodexMCPCommand(command string) (string, error) {
+	command = strings.TrimSpace(command)
+	if command == qmaxMCPCommand {
+		return command, nil
+	}
+	return "", fmt.Errorf("command must be %s", qmaxMCPCommand)
+}
+
+func tomlQuote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 {
+				b.WriteString(fmt.Sprintf(`\u%04x`, r))
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }
 
 // RunOrchSetup runs the one-time integration setup for the chosen backend,
@@ -149,7 +265,7 @@ func IsOrchSetupDone(backend string) bool {
 	case "cc":
 		cfgPath = filepath.Join(home, ".claude", "settings.json")
 	case "codex":
-		cfgPath = filepath.Join(home, ".codex", "config.json")
+		cfgPath = filepath.Join(home, ".codex", "config.toml")
 	default:
 		return true
 	}
@@ -159,15 +275,15 @@ func IsOrchSetupDone(backend string) bool {
 		return false
 	}
 
+	if backend == "codex" {
+		return codexMCPEntryExists(string(data))
+	}
+
 	var cfg map[string]interface{}
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return false
 	}
-
 	mcpServers, _ := cfg["mcpServers"].(map[string]interface{})
-	if mcpServers == nil {
-		return false
-	}
 	_, exists := mcpServers["qmax"]
 	return exists
 }

--- a/setup_orch_test.go
+++ b/setup_orch_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpsertCodexMCPEntryAddsQMaxTable(t *testing.T) {
+	input := `model = "gpt-5.5"
+
+[projects."/tmp/app"]
+trust_level = "trusted"
+`
+
+	got := upsertCodexMCPEntry(input, "qmax-code", nil)
+
+	for _, want := range []string{
+		`model = "gpt-5.5"`,
+		`[projects."/tmp/app"]`,
+		`[mcp_servers.qmax]`,
+		`command = "qmax-code"`,
+		`args = ["serve", "--mcp"]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestUpsertCodexMCPEntryReplacesExistingQMaxOnly(t *testing.T) {
+	input := `model = "gpt-5.5"
+
+[mcp_servers.qualitymax]
+url = "https://app.qualitymax.io/api/mcp/"
+enabled = true
+
+[mcp_servers.qmax]
+command = "/old/qmax-code"
+args = ["serve"]
+env = { "QMAX_PROJECT_ID" = "7" }
+
+[plugins."browser-use@openai-bundled"]
+enabled = true
+`
+
+	got := upsertCodexMCPEntry(input, "qmax-code", map[string]string{"QMAX_PROJECT_ID": "42"})
+
+	if strings.Contains(got, "/old/qmax-code") || strings.Contains(got, `args = ["serve"]`) {
+		t.Fatalf("stale qmax entry was not replaced:\n%s", got)
+	}
+	for _, want := range []string{
+		`[mcp_servers.qualitymax]`,
+		`url = "https://app.qualitymax.io/api/mcp/"`,
+		`[plugins."browser-use@openai-bundled"]`,
+		`command = "qmax-code"`,
+		`args = ["serve", "--mcp"]`,
+		`env = { "QMAX_PROJECT_ID" = "42" }`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Count(got, "[mcp_servers.qmax]") != 1 {
+		t.Fatalf("expected one qmax table, got:\n%s", got)
+	}
+}
+
+func TestCodexMCPEntryExists(t *testing.T) {
+	if !codexMCPEntryExists("\n[mcp_servers.qmax]\ncommand = \"qmax-code\"\n") {
+		t.Fatal("expected qmax MCP entry to be detected")
+	}
+	if codexMCPEntryExists("\n[mcp_servers.qualitymax]\nenabled = true\n") {
+		t.Fatal("qualitymax remote entry should not satisfy qmax local entry")
+	}
+}
+
+func TestRenderCodexMCPEntryRejectsUnsafeCommand(t *testing.T) {
+	lines := renderCodexMCPEntry("/tmp/qmax-code\" \n[mcp_servers.evil]\ncommand = \"sh\"", nil)
+	got := strings.Join(lines, "\n")
+
+	if !strings.Contains(got, `command = "qmax-code"`) {
+		t.Fatalf("unsafe command should fall back to qmax-code:\n%s", got)
+	}
+	if strings.Contains(got, "evil") || strings.Contains(got, "/tmp/qmax-code") {
+		t.Fatalf("unsafe command leaked into TOML:\n%s", got)
+	}
+}
+
+func TestValidateCodexMCPCommand(t *testing.T) {
+	if got, err := validateCodexMCPCommand("qmax-code"); err != nil || got != "qmax-code" {
+		t.Fatalf("validateCodexMCPCommand(qmax-code) = %q, %v", got, err)
+	}
+
+	for _, command := range []string{"", "sh", "/tmp/not-qmax", "/usr/local/bin/qmax-code", "/tmp/qmax-code;rm", "/tmp/qmax-code/.."} {
+		if got, err := validateCodexMCPCommand(command); err == nil {
+			t.Fatalf("validateCodexMCPCommand(%q) = %q, nil; want error", command, got)
+		}
+	}
+}
+
+func TestSetupCodexIntegrationWritesConfigTOML(t *testing.T) {
+	home := withTempHome(t)
+
+	res, err := SetupCodexIntegration()
+	if err != nil {
+		t.Fatalf("SetupCodexIntegration: %v", err)
+	}
+	if res.MCPPath != filepath.Join(home, ".codex", "config.toml") {
+		t.Fatalf("MCPPath = %q, want config.toml under temp home", res.MCPPath)
+	}
+	if res.AlreadyHadMCP {
+		t.Fatal("fresh setup should not report an existing MCP entry")
+	}
+
+	data, err := os.ReadFile(res.MCPPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "[mcp_servers.qmax]") {
+		t.Fatalf("missing qmax table:\n%s", text)
+	}
+	if !IsOrchSetupDone("codex") {
+		t.Fatal("IsOrchSetupDone(codex) should detect config.toml qmax entry")
+	}
+}
+
+func TestWriteCodexMCPEntryReportsAlreadyHad(t *testing.T) {
+	home := withTempHome(t)
+	path := filepath.Join(home, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("[mcp_servers.qmax]\ncommand = \"old\"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := writeCodexMCPEntry(path, nil)
+	if err != nil {
+		t.Fatalf("writeCodexMCPEntry: %v", err)
+	}
+	if !res.AlreadyHadMCP {
+		t.Fatal("expected AlreadyHadMCP for existing qmax table")
+	}
+}


### PR DESCRIPTION
## Summary
- switch Codex MCP setup from `~/.codex/config.json` to `~/.codex/config.toml`
- add TOML upsert logic that replaces only the local `[mcp_servers.qmax]` entry while preserving other tables
- update setup detection and consent/config copy for the TOML path
- add setup coverage for add, replace, detection, and fresh setup flows

## Tests
- `go test -count=1 ./...`

## Coverage / Risk Notes
- Covered happy path: fresh Codex setup writes `config.toml` with qmax MCP entry.
- Covered state transition: existing qmax table is replaced exactly once and reports AlreadyHadMCP.
- Covered boundary-ish path: unrelated `mcp_servers.qualitymax` table does not satisfy qmax local entry detection.
- Remaining gap: no full TOML parser round-trip test; current implementation preserves tables by section-level string surgery.
