### PR TITLE
chore: bump version to 1.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.15.7] - 2026-05-04
+
+### Fixed
+- **Cloud session sync was silently dropping all conversation content.** `UploadSessionMessages` posted to `POST /api/agent-sessions/{id}/messages`, which the server doesn't expose (405). Every completed cloud session since 1.15.0 ended with `event_count: 0` and the auto-summary "No agent session events to summarize." Now posts to `/events` with the correct discriminated-union shape `{"events":[{"type":"message","payload":<msg>}, ...]}`. Verified live; server-generated summaries now reflect the actual conversation.
+
+### Added
+- `/cloudsync` slash command — native TUI toggle for cloud session sync (Enabled / Disabled), as an alternative to `/set cloudsync ...`. Persists to config and starts the cloud session immediately when enabled.
+
 ## [1.15.6] - 2026-05-04
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.15.6"
+var Version = "1.15.7"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps `Version` to 1.15.7 to ship the cloud-session-events fix from #77.
- 1.15.0–1.15.6 silently drop every cloud session (`POST .../messages` → 405). 1.15.7 uses the correct `/events` endpoint with `{type:"message", payload:<msg>}` shape, verified live.
- Adds CHANGELOG entry covering the fix and the new `/cloudsync` TUI toggle.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] After merge: tag and release so users on 1.15.x can upgrade and stop losing sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)