### PR TITLE
fix(sessions): upload to /events with payload, add /cloudsync TUI toggle

### DIFF
--- a/api_client.go
+++ b/api_client.go
@@ -409,15 +409,29 @@ const maxSessionUploadBytes = 4 * 1024 * 1024 // 4 MiB
 // Called alongside CompleteAgentSession so the cloud has complete context for
 // cross-session recall. If the payload exceeds maxSessionUploadBytes, older
 // messages are trimmed. Errors are silently dropped.
+//
+// The server exposes a generic /events endpoint with a discriminated-union body:
+//
+//	{"events": [{"type": "message", "payload": <Message>}, ...]}
+//
+// Valid event types per the server enum: file_edit, message, shell_cmd,
+// test_result, tool_call — we only emit "message" here. The body must use the
+// key "payload" (not "data"); other keys are silently dropped server-side and
+// the event lands with payload={}.
 func (c *APIClient) UploadSessionMessages(ctx context.Context, cloudID string, messages []Message) {
 	if len(messages) == 0 {
 		return
 	}
 	msgs := trimMessagesToFit(messages, maxSessionUploadBytes)
-	body := map[string]interface{}{
-		"messages": msgs,
+	events := make([]map[string]interface{}, 0, len(msgs))
+	for _, m := range msgs {
+		events = append(events, map[string]interface{}{
+			"type":    "message",
+			"payload": m,
+		})
 	}
-	c.post(ctx, "/api/agent-sessions/"+cloudID+"/messages", body)
+	body := map[string]interface{}{"events": events}
+	c.post(ctx, "/api/agent-sessions/"+cloudID+"/events", body)
 }
 
 // trimMessagesToFit drops oldest messages until the JSON-encoded payload fits

--- a/api_client_agent_session_test.go
+++ b/api_client_agent_session_test.go
@@ -186,7 +186,7 @@ func TestUploadSessionMessages_PostsToCorrectEndpoint(t *testing.T) {
 		gotPath = r.URL.Path
 		raw, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(raw, &gotBody)
-		_, _ = w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{"appended":2}`))
 	})
 
 	msgs := []Message{
@@ -198,11 +198,42 @@ func TestUploadSessionMessages_PostsToCorrectEndpoint(t *testing.T) {
 	if gotMethod != "POST" {
 		t.Errorf("method: got %q, want POST", gotMethod)
 	}
-	if gotPath != "/api/agent-sessions/sess-123/messages" {
-		t.Errorf("path: got %q", gotPath)
+	// Server exposes /events, not /messages. The 405 from /messages is the bug
+	// this test now guards against.
+	if gotPath != "/api/agent-sessions/sess-123/events" {
+		t.Errorf("path: got %q, want /api/agent-sessions/sess-123/events", gotPath)
 	}
-	if gotBody["messages"] == nil {
-		t.Error("body missing 'messages' key")
+	events, ok := gotBody["events"].([]interface{})
+	if !ok {
+		t.Fatalf("body missing 'events' array: %+v", gotBody)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	for i, ev := range events {
+		m, ok := ev.(map[string]interface{})
+		if !ok {
+			t.Fatalf("event %d not an object: %v", i, ev)
+		}
+		if m["type"] != "message" {
+			t.Errorf("event %d type: got %v, want \"message\"", i, m["type"])
+		}
+		// Server stores message bodies under "payload" — using "data" silently
+		// drops the content (event lands with payload={}). Guard against regression.
+		payload, ok := m["payload"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("event %d missing payload object: %v", i, m)
+		}
+		if payload["role"] == nil || payload["content"] == nil {
+			t.Errorf("event %d payload missing role/content: %v", i, payload)
+		}
+		if _, hasData := m["data"]; hasData {
+			t.Errorf("event %d should not use 'data' key (server expects 'payload'): %v", i, m)
+		}
+	}
+	first := events[0].(map[string]interface{})["payload"].(map[string]interface{})
+	if first["role"] != "user" || first["content"] != "hello" {
+		t.Errorf("first event payload mismatch: %+v", first)
 	}
 }
 

--- a/cloud_session_test.go
+++ b/cloud_session_test.go
@@ -269,8 +269,8 @@ func TestCloudTracker_Complete_UploadsMessages(t *testing.T) {
 	if methods[1] != "POST" {
 		t.Errorf("second call: got %s, want POST", methods[1])
 	}
-	if paths[1] != "/api/agent-sessions/cloud-xyz/messages" {
-		t.Errorf("messages path: got %q, want /api/agent-sessions/cloud-xyz/messages", paths[1])
+	if paths[1] != "/api/agent-sessions/cloud-xyz/events" {
+		t.Errorf("messages path: got %q, want /api/agent-sessions/cloud-xyz/events", paths[1])
 	}
 }
 

--- a/input.go
+++ b/input.go
@@ -21,6 +21,7 @@ var slashMenuItems = []SlashMenuItem{
 	{"/help", "Show help"},
 	{"/orch", "Model + effort picker (CC / Codex / API)"},
 	{"/theme", "Live-preview color scheme picker"},
+	{"/cloudsync", "Toggle cloud session sync (enabled/disabled)"},
 	{"/cc", "Switch to Claude Code backend"},
 	{"/codex", "Switch to Codex CLI backend"},
 	{"/api", "Switch to direct Anthropic API"},

--- a/main.go
+++ b/main.go
@@ -806,6 +806,31 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			}
 			continue
 
+		case input == "/cloudsync":
+			cfg := agent.appConfig
+			if cfg == nil {
+				term.PrintError("Config not loaded.")
+				continue
+			}
+			enabled, ok := ShowCloudSyncPicker(cfg.CloudSync)
+			if !ok {
+				continue
+			}
+			v := enabled
+			cfg.CloudSync = &v
+			if err := cfg.Save(); err != nil {
+				term.PrintError(fmt.Sprintf("Failed to save config: %v", err))
+				continue
+			}
+			if enabled {
+				term.PrintSystem("Cloud session sync enabled.")
+				// Open the cloud session immediately so the rest of this run is tracked.
+				startCloudSession()
+			} else {
+				term.PrintSystem("Cloud session sync disabled.")
+			}
+			continue
+
 		case input == "/cc", input == "/codex", input == "/api":
 			// Instant backend switching — no restart needed.
 			cfg := agent.appConfig
@@ -1225,6 +1250,7 @@ Commands:
   /cost          Show session token usage and estimated cost
   /orch          Cycle orchestration backend: off → CC → Codex → off
   /theme         Live-preview color scheme picker
+  /cloudsync     Toggle cloud session sync (enabled/disabled)
   /cc            Switch to Claude Code backend (CC subscription, no API tokens)
   /codex         Switch to Codex CLI backend (OpenAI subscription, no API tokens)
   /api           Switch back to direct Anthropic API

--- a/tui_backend.go
+++ b/tui_backend.go
@@ -866,3 +866,121 @@ func ShowSessionPicker(sessions []SessionSummary, activeID string) (string, bool
 	}
 	return final.sessions[final.cursor].ID, true
 }
+
+// ─── Cloud-sync toggle ────────────────────────────────────────────────────────
+
+type cloudSyncPickerModel struct {
+	cursor    int  // 0 = enabled, 1 = disabled
+	current   bool // current value (true = enabled)
+	hasValue  bool // false when CloudSync is unset (never asked)
+	confirmed bool
+	cancelled bool
+}
+
+func newCloudSyncPickerModel(current *bool) cloudSyncPickerModel {
+	m := cloudSyncPickerModel{}
+	if current != nil {
+		m.hasValue = true
+		m.current = *current
+		if *current {
+			m.cursor = 0
+		} else {
+			m.cursor = 1
+		}
+	}
+	return m
+}
+
+func (m cloudSyncPickerModel) Init() tea.Cmd { return nil }
+
+func (m cloudSyncPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		switch k.String() {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < 1 {
+				m.cursor++
+			}
+		case "enter", " ":
+			m.confirmed = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m cloudSyncPickerModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(pickerSectionHeader.Render("Cloud session sync"))
+	b.WriteByte('\n')
+
+	rows := []struct {
+		label string
+		desc  string
+		value bool
+	}{
+		{"Enabled", "Sync sessions to QualityMax cloud", true},
+		{"Disabled", "Keep sessions on this machine only", false},
+	}
+
+	for i, r := range rows {
+		isCursor := i == m.cursor
+
+		arrow := "  "
+		if isCursor {
+			arrow = pickerBadgeStar.Render("▶ ")
+		}
+
+		var label string
+		if isCursor {
+			label = pickerLabelSel.Render(fmt.Sprintf("%-9s", r.label))
+		} else {
+			label = pickerLabel.Render(fmt.Sprintf("%-9s", r.label))
+		}
+
+		check := ""
+		if m.hasValue && r.value == m.current {
+			check = "  " + pickerBadgeCurrent.Render("✓ current")
+		}
+
+		desc := pickerFooter.Render(r.desc)
+		row := fmt.Sprintf("%s%s  %s%s", arrow, label, desc, check)
+		if isCursor {
+			b.WriteString(pickerRowSelected.Render(row))
+		} else {
+			b.WriteString(pickerRowNormal.Render(row))
+		}
+		b.WriteByte('\n')
+	}
+
+	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+	b.WriteByte('\n')
+	b.WriteString(pickerFooter.Render("↑↓ navigate  ·  Enter confirm  ·  Esc cancel"))
+	b.WriteByte('\n')
+
+	return pickerBox.Render(b.String())
+}
+
+// ShowCloudSyncPicker opens a small TUI to toggle cloud session sync.
+// `current` is the present setting (nil = unset). Returns (chosen, ok); ok=false
+// means the user cancelled and the current value should be preserved.
+func ShowCloudSyncPicker(current *bool) (bool, bool) {
+	m := newCloudSyncPickerModel(current)
+	p := tea.NewProgram(m)
+	result, err := p.Run()
+	if err != nil {
+		return false, false
+	}
+	final := result.(cloudSyncPickerModel)
+	if final.cancelled || !final.confirmed {
+		return false, false
+	}
+	return final.cursor == 0, true
+}


### PR DESCRIPTION
## Summary

- **Bug fix:** `UploadSessionMessages` was hitting a non-existent endpoint with the wrong body shape — every cloud session since #72 was lost.
- **TUI:** Cloud-sync is now toggleable from a native picker (`/cloudsync`), not just `/set cloudsync ...`.

## Root cause

`api_client.go` was posting to `POST /api/agent-sessions/{id}/messages` with `{"messages":[...]}`. The server only exposes `POST /api/agent-sessions/{id}/events` with `{"events":[{"type":"message","payload":<Message>}, ...]}`.

Verified against the production cloud:

| Step | Old code | After fix |
|---|---|---|
| `POST .../messages` | **405 Method Not Allowed** | n/a |
| `POST .../events` (key `data`) | n/a | 200, but `payload={}` (silently dropped) |
| `POST .../events` (key `payload`) | n/a | 200, `event_count` increments, content stored, auto-summary correct |

Net effect of the bug: every completed session ended with `event_count: 0` and the server-generated summary read *"No agent session events to summarize."*

After the fix, a real run on session `d48d767e-…` ended with:

> *"User requested final verification and the assistant confirmed that all systems are working properly."*

## Changes

**`api_client.go`** — `UploadSessionMessages`
- Path: `/messages` → `/events`
- Body: `{"messages":[<msg>,...]}` → `{"events":[{"type":"message","payload":<msg>}, ...]}`
- Comment documents the discriminated-union shape and the `payload` vs `data` gotcha

**Tests**
- `api_client_agent_session_test.go` — assert path is `/events`, key is `payload`, and explicitly forbid `data` (silent-drop regression guard)
- `cloud_session_test.go` — update path expectation in `TestCloudTracker_Complete_UploadsMessages`

**`tui_backend.go`** — new `ShowCloudSyncPicker` (`cloudSyncPickerModel`), 2-row toggle styled to match the existing theme/session pickers, marks current value with ✓.

**`main.go`** — new `/cloudsync` handler: shows the picker, persists to config, and calls `startCloudSession()` immediately when enabled so the current run is tracked. Added to `/help`.

**`input.go`** — `/cloudsync` registered in `slashMenuItems` (per CLAUDE.md memory: new `/cmd` handlers also need a SlashMenuItem entry to appear in autocomplete).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all tests pass, including the new path/shape assertions
- [x] Live e2e against `app.qualitymax.io`: create → upload events → complete; `event_count` and auto-summary both correct
- [ ] Manual: run `qmax-code`, type `/cloudsync`, confirm picker appears, toggle off and back on, confirm config persists in `~/.qmax-code/config.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)