### PR TITLE
chore: bump version to 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.16.1] - 2026-05-07
+
+### Changed
+- Internal restructure: extracted `internal/security`, `internal/vnc`, and `internal/sysutil` out of the flat root `package main`. No user-visible behavior change. Sets up follow-up extractions (agent, tui, api, session, tools, mcp) once a shared `internal/core` package lands.
+
 ## [1.15.7] - 2026-05-04
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.0"
+var Version = "1.16.1"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps `Version` to 1.16.1 to ship the internal/ leaf-package extractions from #81 (security, vnc, sysutil).
- No user-visible behavior change. Patch release sets up follow-up extractions (agent, tui, api, session, tools, mcp) once a shared `internal/core` package lands.
- CHANGELOG entry added.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] After merge: tag `v1.16.1` from main; release workflow builds binaries and publishes to qmax-code-releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)