### PR TITLE
Add terminal hotkeys, output mode, and persistence coverage

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -23,13 +23,14 @@ const (
 
 // AgentConfig holds configuration for the LLM agent.
 type AgentConfig struct {
-	AnthropicKey string
-	Model        string // base model (used for tool execution loops)
-	ChatModel    string // cheaper model for conversational responses
-	Verbose      bool
-	Context      *SessionContext
-	AutoRoute    bool // true = haiku for chat, sonnet for tools
-	Professional bool // disable cat personality, be direct
+	AnthropicKey  string
+	Model         string // base model (used for tool execution loops)
+	ChatModel     string // cheaper model for conversational responses
+	Verbose       bool
+	OutputVerbose bool // user-facing answer style; false = compact, true = detailed
+	Context       *SessionContext
+	AutoRoute     bool // true = haiku for chat, sonnet for tools
+	Professional  bool // disable cat personality, be direct
 }
 
 // OllamaMode controls how much work Ollama handles.
@@ -1121,6 +1122,8 @@ You MUST call list_projects first to get the slug. Never guess it.
 	if a.usage.TotalTokens() > budgetThreshold {
 		prompt += fmt.Sprintf("\n⚠️ HIGH TOKEN USAGE: Session has used %d tokens. Be extra concise.\n", a.usage.TotalTokens())
 	}
+
+	prompt += outputStyleDirective(a.config.OutputVerbose)
 
 	// Git context
 	if gi := a.config.Context.GitInfo; gi != nil {

--- a/cc_agent.go
+++ b/cc_agent.go
@@ -19,6 +19,7 @@ import (
 // which CLI is underneath.
 type CLIAgent interface {
 	Run(userMsg string, term *Terminal) (string, error)
+	SetOutputVerbose(verbose bool)
 	Cleanup()
 }
 
@@ -39,6 +40,7 @@ type CCAgent struct {
 	claudeBin      string
 	modelID        string // "" = let CC decide; otherwise passed as --model
 	effort         string // "low" | "medium" | "high" — injected into system prompt
+	outputVerbose  bool   // false = compact answer style; true = previous detailed style
 	permissionMode string // "standard" | "unattended" — see Run() for behavior
 	ccSessionID    string // CC's own session ID, for --resume
 	mcpConfigPath  string // temp MCP config written once per qmax session
@@ -159,7 +161,7 @@ func FindClaudeCode() string {
 // effort is "low" | "medium" | "high" (empty defaults to "high").
 // permissionMode is "standard" (curated allowlist) or "unattended"
 // (--dangerously-skip-permissions). Both require explicit user consent.
-func NewCCAgent(claudeBin, modelID, effort, permissionMode string, sctx *SessionContext) *CCAgent {
+func NewCCAgent(claudeBin, modelID, effort, permissionMode string, outputVerbose bool, sctx *SessionContext) *CCAgent {
 	if effort == "" {
 		effort = "high"
 	}
@@ -170,6 +172,7 @@ func NewCCAgent(claudeBin, modelID, effort, permissionMode string, sctx *Session
 		claudeBin:      claudeBin,
 		modelID:        modelID,
 		effort:         effort,
+		outputVerbose:  outputVerbose,
 		permissionMode: permissionMode,
 		sctx:           sctx,
 	}
@@ -230,7 +233,7 @@ func (a *CCAgent) Run(userMsg string, term *Terminal) (string, error) {
 	mcpPath := a.mcpConfigPath
 	a.mu.Unlock()
 
-	systemPrompt := ccQASystemPrompt + effortDirective(a.effort)
+	systemPrompt := ccQASystemPrompt + effortDirective(a.effort) + outputStyleDirective(a.outputVerbose)
 
 	args := []string{
 		"--print", userMsg,
@@ -264,6 +267,7 @@ func (a *CCAgent) Run(userMsg string, term *Terminal) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, a.claudeBin, args...)
+	cmd.Stdin = strings.NewReader("")
 	cmd.Stderr = os.Stderr // CC's own errors and status messages
 
 	stdout, err := cmd.StdoutPipe()
@@ -324,12 +328,12 @@ func cleanupStaleMCPConfigs() {
 
 // ccEvent is a single line from CC's --output-format stream-json output.
 type ccEvent struct {
-	Type      string       `json:"type"`
-	Subtype   string       `json:"subtype,omitempty"`
-	SessionID string       `json:"session_id,omitempty"`
-	Message   *ccEventMsg  `json:"message,omitempty"`
-	Result    string       `json:"result,omitempty"`
-	IsError   bool         `json:"is_error,omitempty"`
+	Type      string      `json:"type"`
+	Subtype   string      `json:"subtype,omitempty"`
+	SessionID string      `json:"session_id,omitempty"`
+	Message   *ccEventMsg `json:"message,omitempty"`
+	Result    string      `json:"result,omitempty"`
+	IsError   bool        `json:"is_error,omitempty"`
 }
 
 type ccEventMsg struct {
@@ -391,7 +395,11 @@ func (a *CCAgent) parseStream(stdout interface{ Read([]byte) (int, error) }, ter
 					a.lastToolName = displayName
 					a.mu.Unlock()
 					term.PrintToolIcon(displayName)
-					term.PrintToolStart(displayName, block.Input)
+					if a.outputVerbose {
+						term.PrintToolStart(displayName, block.Input)
+					} else {
+						fmt.Println()
+					}
 				}
 			}
 
@@ -407,7 +415,11 @@ func (a *CCAgent) parseStream(stdout interface{ Read([]byte) (int, error) }, ter
 					toolName := a.lastToolName
 					a.mu.Unlock()
 					content := extractToolResultText(block.Content)
-					term.PrintToolResult(toolName, truncateStr(content, 200))
+					if a.outputVerbose {
+						term.PrintToolResult(toolName, truncateStr(content, 200))
+					} else {
+						term.StartThinking()
+					}
 				}
 			}
 
@@ -453,6 +465,20 @@ func effortDirective(effort string) string {
 	default: // "high" or unset
 		return "\n\nEFFORT: HIGH — Be exhaustive. Explore all coverage axes, flag every risk, leave no stone unturned."
 	}
+}
+
+// outputStyleDirective controls report length without reducing the actual QA work.
+func outputStyleDirective(verbose bool) string {
+	if verbose {
+		return "\n\nOUTPUT MODE: VERBOSE — Use the previous detailed response style. Include material findings, rationale, coverage gaps, and the next highest-impact action. Do not dump raw JSON unless explicitly requested."
+	}
+	return "\n\nOUTPUT MODE: COMPACT — Keep final answers short and high-signal by default. Lead with the result, use at most 3-5 bullets unless critical failures require more, and avoid low-risk enumeration. Still fetch real data, run tests, diagnose failures, and flag high-risk coverage gaps."
+}
+
+func (a *CCAgent) SetOutputVerbose(verbose bool) {
+	a.mu.Lock()
+	a.outputVerbose = verbose
+	a.mu.Unlock()
 }
 
 // stripMCPPrefix removes the "mcp__<server>__" prefix CC adds to MCP tool names.

--- a/cc_agent_session_test.go
+++ b/cc_agent_session_test.go
@@ -13,6 +13,7 @@ package main
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -37,6 +38,8 @@ func (m *mockCLIAgent) Run(_ string, _ *Terminal) (string, error) {
 }
 
 func (m *mockCLIAgent) Cleanup() {}
+
+func (m *mockCLIAgent) SetOutputVerbose(bool) {}
 
 // historyAfterCLITurns simulates the fixed main-loop path for N turns:
 // calls mockCLIAgent.Run() and mirrors each successful turn into history.
@@ -162,5 +165,17 @@ func TestCLIAgentMultiTurnSessionAccumulates(t *testing.T) {
 		if session.Turns != want {
 			t.Errorf("after turn %d: Turns = %d, want %d", i+1, session.Turns, want)
 		}
+	}
+}
+
+func TestOutputStyleDirectiveModes(t *testing.T) {
+	compact := outputStyleDirective(false)
+	if !strings.Contains(compact, "OUTPUT MODE: COMPACT") || !strings.Contains(compact, "Still fetch real data") {
+		t.Fatalf("compact directive does not preserve QA rigor: %q", compact)
+	}
+
+	verbose := outputStyleDirective(true)
+	if !strings.Contains(verbose, "OUTPUT MODE: VERBOSE") || !strings.Contains(verbose, "previous detailed response style") {
+		t.Fatalf("verbose directive does not describe previous style: %q", verbose)
 	}
 }

--- a/cc_agent_session_test.go
+++ b/cc_agent_session_test.go
@@ -179,3 +179,27 @@ func TestOutputStyleDirectiveModes(t *testing.T) {
 		t.Fatalf("verbose directive does not describe previous style: %q", verbose)
 	}
 }
+
+func TestCodexBuildPromptReflectsOutputVerbose(t *testing.T) {
+	a := &CodexAgent{effort: "high", outputVerbose: false, sctx: &SessionContext{}}
+	if !strings.Contains(a.buildPrompt("hi"), "OUTPUT MODE: COMPACT") {
+		t.Fatal("compact directive not in built prompt")
+	}
+
+	a.SetOutputVerbose(true)
+	if !strings.Contains(a.buildPrompt("hi"), "OUTPUT MODE: VERBOSE") {
+		t.Fatal("SetOutputVerbose(true) did not propagate into the built prompt")
+	}
+}
+
+func TestCCAgentSetOutputVerboseTogglesField(t *testing.T) {
+	a := &CCAgent{effort: "high", outputVerbose: false}
+	a.SetOutputVerbose(true)
+	if !a.outputVerbose {
+		t.Fatal("SetOutputVerbose(true) did not toggle CC agent field")
+	}
+	a.SetOutputVerbose(false)
+	if a.outputVerbose {
+		t.Fatal("SetOutputVerbose(false) did not toggle CC agent field")
+	}
+}

--- a/codex_agent.go
+++ b/codex_agent.go
@@ -32,6 +32,7 @@ type CodexAgent struct {
 	codexBin       string
 	modelID        string // "" = codex default; otherwise passed as -m
 	effort         string // "low" | "medium" | "high"
+	outputVerbose  bool   // false = compact answer style; true = previous detailed style
 	permissionMode string // "standard" (Codex prompts per-action) | "unattended" (--dangerously-bypass-approvals-and-sandbox)
 	sctx           *SessionContext
 	history        []codexTurn // conversation history managed on our side
@@ -67,7 +68,7 @@ func FindCodex() string {
 // permissionMode is "standard" or "unattended" — Codex has no allowlist primitive,
 // so Standard relies on Codex's own sandbox policy and Unattended adds
 // --dangerously-bypass-approvals-and-sandbox.
-func NewCodexAgent(bin, modelID, effort, permissionMode string, sctx *SessionContext) *CodexAgent {
+func NewCodexAgent(bin, modelID, effort, permissionMode string, outputVerbose bool, sctx *SessionContext) *CodexAgent {
 	if effort == "" {
 		effort = "high"
 	}
@@ -78,6 +79,7 @@ func NewCodexAgent(bin, modelID, effort, permissionMode string, sctx *SessionCon
 		codexBin:       bin,
 		modelID:        modelID,
 		effort:         effort,
+		outputVerbose:  outputVerbose,
 		permissionMode: permissionMode,
 		sctx:           sctx,
 	}
@@ -141,6 +143,7 @@ func (a *CodexAgent) Run(userMsg string, term *Terminal) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, a.codexBin, args...)
+	cmd.Stdin = strings.NewReader("")
 	cmd.Stderr = os.Stderr
 
 	stdout, err := cmd.StdoutPipe()
@@ -194,7 +197,7 @@ func (a *CodexAgent) buildPrompt(userMsg string) string {
 	history := a.history
 	a.mu.Unlock()
 
-	systemPrompt := codexQASystemPrompt + effortDirective(a.effort) + "\n\n"
+	systemPrompt := codexQASystemPrompt + effortDirective(a.effort) + outputStyleDirective(a.outputVerbose) + "\n\n"
 
 	if len(history) == 0 {
 		// First turn: include the system prompt.
@@ -225,6 +228,12 @@ func (a *CodexAgent) buildPrompt(userMsg string) string {
 func (a *CodexAgent) ClearHistory() {
 	a.mu.Lock()
 	a.history = nil
+	a.mu.Unlock()
+}
+
+func (a *CodexAgent) SetOutputVerbose(verbose bool) {
+	a.mu.Lock()
+	a.outputVerbose = verbose
 	a.mu.Unlock()
 }
 

--- a/config.go
+++ b/config.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Config holds persistent user preferences for qmax-code.
@@ -58,6 +60,10 @@ type Config struct {
 	// Theme selects the terminal color scheme.
 	// Available: historic, ocean, neon, ember, aurora (dark) or paper, sky, sparkling, radiance, goldenhour (light). Empty defaults to "historic".
 	Theme string `json:"theme,omitempty"`
+
+	// OutputVerbose controls the user-facing answer style for CLI backends.
+	// false = compact terminal reports; true = previous detailed report style.
+	OutputVerbose bool `json:"output_verbose,omitempty"`
 
 	// CloudSync controls whether sessions are synced to the QualityMax cloud.
 	// nil = not asked yet (prompt fires on the next eligible session).
@@ -120,6 +126,34 @@ func (c *Config) Save() error {
 	}
 
 	return os.WriteFile(filepath.Join(dir, qmaxCodeConfigFile), data, 0600)
+}
+
+// SaveTheme persists the selected terminal color theme in the user's local
+// config file. The empty value clears the preference and restores the default.
+func (c *Config) SaveTheme(theme string) error {
+	if c == nil {
+		return fmt.Errorf("config not loaded")
+	}
+	if theme != "" {
+		valid := false
+		for _, name := range ThemeNames() {
+			if name == theme {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("invalid theme %q; available: %s", theme, strings.Join(ThemeNames(), ", "))
+		}
+	}
+
+	previous := c.Theme
+	c.Theme = theme
+	if err := c.Save(); err != nil {
+		c.Theme = previous
+		return err
+	}
+	return nil
 }
 
 func defaultConfig() *Config {

--- a/config_command.go
+++ b/config_command.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 )
 
 // handleConfigCommand implements the `qmax-code config ...` subcommand
@@ -27,6 +26,7 @@ import (
 //	default_model     → "auto", "sonnet", "opus", "haiku", or full model ID
 //	professional      → bool ("true" / "false")
 //	auto_save         → bool
+//	output_verbose    → bool (compact vs previous detailed answer style)
 //	max_token_budget  → integer
 func handleConfigCommand(args []string) {
 	if len(args) == 0 || args[0] == "show" {
@@ -80,6 +80,7 @@ func printConfig() {
 	fmt.Printf("    default_framework = %q\n", cfg.DefaultFramework)
 	fmt.Printf("    professional      = %t\n", cfg.Professional)
 	fmt.Printf("    auto_save         = %t\n", cfg.AutoSave)
+	fmt.Printf("    output_verbose    = %t\n", cfg.OutputVerbose)
 	fmt.Printf("    max_token_budget  = %d\n", cfg.MaxTokenBudget)
 	if cfg.AnthropicKey != "" {
 		fmt.Println("    anthropic_key     = (set; stored in OS keychain)")
@@ -171,6 +172,13 @@ func setConfigField(key, value string) error {
 		}
 		cfg.AutoSave = b
 
+	case "output_verbose":
+		b, err := parseConfigBool(value)
+		if err != nil {
+			return err
+		}
+		cfg.OutputVerbose = b
+
 	case "max_token_budget":
 		if value == "" {
 			cfg.MaxTokenBudget = 200000
@@ -200,20 +208,7 @@ func setConfigField(key, value string) error {
 		}
 
 	case "theme":
-		if value != "" {
-			valid := ThemeNames()
-			found := false
-			for _, n := range valid {
-				if n == value {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return fmt.Errorf("invalid theme %q; available: %s", value, strings.Join(valid, ", "))
-			}
-		}
-		cfg.Theme = value
+		return cfg.SaveTheme(value)
 
 	case "cloud_sync":
 		if value == "" {

--- a/config_command_test.go
+++ b/config_command_test.go
@@ -106,6 +106,30 @@ func TestSetConfigField_BoolForms(t *testing.T) {
 	}
 }
 
+func TestSetConfigField_OutputVerboseBoolForms(t *testing.T) {
+	withTempHome(t)
+
+	if err := setConfigField("output_verbose", "true"); err != nil {
+		t.Fatalf("set output_verbose true: %v", err)
+	}
+	loaded := LoadQMaxCodeConfig()
+	if !loaded.OutputVerbose {
+		t.Fatal("expected OutputVerbose=true")
+	}
+
+	if err := setConfigField("output_verbose", "off"); err != nil {
+		t.Fatalf("set output_verbose off: %v", err)
+	}
+	loaded = LoadQMaxCodeConfig()
+	if loaded.OutputVerbose {
+		t.Fatal("expected OutputVerbose=false")
+	}
+
+	if err := setConfigField("output_verbose", "maybe"); err == nil {
+		t.Fatal("expected error for invalid output_verbose value")
+	}
+}
+
 func TestSetConfigField_UnknownKey(t *testing.T) {
 	withTempHome(t)
 
@@ -179,6 +203,68 @@ func TestSetConfigField_ThemePersistsToDisk(t *testing.T) {
 	loaded := LoadQMaxCodeConfig()
 	if loaded.Theme != "aurora" {
 		t.Errorf("loaded.Theme = %q, want \"aurora\"", loaded.Theme)
+	}
+}
+
+func TestConfigSaveTheme_PersistsLocalSelection(t *testing.T) {
+	tmp := withTempHome(t)
+	cfg := defaultConfig()
+
+	if err := cfg.SaveTheme("radiance"); err != nil {
+		t.Fatalf("SaveTheme(\"radiance\") unexpected error: %v", err)
+	}
+
+	loaded := LoadQMaxCodeConfig()
+	if loaded.Theme != "radiance" {
+		t.Errorf("loaded.Theme = %q, want \"radiance\"", loaded.Theme)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmp, ".qmax-code", "config.json"))
+	if err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("config JSON malformed: %v", err)
+	}
+	if parsed["theme"] != "radiance" {
+		t.Errorf("file did not contain theme=radiance; got %v", parsed["theme"])
+	}
+}
+
+func TestConfigSaveTheme_RejectsInvalidWithoutOverwriting(t *testing.T) {
+	withTempHome(t)
+	cfg := defaultConfig()
+	if err := cfg.SaveTheme("ocean"); err != nil {
+		t.Fatalf("SaveTheme(\"ocean\") unexpected error: %v", err)
+	}
+
+	if err := cfg.SaveTheme("../evil"); err == nil {
+		t.Fatal("SaveTheme(\"../evil\") expected error, got nil")
+	}
+
+	loaded := LoadQMaxCodeConfig()
+	if loaded.Theme != "ocean" {
+		t.Errorf("invalid theme overwrote persisted selection: got %q, want \"ocean\"", loaded.Theme)
+	}
+	if cfg.Theme != "ocean" {
+		t.Errorf("invalid theme overwrote in-memory selection: got %q, want \"ocean\"", cfg.Theme)
+	}
+}
+
+func TestConfigSaveTheme_EmptyClearsLocalSelection(t *testing.T) {
+	withTempHome(t)
+	cfg := defaultConfig()
+	if err := cfg.SaveTheme("neon"); err != nil {
+		t.Fatalf("SaveTheme(\"neon\") unexpected error: %v", err)
+	}
+	if err := cfg.SaveTheme(""); err != nil {
+		t.Fatalf("SaveTheme(\"\") unexpected error: %v", err)
+	}
+
+	loaded := LoadQMaxCodeConfig()
+	if loaded.Theme != "" {
+		t.Errorf("loaded.Theme = %q, want empty", loaded.Theme)
 	}
 }
 

--- a/input.go
+++ b/input.go
@@ -126,12 +126,6 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.ctrlC = true
 		return m, tea.Quit
 
-	case tea.KeyCtrlO:
-		m.result = ""
-		m.done = true
-		m.outputToggle = true
-		return m, tea.Quit
-
 	case tea.KeyBackspace:
 		if m.cursor > 0 {
 			runes = append(runes[:m.cursor-1], runes[m.cursor:]...)

--- a/input.go
+++ b/input.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -162,14 +163,8 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.cursor = len(runes)
 
 	case tea.KeyCtrlW:
-		// Delete word backwards (skip trailing spaces, then delete word chars).
 		end := m.cursor
-		for m.cursor > 0 && runes[m.cursor-1] == ' ' {
-			m.cursor--
-		}
-		for m.cursor > 0 && runes[m.cursor-1] != ' ' {
-			m.cursor--
-		}
+		m.cursor = previousWordBoundary(runes, m.cursor)
 		runes = append(runes[:m.cursor], runes[end:]...)
 		m.text = string(runes)
 
@@ -254,14 +249,21 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// isWordChar matches readline's word definition: letters, digits, underscore.
+// Punctuation, slashes, dots, etc. are treated as separators so word motion
+// stops at each path segment / identifier boundary, matching bash/zsh muscle memory.
+func isWordChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}
+
 func previousWordBoundary(runes []rune, cursor int) int {
 	if cursor > len(runes) {
 		cursor = len(runes)
 	}
-	for cursor > 0 && runes[cursor-1] == ' ' {
+	for cursor > 0 && !isWordChar(runes[cursor-1]) {
 		cursor--
 	}
-	for cursor > 0 && runes[cursor-1] != ' ' {
+	for cursor > 0 && isWordChar(runes[cursor-1]) {
 		cursor--
 	}
 	return cursor
@@ -271,10 +273,10 @@ func nextWordBoundary(runes []rune, cursor int) int {
 	if cursor < 0 {
 		cursor = 0
 	}
-	for cursor < len(runes) && runes[cursor] != ' ' {
+	for cursor < len(runes) && isWordChar(runes[cursor]) {
 		cursor++
 	}
-	for cursor < len(runes) && runes[cursor] == ' ' {
+	for cursor < len(runes) && !isWordChar(runes[cursor]) {
 		cursor++
 	}
 	return cursor

--- a/input.go
+++ b/input.go
@@ -52,30 +52,39 @@ const (
 
 // inputModel is a bubbletea model that handles text input + slash menu.
 type inputModel struct {
-	mode    inputMode
-	text    string
-	cursor  int // cursor position in runes
-	width   int // terminal width; 0 = not yet known
-	menu    int // selected menu index
-	filter  string
-	result  string // final submitted text
-	done    bool
-	ctrlC   bool // true if exited via Ctrl+C
-	prompt  string
-	history []string
-	histIdx int
+	mode          inputMode
+	text          string
+	cursor        int // cursor position in runes
+	width         int // terminal width; 0 = not yet known
+	menu          int // selected menu index
+	filter        string
+	result        string // final submitted text
+	done          bool
+	ctrlC         bool // true if exited via Ctrl+C
+	pasted        bool
+	outputToggle  bool
+	outputVerbose bool
+	clearPresses  int
+	prompt        string
+	history       []string
+	histIdx       int
 }
 
 func newInputModel(prompt string, history []string) inputModel {
+	return newInputModelWithOutputMode(prompt, history, false)
+}
+
+func newInputModelWithOutputMode(prompt string, history []string, outputVerbose bool) inputModel {
 	w := 80 // sensible fallback
 	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && width > 0 {
 		w = width
 	}
 	return inputModel{
-		prompt:  prompt,
-		history: history,
-		histIdx: -1,
-		width:   w,
+		prompt:        prompt,
+		history:       history,
+		histIdx:       -1,
+		width:         w,
+		outputVerbose: outputVerbose,
 	}
 }
 
@@ -87,6 +96,12 @@ func (m inputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		return m, nil
 	case tea.KeyMsg:
+		if msg.Type == tea.KeyCtrlO {
+			m.result = ""
+			m.done = true
+			m.outputToggle = true
+			return m, tea.Quit
+		}
 		if m.mode == modeMenu {
 			return m.updateMenu(msg)
 		}
@@ -97,6 +112,7 @@ func (m inputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	runes := []rune(m.text)
+	resetClearPresses := true
 
 	switch msg.Type {
 	case tea.KeyEnter:
@@ -108,6 +124,12 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.result = ""
 		m.done = true
 		m.ctrlC = true
+		return m, tea.Quit
+
+	case tea.KeyCtrlO:
+		m.result = ""
+		m.done = true
+		m.outputToggle = true
 		return m, tea.Quit
 
 	case tea.KeyBackspace:
@@ -132,6 +154,12 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.cursor < len(runes) {
 			m.cursor++
 		}
+
+	case tea.KeyCtrlLeft:
+		m.cursor = previousWordBoundary(runes, m.cursor)
+
+	case tea.KeyCtrlRight:
+		m.cursor = nextWordBoundary(runes, m.cursor)
 
 	case tea.KeyCtrlA:
 		m.cursor = 0
@@ -158,6 +186,17 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyCtrlK:
 		m.text = string(runes[:m.cursor])
 
+	case tea.KeyCtrlX:
+		resetClearPresses = false
+		if len(runes) > 0 {
+			m.clearPresses++
+			if m.clearPresses >= 3 {
+				m.text = ""
+				m.cursor = 0
+				m.clearPresses = 0
+			}
+		}
+
 	case tea.KeyUp:
 		if len(m.history) > 0 {
 			if m.histIdx < len(m.history)-1 {
@@ -179,6 +218,9 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.KeyRunes:
+		if msg.Paste {
+			m.pasted = true
+		}
 		ch := string(msg.Runes)
 		// Typing "/" on an empty line opens the slash menu.
 		if ch == "/" && m.text == "" {
@@ -211,8 +253,37 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.Type != tea.KeyUp && msg.Type != tea.KeyDown {
 		m.histIdx = -1
 	}
+	if resetClearPresses {
+		m.clearPresses = 0
+	}
 
 	return m, nil
+}
+
+func previousWordBoundary(runes []rune, cursor int) int {
+	if cursor > len(runes) {
+		cursor = len(runes)
+	}
+	for cursor > 0 && runes[cursor-1] == ' ' {
+		cursor--
+	}
+	for cursor > 0 && runes[cursor-1] != ' ' {
+		cursor--
+	}
+	return cursor
+}
+
+func nextWordBoundary(runes []rune, cursor int) int {
+	if cursor < 0 {
+		cursor = 0
+	}
+	for cursor < len(runes) && runes[cursor] != ' ' {
+		cursor++
+	}
+	for cursor < len(runes) && runes[cursor] == ' ' {
+		cursor++
+	}
+	return cursor
 }
 
 func (m inputModel) updateMenu(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -330,6 +401,13 @@ func (m inputModel) View() string {
 				col++
 			}
 		}
+
+		mode := "compact"
+		if m.outputVerbose {
+			mode = "verbose"
+		}
+		b.WriteString("\n")
+		b.WriteString(menuHintStyle.Render(fmt.Sprintf("  Ctrl+O output: %s • Ctrl+X×3 clear • Ctrl+←/→ words • Ctrl+C cancel • / commands", mode)))
 	} else {
 		// Menu mode
 		b.WriteString(m.prompt)
@@ -364,13 +442,15 @@ func (m inputModel) View() string {
 
 // InputResult holds the result of a ReadInput call.
 type InputResult struct {
-	Text  string
-	CtrlC bool
+	Text         string
+	CtrlC        bool
+	Pasted       bool
+	OutputToggle bool
 }
 
 // ReadInput runs the bubbletea input widget and returns the submitted text.
-func ReadInput(prompt string, history []string) InputResult {
-	m := newInputModel(prompt, history)
+func ReadInput(prompt string, history []string, outputVerbose bool) InputResult {
+	m := newInputModelWithOutputMode(prompt, history, outputVerbose)
 	p := tea.NewProgram(m)
 	result, err := p.Run()
 	if err != nil {
@@ -378,7 +458,9 @@ func ReadInput(prompt string, history []string) InputResult {
 	}
 	final := result.(inputModel)
 	return InputResult{
-		Text:  final.result,
-		CtrlC: final.ctrlC,
+		Text:         final.result,
+		CtrlC:        final.ctrlC,
+		Pasted:       final.pasted,
+		OutputToggle: final.outputToggle,
 	}
 }

--- a/input_test.go
+++ b/input_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func applyInputKey(t *testing.T, m inputModel, msg tea.KeyMsg) inputModel {
+	t.Helper()
+	updated, _ := m.updateTyping(msg)
+	next, ok := updated.(inputModel)
+	if !ok {
+		t.Fatalf("updateTyping returned %T, want inputModel", updated)
+	}
+	return next
+}
+
+func TestInputCtrlArrowsMoveByWord(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m.text = "alpha beta  gamma"
+	m.cursor = len([]rune(m.text))
+
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlLeft})
+	if got, want := m.cursor, len([]rune("alpha beta  ")); got != want {
+		t.Fatalf("ctrl+left cursor = %d, want %d", got, want)
+	}
+
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlLeft})
+	if got, want := m.cursor, len([]rune("alpha ")); got != want {
+		t.Fatalf("second ctrl+left cursor = %d, want %d", got, want)
+	}
+
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlRight})
+	if got, want := m.cursor, len([]rune("alpha beta  ")); got != want {
+		t.Fatalf("ctrl+right cursor = %d, want %d", got, want)
+	}
+}
+
+func TestInputCtrlXTripleClearsLine(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m.text = "clear this input"
+	m.cursor = len([]rune(m.text))
+
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlX})
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlX})
+	if m.text == "" {
+		t.Fatal("line cleared before third ctrl+x")
+	}
+
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlX})
+	if m.text != "" || m.cursor != 0 {
+		t.Fatalf("triple ctrl+x should clear line, got text=%q cursor=%d", m.text, m.cursor)
+	}
+}
+
+func TestInputCtrlOTogglesOutputMode(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m.text = "keep this draft"
+	m.cursor = len([]rune(m.text))
+
+	updated, cmd := m.updateTyping(tea.KeyMsg{Type: tea.KeyCtrlO})
+	next, ok := updated.(inputModel)
+	if !ok {
+		t.Fatalf("updateTyping returned %T, want inputModel", updated)
+	}
+	if cmd == nil {
+		t.Fatal("ctrl+o should quit input so the REPL can toggle output mode")
+	}
+	if !next.done || !next.outputToggle {
+		t.Fatalf("ctrl+o done=%v outputToggle=%v, want both true", next.done, next.outputToggle)
+	}
+	if next.result != "" || next.ctrlC {
+		t.Fatalf("ctrl+o should not submit text or mark ctrl-c, result=%q ctrlC=%v", next.result, next.ctrlC)
+	}
+}
+
+func TestInputCtrlXClearStreakResets(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m.text = "keep text"
+	m.cursor = len([]rune(m.text))
+
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlX})
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("!")})
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlX})
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlX})
+	if m.text == "" {
+		t.Fatal("non-ctrl+x key did not reset clear streak")
+	}
+}
+
+func TestInputFooterShowsOutputModeAndHotkeys(t *testing.T) {
+	m := newInputModelWithOutputMode("qmax > ", nil, true)
+	view := m.View()
+
+	for _, want := range []string{"Ctrl+O output: verbose", "Ctrl+X×3 clear", "Ctrl+←/→ words"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("input footer missing %q in %q", want, view)
+		}
+	}
+}
+
+func TestInputMarksBracketedPaste(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("large pasted body"), Paste: true})
+
+	if !m.pasted {
+		t.Fatal("paste flag was not recorded")
+	}
+	if !strings.Contains(m.text, "large pasted body") {
+		t.Fatalf("pasted text not inserted, got %q", m.text)
+	}
+}

--- a/input_test.go
+++ b/input_test.go
@@ -60,10 +60,10 @@ func TestInputCtrlOTogglesOutputMode(t *testing.T) {
 	m.text = "keep this draft"
 	m.cursor = len([]rune(m.text))
 
-	updated, cmd := m.updateTyping(tea.KeyMsg{Type: tea.KeyCtrlO})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
 	next, ok := updated.(inputModel)
 	if !ok {
-		t.Fatalf("updateTyping returned %T, want inputModel", updated)
+		t.Fatalf("Update returned %T, want inputModel", updated)
 	}
 	if cmd == nil {
 		t.Fatal("ctrl+o should quit input so the REPL can toggle output mode")
@@ -73,6 +73,23 @@ func TestInputCtrlOTogglesOutputMode(t *testing.T) {
 	}
 	if next.result != "" || next.ctrlC {
 		t.Fatalf("ctrl+o should not submit text or mark ctrl-c, result=%q ctrlC=%v", next.result, next.ctrlC)
+	}
+}
+
+func TestInputCtrlOTogglesFromMenuMode(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m.mode = modeMenu
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlO})
+	next, ok := updated.(inputModel)
+	if !ok {
+		t.Fatalf("Update returned %T, want inputModel", updated)
+	}
+	if cmd == nil {
+		t.Fatal("ctrl+o from menu mode should quit input")
+	}
+	if !next.done || !next.outputToggle {
+		t.Fatalf("ctrl+o from menu mode done=%v outputToggle=%v, want both true", next.done, next.outputToggle)
 	}
 }
 

--- a/input_test.go
+++ b/input_test.go
@@ -38,6 +38,36 @@ func TestInputCtrlArrowsMoveByWord(t *testing.T) {
 	}
 }
 
+func TestInputCtrlArrowsStopOnPunctuation(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m.text = "src/foo/bar.go"
+	m.cursor = len([]rune(m.text))
+
+	want := []int{
+		len([]rune("src/foo/bar.")),
+		len([]rune("src/foo/")),
+		len([]rune("src/")),
+		0,
+	}
+	for i, w := range want {
+		m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlLeft})
+		if m.cursor != w {
+			t.Fatalf("ctrl+left step %d: cursor = %d, want %d", i+1, m.cursor, w)
+		}
+	}
+}
+
+func TestInputCtrlWDeletesPathSegment(t *testing.T) {
+	m := newInputModel("qmax > ", nil)
+	m.text = "src/foo/bar.go"
+	m.cursor = len([]rune(m.text))
+
+	m = applyInputKey(t, m, tea.KeyMsg{Type: tea.KeyCtrlW})
+	if m.text != "src/foo/bar." {
+		t.Fatalf("ctrl+w on path: text = %q, want %q", m.text, "src/foo/bar.")
+	}
+}
+
 func TestInputCtrlXTripleClearsLine(t *testing.T) {
 	m := newInputModel("qmax > ", nil)
 	m.text = "clear this input"

--- a/main.go
+++ b/main.go
@@ -971,8 +971,8 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				term.PrintError(fmt.Sprintf("Could not save pasted_file: %v", err))
 				continue
 			}
-			term.PrintSystem(fmt.Sprintf("Large paste saved as pasted_file: %s (%d bytes)", path, len([]byte(input))))
-			input = pastedFilePrompt(path, len([]byte(input)))
+			term.PrintSystem(fmt.Sprintf("Large paste saved as pasted_file: %s (%d bytes)", path, len(input)))
+			input = pastedFilePrompt(path, len(input))
 			if len(inputHistory) > 0 {
 				inputHistory[len(inputHistory)-1] = input
 			}

--- a/main.go
+++ b/main.go
@@ -289,13 +289,14 @@ func main() {
 	}
 
 	agent := NewAgent(AgentConfig{
-		AnthropicKey: anthropicKey,
-		Model:        baseModel,
-		ChatModel:    chatModel,
-		Verbose:      *verbose,
-		Context:      ctx,
-		AutoRoute:    autoRoute,
-		Professional: appConfig.Professional,
+		AnthropicKey:  anthropicKey,
+		Model:         baseModel,
+		ChatModel:     chatModel,
+		Verbose:       *verbose,
+		OutputVerbose: appConfig.OutputVerbose,
+		Context:       ctx,
+		AutoRoute:     autoRoute,
+		Professional:  appConfig.Professional,
 	})
 	agent.appConfig = appConfig
 	agent.ollama = NewOllamaClient(appConfig)
@@ -313,14 +314,14 @@ func main() {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
 			}
 		}
-		cliAgent = NewCCAgent(FindClaudeCode(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, ctx)
+		cliAgent = NewCCAgent(FindClaudeCode(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, appConfig.OutputVerbose, ctx)
 	case "codex":
 		if appConfig.OrchGlobalInstall && !IsOrchSetupDone("codex") {
 			if res, err := SetupCodexIntegration(); err == nil && !res.AlreadyHadMCP {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
 			}
 		}
-		ca := NewCodexAgent(FindCodex(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, ctx)
+		ca := NewCodexAgent(FindCodex(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, appConfig.OutputVerbose, ctx)
 		if err := ca.writeMCPConfig(); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not write Codex MCP config: %v\n", err)
 		}
@@ -515,6 +516,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 
 	for {
 		var input string
+		inputWasPasted := false
 
 		// Drain the prompt queue before blocking on interactive input.
 		// This processes prompts the user typed while the agent was running.
@@ -530,7 +532,12 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			fmt.Println()
 			inputHistory = append(inputHistory, input)
 		} else {
-			result := ReadInput(term.currentPrompt, inputHistory)
+			result := ReadInput(term.currentPrompt, inputHistory, agent.config.OutputVerbose)
+
+			if result.OutputToggle {
+				toggleOutputVerbose(agent, cliAgent, term)
+				continue
+			}
 
 			// Handle Ctrl+C: double-tap within 1s exits
 			if result.CtrlC {
@@ -548,6 +555,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			if input == "" {
 				continue
 			}
+			inputWasPasted = result.Pasted
 			inputHistory = append(inputHistory, input)
 		}
 
@@ -760,10 +768,10 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			// Spin up the new agent with selected model + effort.
 			switch result.Backend {
 			case "cc":
-				cliAgent = NewCCAgent(FindClaudeCode(), result.ModelID, result.Effort, cfg.OrchPermissionMode, agent.config.Context)
+				cliAgent = NewCCAgent(FindClaudeCode(), result.ModelID, result.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, agent.config.Context)
 				term.PrintSystem(fmt.Sprintf("Backend: Claude Code  model: %s  effort: %s", result.ModelID, result.Effort))
 			case "codex":
-				ca := NewCodexAgent(FindCodex(), result.ModelID, result.Effort, cfg.OrchPermissionMode, agent.config.Context)
+				ca := NewCodexAgent(FindCodex(), result.ModelID, result.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, agent.config.Context)
 				if err := ca.writeMCPConfig(); err != nil {
 					term.PrintSystem(fmt.Sprintf("Warning: Codex MCP config: %v", err))
 				}
@@ -790,11 +798,10 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			if !ok {
 				continue
 			}
-			cfg.Theme = chosen
-			ApplyTheme(ThemeByName(chosen))
-			if err := cfg.Save(); err != nil {
+			if err := cfg.SaveTheme(chosen); err != nil {
 				term.PrintError(fmt.Sprintf("Failed to save config: %v", err))
 			} else {
+				ApplyTheme(ThemeByName(chosen))
 				term.PrintSystem(fmt.Sprintf("Theme set to: %s", chosen))
 			}
 			continue
@@ -846,7 +853,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				if consent.GlobalInstall && !IsOrchSetupDone("cc") {
 					RunOrchSetup("cc", term)
 				}
-				cliAgent = NewCCAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, agent.config.Context)
+				cliAgent = NewCCAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, agent.config.Context)
 				cfg.Backend = "cc"
 				_ = cfg.Save()
 				term.PrintSystem(fmt.Sprintf("Backend → Claude Code (%s) · %s mode", bin, cfg.OrchPermissionMode))
@@ -868,7 +875,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				if consent.GlobalInstall && !IsOrchSetupDone("codex") {
 					RunOrchSetup("codex", term)
 				}
-				ca := NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, agent.config.Context)
+				ca := NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, agent.config.Context)
 				if err := ca.writeMCPConfig(); err != nil {
 					term.PrintSystem(fmt.Sprintf("Warning: MCP config: %v", err))
 				}
@@ -955,6 +962,20 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			}
 			term.PrintSystem(fmt.Sprintf("Pasted %d chars from clipboard", len(text)))
 			input = text // fall through to normal processing
+			inputWasPasted = true
+		}
+
+		if isLargePastedText(input, inputWasPasted) {
+			path, err := savePastedTextFile(input)
+			if err != nil {
+				term.PrintError(fmt.Sprintf("Could not save pasted_file: %v", err))
+				continue
+			}
+			term.PrintSystem(fmt.Sprintf("Large paste saved as pasted_file: %s (%d bytes)", path, len([]byte(input))))
+			input = pastedFilePrompt(path, len([]byte(input)))
+			if len(inputHistory) > 0 {
+				inputHistory[len(inputHistory)-1] = input
+			}
 		}
 
 		// Detect image file paths dragged/pasted into input
@@ -1106,6 +1127,32 @@ func handleDisconnect(agent *Agent, term *Terminal) {
 	term.PrintSystem("Run /connect to log in again.")
 }
 
+func toggleOutputVerbose(agent *Agent, cliAgent CLIAgent, term *Terminal) {
+	if agent == nil {
+		return
+	}
+	cfg := agent.appConfig
+	if cfg == nil {
+		cfg = defaultConfig()
+		agent.appConfig = cfg
+	}
+	cfg.OutputVerbose = !cfg.OutputVerbose
+	agent.config.OutputVerbose = cfg.OutputVerbose
+	if cliAgent != nil {
+		cliAgent.SetOutputVerbose(cfg.OutputVerbose)
+	}
+
+	mode := "compact"
+	if cfg.OutputVerbose {
+		mode = "verbose"
+	}
+	if err := cfg.Save(); err != nil {
+		term.PrintError(fmt.Sprintf("Output mode changed to %s but could not save config: %v", mode, err))
+		return
+	}
+	term.PrintSystem(fmt.Sprintf("Output mode: %s (Ctrl+O toggles)", mode))
+}
+
 // handleKeys provides an interactive TUI for managing API keys.
 func handleKeys(agent *Agent, term *Terminal) {
 	fmt.Println()
@@ -1182,6 +1229,8 @@ Commands:
   /codex         Switch to Codex CLI backend (OpenAI subscription, no API tokens)
   /api           Switch back to direct Anthropic API
   /ollama        Toggle Ollama on/off (self-hosted LLM for chat)
+  /set output_verbose true|false
+                 Toggle compact vs detailed Codex/CC answers
   /config        Show current config settings
   /keys          Set API keys (interactive menu)
   /screenshot    Capture a screenshot and analyze it
@@ -1216,6 +1265,9 @@ Queue:
 
 Shortcuts:
   Ctrl+C         Cancel current operation (double-tap to exit)
+  Ctrl+O         Toggle compact/verbose agent output
+  Ctrl+X x3      Clear the whole input line
+  Ctrl+←/→       Move by word
 
 Models (--model flag):
   auto            Smart routing: haiku for chat, sonnet for tools (default)
@@ -1246,6 +1298,11 @@ func printConfigInfo(cfg *Config, term *Terminal) {
 	fmt.Printf("  %-20s %d\n", "Default project:", cfg.DefaultProject)
 	fmt.Printf("  %-20s %v\n", "Professional:", cfg.Professional)
 	fmt.Printf("  %-20s %v\n", "Auto-save:", cfg.AutoSave)
+	outputMode := "compact"
+	if cfg.OutputVerbose {
+		outputMode = "verbose"
+	}
+	fmt.Printf("  %-20s %s\n", "Output mode:", outputMode)
 	cloudSyncVal := "not set (will prompt)"
 	if cfg.CloudSync != nil {
 		if *cfg.CloudSync {
@@ -1269,7 +1326,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 	parts := strings.Fields(input)
 	if len(parts) < 3 {
 		term.PrintError("Usage: /set <key> <value>")
-		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, budget, apikey, ollama, backend, theme")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, output_verbose, budget, apikey, ollama, backend, theme")
 		return
 	}
 	key := strings.ToLower(parts[1])
@@ -1325,6 +1382,21 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 			term.PrintSystem("Auto-save disabled.")
 		default:
 			term.PrintError("Value must be true or false.")
+			return
+		}
+
+	case "output_verbose", "output-verbose", "output":
+		switch strings.ToLower(value) {
+		case "true", "1", "yes", "on", "verbose":
+			cfg.OutputVerbose = true
+			agent.config.OutputVerbose = true
+			term.PrintSystem("Output mode set to verbose.")
+		case "false", "0", "no", "off", "compact":
+			cfg.OutputVerbose = false
+			agent.config.OutputVerbose = false
+			term.PrintSystem("Output mode set to compact.")
+		default:
+			term.PrintError("Value must be compact/verbose or true/false.")
 			return
 		}
 
@@ -1443,7 +1515,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 
 	default:
 		term.PrintError(fmt.Sprintf("Unknown config key: %s", key))
-		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, budget, apikey, ollama, backend, theme")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, output_verbose, budget, apikey, ollama, backend, theme")
 		return
 	}
 

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -46,18 +46,31 @@ func RunMCPServer() {
 			continue
 		}
 
-		var req mcpRequest
-		if err := json.Unmarshal(line, &req); err != nil {
-			continue
+		if resp, ok := handleMCPLine(line, sctx); ok {
+			_ = encoder.Encode(resp)
 		}
-
-		// JSON-RPC notifications have no id and require no response.
-		if req.ID == nil {
-			continue
-		}
-
-		_ = encoder.Encode(dispatchMCPRequest(req, sctx))
 	}
+}
+
+func handleMCPLine(line []byte, sctx *SessionContext) (mcpResponse, bool) {
+	var req mcpRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		return mcpErr(nil, -32700, "parse error"), true
+	}
+
+	// JSON-RPC notifications have no id and require no response.
+	if req.ID == nil {
+		return mcpResponse{}, false
+	}
+
+	if req.JSONRPC != "2.0" {
+		return mcpErr(req.ID, -32600, "invalid request: jsonrpc must be 2.0"), true
+	}
+	if req.Method == "" {
+		return mcpErr(req.ID, -32600, "invalid request: method is required"), true
+	}
+
+	return dispatchMCPRequest(req, sctx), true
 }
 
 // --- JSON-RPC / MCP types ---
@@ -71,7 +84,7 @@ type mcpRequest struct {
 
 type mcpResponse struct {
 	JSONRPC string      `json:"jsonrpc"`
-	ID      interface{} `json:"id,omitempty"`
+	ID      interface{} `json:"id"`
 	Result  interface{} `json:"result,omitempty"`
 	Error   *mcpRPCErr  `json:"error,omitempty"`
 }

--- a/mcp_server_test.go
+++ b/mcp_server_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestHandleMCPLineReturnsParseErrorForMalformedJSON(t *testing.T) {
+	resp, ok := handleMCPLine([]byte("Reading additional input from stdin..."), &SessionContext{})
+	if !ok {
+		t.Fatal("malformed request should produce a JSON-RPC error response")
+	}
+	if resp.JSONRPC != "2.0" || resp.Error == nil {
+		t.Fatalf("response = %+v, want JSON-RPC error", resp)
+	}
+	if resp.Error.Code != -32700 {
+		t.Fatalf("error code = %d, want -32700", resp.Error.Code)
+	}
+}
+
+func TestHandleMCPLineIgnoresNotifications(t *testing.T) {
+	_, ok := handleMCPLine([]byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`), &SessionContext{})
+	if ok {
+		t.Fatal("notification should not produce a response")
+	}
+}
+
+func TestHandleMCPLineRejectsInvalidJSONRPCVersion(t *testing.T) {
+	resp, ok := handleMCPLine([]byte(`{"jsonrpc":"1.0","id":1,"method":"tools/list"}`), &SessionContext{})
+	if !ok {
+		t.Fatal("invalid request should produce a response")
+	}
+	if resp.Error == nil || resp.Error.Code != -32600 {
+		t.Fatalf("response = %+v, want invalid request error", resp)
+	}
+}

--- a/media.go
+++ b/media.go
@@ -101,7 +101,7 @@ func PasteTextFromClipboard() (string, error) {
 }
 
 func isLargePastedText(text string, pasted bool) bool {
-	return pasted && len([]byte(text)) >= largePastedTextThreshold
+	return pasted && len(text) >= largePastedTextThreshold
 }
 
 func savePastedTextFile(text string) (string, error) {

--- a/media.go
+++ b/media.go
@@ -7,7 +7,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const largePastedTextThreshold = 8 * 1024
 
 // imageExtensions maps file extensions to MIME types.
 var imageExtensions = map[string]string{
@@ -95,6 +98,31 @@ func PasteTextFromClipboard() (string, error) {
 		return "", fmt.Errorf("clipboard read failed: %w", err)
 	}
 	return string(out), nil
+}
+
+func isLargePastedText(text string, pasted bool) bool {
+	return pasted && len([]byte(text)) >= largePastedTextThreshold
+}
+
+func savePastedTextFile(text string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, qmaxCodeConfigDir, "pastes")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("pasted_file_%s.txt", time.Now().UTC().Format("20060102T150405.000000000Z"))
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(text), 0600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func pastedFilePrompt(path string, size int) string {
+	return fmt.Sprintf("A large text paste was saved as pasted_file. Read and use this local file: %s (%d bytes).", path, size)
 }
 
 // DetectAndLoadImages checks if the input contains file paths to images.

--- a/media_test.go
+++ b/media_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLargePastedTextDetectionRequiresPaste(t *testing.T) {
+	large := strings.Repeat("x", largePastedTextThreshold)
+	if !isLargePastedText(large, true) {
+		t.Fatal("large bracketed paste should be treated as pasted_file")
+	}
+	if isLargePastedText(large, false) {
+		t.Fatal("large typed input should not be treated as pasted_file")
+	}
+	if isLargePastedText("small paste", true) {
+		t.Fatal("small paste should remain inline")
+	}
+}
+
+func TestSavePastedTextFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := savePastedTextFile("sensitive pasted body")
+	if err != nil {
+		t.Fatalf("savePastedTextFile: %v", err)
+	}
+	if !strings.Contains(path, "pasted_file_") {
+		t.Fatalf("path %q does not use pasted_file naming", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pasted file: %v", err)
+	}
+	if string(data) != "sensitive pasted body" {
+		t.Fatalf("file content = %q", string(data))
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat pasted file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("file mode = %o, want 0600", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add footer and handlers for Ctrl+O output mode toggle, Ctrl+X triple-clear, and Ctrl+Left/Ctrl+Right word navigation
- persist theme changes through SaveTheme and add output_verbose config/set support for compact vs verbose CLI responses
- harden MCP JSON-RPC line handling and prevent CLI backends from consuming stdin banner/input
- save large bracketed pastes as local pasted_file references and add focused coverage for paste handling

## Verification
- gofmt on touched Go files
- git diff --check
- go test ./...

## Coverage
- happy path: hotkey behavior, theme persistence, output mode config, MCP notifications
- error paths: invalid theme rejection, invalid output_verbose values, malformed MCP JSON, invalid JSON-RPC versions
- boundary conditions: Ctrl+X streak reset, large paste threshold, file permissions for saved paste files
- state transitions: compact/verbose toggle propagation to active CLI agents and persisted config

## Remaining Risk
- Manual interactive restart verification for /theme persistence is still the highest-value smoke check after CI because it exercises the actual terminal lifecycle and local config file.
