### PR TITLE
refactor: extract internal/api (Phase 2 of package reorg)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
 
@@ -58,7 +59,7 @@ func (m OllamaMode) String() string {
 // Agent is the LLM-powered QA orchestration engine.
 type Agent struct {
 	config          AgentConfig
-	appConfig       *Config // persistent user preferences
+	appConfig       *api.Config // persistent user preferences
 	history         []Message
 	tools           []ToolDef
 	client          *http.Client

--- a/cloud_session.go
+++ b/cloud_session.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/qualitymax/qmax-code/internal/api"
 	"strings"
 	"time"
 )
@@ -13,7 +14,7 @@ import (
 //
 // readLine must use the active readline instance (e.g. term.ReadConsent) so
 // that it works correctly when readline already owns the terminal in raw mode.
-func promptCloudSyncConsent(cfg *Config, readLine func() (string, error)) bool {
+func promptCloudSyncConsent(cfg *api.Config, readLine func() (string, error)) bool {
 	fmt.Println()
 	fmt.Println("  ┌─ Cloud session sync ──────────────────────────────────────────┐")
 	fmt.Println("  │  qmax-code can sync your sessions to the QualityMax cloud so  │")
@@ -39,7 +40,7 @@ func promptCloudSyncConsent(cfg *Config, readLine func() (string, error)) bool {
 // applyCloudSyncChoice parses a raw answer line, updates cfg.CloudSync, and
 // persists it. Extracted from promptCloudSyncConsent so it can be unit-tested
 // without touching stdin/stdout.
-func applyCloudSyncChoice(cfg *Config, line string) bool {
+func applyCloudSyncChoice(cfg *api.Config, line string) bool {
 	ans := strings.ToLower(strings.TrimSpace(line))
 	enabled := ans == "" || ans == "y" || ans == "yes"
 	v := enabled
@@ -56,28 +57,40 @@ type cloudSessionTracker struct {
 
 // Start opens a cloud session the first time it is called with a valid API
 // client and non-zero project ID. Subsequent calls are no-ops (idempotent).
-func (t *cloudSessionTracker) Start(api *APIClient, projectID int, model string) {
-	if api == nil || projectID == 0 || t.cloudID != "" {
+func (t *cloudSessionTracker) Start(client *api.APIClient, projectID int, model string) {
+	if client == nil || projectID == 0 || t.cloudID != "" {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	t.cloudID = api.CreateAgentSession(ctx, projectID, model)
+	t.cloudID = client.CreateAgentSession(ctx, projectID, model)
 }
 
 // Complete patches the cloud session as finished and uploads the full message
 // history. No-op if Start was never called successfully (cloudID is empty) or
-// api is nil.
-func (t *cloudSessionTracker) Complete(api *APIClient, totalTokens int, summary string, messages []Message) {
-	if api == nil || t.cloudID == "" {
+// client is nil.
+func (t *cloudSessionTracker) Complete(client *api.APIClient, totalTokens int, summary string, messages []Message) {
+	if client == nil || t.cloudID == "" {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	api.CompleteAgentSession(ctx, t.cloudID, totalTokens, summary)
+	client.CompleteAgentSession(ctx, t.cloudID, totalTokens, summary)
 	cancel()
 
-	// Separate timeout for message upload — payload can be large.
+	// Build the discriminated-union events the server expects, then trim to
+	// fit the upload cap before sending. The api client doesn't need to know
+	// what a Message is — only the event shape.
+	events := make([]any, 0, len(messages))
+	for _, m := range messages {
+		events = append(events, map[string]interface{}{
+			"type":    "message",
+			"payload": m,
+		})
+	}
+	events = api.TrimEventsToFit(events, api.MaxSessionUploadBytes)
+
+	// Separate timeout for upload — payload can be large.
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel2()
-	api.UploadSessionMessages(ctx2, t.cloudID, messages)
+	client.UploadSessionEvents(ctx2, t.cloudID, events)
 }

--- a/cloud_session_test.go
+++ b/cloud_session_test.go
@@ -3,15 +3,33 @@ package main
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
 )
+
+// newTestClient wires an api.APIClient to a local httptest.Server so callers
+// can observe outbound requests and stub responses. Mirrors the helper in
+// internal/api tests; lives here because main-package tests can't reach
+// across the package boundary.
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*api.APIClient, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return &api.APIClient{
+		BaseURL: srv.URL,
+		APIKey:  "qm-test-key",
+		HTTP:    srv.Client(),
+	}, srv
+}
 
 // ---- applyCloudSyncChoice ----
 
 func TestApplyCloudSyncChoice_YesVariants(t *testing.T) {
 	for _, line := range []string{"y\n", "Y\n", "yes\n", "YES\n", "\n", "  \n"} {
 		withTempHome(t)
-		cfg := defaultConfig()
+		cfg := api.DefaultConfig()
 		got := applyCloudSyncChoice(cfg, line)
 		if !got {
 			t.Errorf("applyCloudSyncChoice(%q): got false, want true", line)
@@ -25,7 +43,7 @@ func TestApplyCloudSyncChoice_YesVariants(t *testing.T) {
 func TestApplyCloudSyncChoice_NoVariants(t *testing.T) {
 	for _, line := range []string{"n\n", "N\n", "no\n", "NO\n"} {
 		withTempHome(t)
-		cfg := defaultConfig()
+		cfg := api.DefaultConfig()
 		got := applyCloudSyncChoice(cfg, line)
 		if got {
 			t.Errorf("applyCloudSyncChoice(%q): got true, want false", line)
@@ -38,10 +56,10 @@ func TestApplyCloudSyncChoice_NoVariants(t *testing.T) {
 
 func TestApplyCloudSyncChoice_PersistsToDisk(t *testing.T) {
 	withTempHome(t)
-	cfg := defaultConfig()
+	cfg := api.DefaultConfig()
 	applyCloudSyncChoice(cfg, "y\n")
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.CloudSync == nil || !*loaded.CloudSync {
 		t.Error("CloudSync=true not persisted to disk")
 	}
@@ -50,7 +68,7 @@ func TestApplyCloudSyncChoice_PersistsToDisk(t *testing.T) {
 // ---- Config.CloudSync JSON round-trip ----
 
 func TestConfigCloudSync_NilOmittedFromJSON(t *testing.T) {
-	cfg := &Config{}
+	cfg := &api.Config{}
 	data, _ := json.Marshal(cfg)
 	var m map[string]interface{}
 	_ = json.Unmarshal(data, &m)
@@ -62,11 +80,11 @@ func TestConfigCloudSync_NilOmittedFromJSON(t *testing.T) {
 func TestConfigCloudSync_TruePersistedAndLoaded(t *testing.T) {
 	withTempHome(t)
 	v := true
-	cfg := defaultConfig()
+	cfg := api.DefaultConfig()
 	cfg.CloudSync = &v
 	_ = cfg.Save()
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.CloudSync == nil || !*loaded.CloudSync {
 		t.Error("CloudSync true did not survive Save/Load round-trip")
 	}
@@ -75,11 +93,11 @@ func TestConfigCloudSync_TruePersistedAndLoaded(t *testing.T) {
 func TestConfigCloudSync_FalsePersistedAndLoaded(t *testing.T) {
 	withTempHome(t)
 	v := false
-	cfg := defaultConfig()
+	cfg := api.DefaultConfig()
 	cfg.CloudSync = &v
 	_ = cfg.Save()
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.CloudSync == nil || *loaded.CloudSync {
 		t.Error("CloudSync false did not survive Save/Load round-trip")
 	}

--- a/config_command.go
+++ b/config_command.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/qualitymax/qmax-code/internal/api"
 	"os"
 	"strconv"
 )
@@ -19,7 +20,7 @@ import (
 //	qmax-code config unset KEY         → clear a single field
 //	qmax-code config reset             → wipe to defaults
 //
-// Supported keys mirror the public Config fields:
+// Supported keys mirror the public api.Config fields:
 //
 //	default_framework → "", "playwright", "pytest", "rust_cargo", "go_test"
 //	default_project   → integer project ID
@@ -58,12 +59,12 @@ func handleConfigCommand(args []string) {
 		fmt.Printf("  Cleared %s\n", args[1])
 
 	case "reset":
-		cfg := defaultConfig()
+		cfg := api.DefaultConfig()
 		if err := cfg.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println("  Config reset to defaults")
+		fmt.Println("  api.Config reset to defaults")
 
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown config command: %s\n", args[0])
@@ -73,7 +74,7 @@ func handleConfigCommand(args []string) {
 }
 
 func printConfig() {
-	cfg := LoadQMaxCodeConfig()
+	cfg := api.LoadQMaxCodeConfig()
 	fmt.Println("  Current config (~/.qmax-code/config.json):")
 	fmt.Printf("    default_model     = %q\n", cfg.DefaultModel)
 	fmt.Printf("    default_project   = %d\n", cfg.DefaultProject)
@@ -136,11 +137,11 @@ func printConfig() {
 // wrong value types return an error so users find out immediately rather
 // than discovering a silently-ignored setting later.
 func setConfigField(key, value string) error {
-	cfg := LoadQMaxCodeConfig()
+	cfg := api.LoadQMaxCodeConfig()
 
 	switch key {
 	case "default_framework":
-		if value != "" && !allowedFrameworks[value] {
+		if value != "" && !api.AllowedFrameworks[value] {
 			return fmt.Errorf("invalid framework %q; allowed: playwright, pytest, go, rust, go_test, rust_cargo", value)
 		}
 		cfg.DefaultFramework = value
@@ -209,7 +210,7 @@ func setConfigField(key, value string) error {
 		}
 
 	case "theme":
-		return cfg.SaveTheme(value)
+		return SaveTheme(cfg, value)
 
 	case "cloud_sync":
 		if value == "" {

--- a/config_command_test.go
+++ b/config_command_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/qualitymax/qmax-code/internal/api"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +23,7 @@ func TestSetConfigField_DefaultFrameworkHappyPath(t *testing.T) {
 	if err := setConfigField("default_framework", "rust_cargo"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.DefaultFramework != "rust_cargo" {
 		t.Errorf("DefaultFramework: got %q, want rust_cargo", loaded.DefaultFramework)
 	}
@@ -45,7 +46,7 @@ func TestSetConfigField_UnsetEqualsEmptyValue(t *testing.T) {
 	_ = setConfigField("default_framework", "rust_cargo")
 	_ = setConfigField("default_framework", "") // "unset" semantics
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.DefaultFramework != "" {
 		t.Errorf("expected framework cleared, got %q", loaded.DefaultFramework)
 	}
@@ -68,7 +69,7 @@ func TestSetConfigField_IntValidation(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.DefaultProject != 42 {
 		t.Errorf("DefaultProject: got %d, want 42", loaded.DefaultProject)
 	}
@@ -85,7 +86,7 @@ func TestSetConfigField_BoolForms(t *testing.T) {
 		if err := setConfigField("professional", v); err != nil {
 			t.Errorf("expected %q to be true, got error: %v", v, err)
 		}
-		loaded := LoadQMaxCodeConfig()
+		loaded := api.LoadQMaxCodeConfig()
 		if !loaded.Professional {
 			t.Errorf("expected Professional true for value %q", v)
 		}
@@ -94,7 +95,7 @@ func TestSetConfigField_BoolForms(t *testing.T) {
 	// All these should coerce to false.
 	for _, v := range []string{"false", "no", "0", "off", ""} {
 		_ = setConfigField("professional", v)
-		loaded := LoadQMaxCodeConfig()
+		loaded := api.LoadQMaxCodeConfig()
 		if loaded.Professional {
 			t.Errorf("expected Professional false for value %q", v)
 		}
@@ -112,7 +113,7 @@ func TestSetConfigField_OutputVerboseBoolForms(t *testing.T) {
 	if err := setConfigField("output_verbose", "true"); err != nil {
 		t.Fatalf("set output_verbose true: %v", err)
 	}
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if !loaded.OutputVerbose {
 		t.Fatal("expected OutputVerbose=true")
 	}
@@ -120,7 +121,7 @@ func TestSetConfigField_OutputVerboseBoolForms(t *testing.T) {
 	if err := setConfigField("output_verbose", "off"); err != nil {
 		t.Fatalf("set output_verbose off: %v", err)
 	}
-	loaded = LoadQMaxCodeConfig()
+	loaded = api.LoadQMaxCodeConfig()
 	if loaded.OutputVerbose {
 		t.Fatal("expected OutputVerbose=false")
 	}
@@ -164,7 +165,7 @@ func TestSetConfigField_ThemeHappyPath(t *testing.T) {
 		if err := setConfigField("theme", name); err != nil {
 			t.Errorf("setConfigField(\"theme\", %q) unexpected error: %v", name, err)
 		}
-		loaded := LoadQMaxCodeConfig()
+		loaded := api.LoadQMaxCodeConfig()
 		if loaded.Theme != name {
 			t.Errorf("theme %q: loaded.Theme = %q, want %q", name, loaded.Theme, name)
 		}
@@ -188,7 +189,7 @@ func TestSetConfigField_ThemeEmptyUnsets(t *testing.T) {
 	if err := setConfigField("theme", ""); err != nil {
 		t.Fatalf("setConfigField(\"theme\", \"\") unexpected error: %v", err)
 	}
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.Theme != "" {
 		t.Errorf("expected Theme cleared, got %q", loaded.Theme)
 	}
@@ -200,7 +201,7 @@ func TestSetConfigField_ThemePersistsToDisk(t *testing.T) {
 	if err := setConfigField("theme", "aurora"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.Theme != "aurora" {
 		t.Errorf("loaded.Theme = %q, want \"aurora\"", loaded.Theme)
 	}
@@ -208,13 +209,13 @@ func TestSetConfigField_ThemePersistsToDisk(t *testing.T) {
 
 func TestConfigSaveTheme_PersistsLocalSelection(t *testing.T) {
 	tmp := withTempHome(t)
-	cfg := defaultConfig()
+	cfg := api.DefaultConfig()
 
-	if err := cfg.SaveTheme("radiance"); err != nil {
+	if err := SaveTheme(cfg, "radiance"); err != nil {
 		t.Fatalf("SaveTheme(\"radiance\") unexpected error: %v", err)
 	}
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.Theme != "radiance" {
 		t.Errorf("loaded.Theme = %q, want \"radiance\"", loaded.Theme)
 	}
@@ -234,16 +235,16 @@ func TestConfigSaveTheme_PersistsLocalSelection(t *testing.T) {
 
 func TestConfigSaveTheme_RejectsInvalidWithoutOverwriting(t *testing.T) {
 	withTempHome(t)
-	cfg := defaultConfig()
-	if err := cfg.SaveTheme("ocean"); err != nil {
+	cfg := api.DefaultConfig()
+	if err := SaveTheme(cfg, "ocean"); err != nil {
 		t.Fatalf("SaveTheme(\"ocean\") unexpected error: %v", err)
 	}
 
-	if err := cfg.SaveTheme("../evil"); err == nil {
+	if err := SaveTheme(cfg, "../evil"); err == nil {
 		t.Fatal("SaveTheme(\"../evil\") expected error, got nil")
 	}
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.Theme != "ocean" {
 		t.Errorf("invalid theme overwrote persisted selection: got %q, want \"ocean\"", loaded.Theme)
 	}
@@ -254,15 +255,15 @@ func TestConfigSaveTheme_RejectsInvalidWithoutOverwriting(t *testing.T) {
 
 func TestConfigSaveTheme_EmptyClearsLocalSelection(t *testing.T) {
 	withTempHome(t)
-	cfg := defaultConfig()
-	if err := cfg.SaveTheme("neon"); err != nil {
+	cfg := api.DefaultConfig()
+	if err := SaveTheme(cfg, "neon"); err != nil {
 		t.Fatalf("SaveTheme(\"neon\") unexpected error: %v", err)
 	}
-	if err := cfg.SaveTheme(""); err != nil {
+	if err := SaveTheme(cfg, ""); err != nil {
 		t.Fatalf("SaveTheme(\"\") unexpected error: %v", err)
 	}
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.Theme != "" {
 		t.Errorf("loaded.Theme = %q, want empty", loaded.Theme)
 	}
@@ -274,7 +275,7 @@ func TestSetConfigField_CloudSyncHappyPath(t *testing.T) {
 	if err := setConfigField("cloud_sync", "true"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.CloudSync == nil || !*loaded.CloudSync {
 		t.Error("expected CloudSync=true after setConfigField(cloud_sync, true)")
 	}
@@ -282,7 +283,7 @@ func TestSetConfigField_CloudSyncHappyPath(t *testing.T) {
 	if err := setConfigField("cloud_sync", "false"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	loaded = LoadQMaxCodeConfig()
+	loaded = api.LoadQMaxCodeConfig()
 	if loaded.CloudSync == nil || *loaded.CloudSync {
 		t.Error("expected CloudSync=false after setConfigField(cloud_sync, false)")
 	}
@@ -295,7 +296,7 @@ func TestSetConfigField_CloudSyncBoolForms(t *testing.T) {
 		if err := setConfigField("cloud_sync", v); err != nil {
 			t.Errorf("setConfigField(cloud_sync, %q) unexpected error: %v", v, err)
 		}
-		loaded := LoadQMaxCodeConfig()
+		loaded := api.LoadQMaxCodeConfig()
 		if loaded.CloudSync == nil || !*loaded.CloudSync {
 			t.Errorf("expected CloudSync=true for value %q", v)
 		}
@@ -304,7 +305,7 @@ func TestSetConfigField_CloudSyncBoolForms(t *testing.T) {
 		if err := setConfigField("cloud_sync", v); err != nil {
 			t.Errorf("setConfigField(cloud_sync, %q) unexpected error: %v", v, err)
 		}
-		loaded := LoadQMaxCodeConfig()
+		loaded := api.LoadQMaxCodeConfig()
 		if loaded.CloudSync == nil || *loaded.CloudSync {
 			t.Errorf("expected CloudSync=false for value %q", v)
 		}
@@ -318,7 +319,7 @@ func TestSetConfigField_CloudSyncUnsetClearsToNil(t *testing.T) {
 	if err := setConfigField("cloud_sync", ""); err != nil {
 		t.Fatalf("unset should not error: %v", err)
 	}
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.CloudSync != nil {
 		t.Errorf("expected CloudSync=nil after unset, got %v", *loaded.CloudSync)
 	}

--- a/consent.go
+++ b/consent.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"github.com/qualitymax/qmax-code/internal/api"
 	"os"
 	"strings"
 )
@@ -20,7 +21,7 @@ type orchConsentResult struct {
 //
 // Conductor's safety model: the user is the principal. We never sneak privilege
 // escalation behind a backend switch. Mode choices are explicit and persisted.
-func promptOrchConsent(cfg *Config, backend string) orchConsentResult {
+func promptOrchConsent(cfg *api.Config, backend string) orchConsentResult {
 	cliName := "Claude Code"
 	globalConfigPath := "~/.claude/settings.json"
 	if backend == "codex" {

--- a/context.go
+++ b/context.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"github.com/qualitymax/qmax-code/internal/api"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,13 +16,13 @@ import (
 type SessionContext struct {
 	ProjectID   int
 	QMaxCfg     QMaxConfig
-	QMaxBin     string      // resolved path to qmax binary (empty = standalone mode)
-	QMaxInfo    string      // output of `qmax status` at startup
-	GitInfo     *GitInfo    // git context from cwd
-	ProjectFile string      // name of .qmax.yml file if detected
-	API         *APIClient  // direct API client (standalone mode, no qmax CLI needed)
-	Auth        *AuthConfig // authentication credentials
-	Backend     string      // "" | "cc" | "codex" — active CLI inference backend
+	QMaxBin     string          // resolved path to qmax binary (empty = standalone mode)
+	QMaxInfo    string          // output of `qmax status` at startup
+	GitInfo     *GitInfo        // git context from cwd
+	ProjectFile string          // name of .qmax.yml file if detected
+	API         *api.APIClient  // direct API client (standalone mode, no qmax CLI needed)
+	Auth        *api.AuthConfig // authentication credentials
+	Backend     string          // "" | "cc" | "codex" — active CLI inference backend
 
 	// LiveFeed enables QM Cloud Sandbox execution for run_test / start_crawl
 	// and turns on auto-launch of /browserfeed when a poll response surfaces

--- a/framework_detect_test.go
+++ b/framework_detect_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/qualitymax/qmax-code/internal/api"
 	"os"
 	"path/filepath"
 	"testing"
@@ -158,7 +159,7 @@ func TestConfigPre180ForwardCompat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 
 	// All legacy fields preserved.
 	if loaded.DefaultModel != "opus" {
@@ -188,13 +189,13 @@ func TestConfigRoundTripIncludesDefaultFramework(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", origHome)
 
-	cfg := defaultConfig()
+	cfg := api.DefaultConfig()
 	cfg.DefaultFramework = "rust_cargo"
 	if err := cfg.Save(); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 
-	loaded := LoadQMaxCodeConfig()
+	loaded := api.LoadQMaxCodeConfig()
 	if loaded.DefaultFramework != "rust_cargo" {
 		t.Errorf("DefaultFramework lost through round-trip: got %q, want rust_cargo", loaded.DefaultFramework)
 	}

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -5,15 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/qualitymax/qmax-code/internal/api"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/api"
 )
 
 // LoginInteractive prompts the user to paste their API key.
@@ -89,8 +91,11 @@ func LoginViaBrowser() (*api.AuthConfig, error) {
 	fmt.Println()
 	fmt.Println("  Waiting for authorization...")
 
-	// Step 3: Poll until authorized (every 2 seconds, up to 10 minutes)
-	pollURL := cloudURL + "/api/auth/cli-poll?code=" + loginResp.Code
+	// Step 3: Poll until authorized (every 2 seconds, up to 10 minutes).
+	// QueryEscape the code defensively — it's server-supplied and goes into
+	// a URL component, so a code containing &, #, or other URL-reserved
+	// characters would otherwise produce a malformed request.
+	pollURL := cloudURL + "/api/auth/cli-poll?code=" + url.QueryEscape(loginResp.Code)
 	deadline := time.Now().Add(10 * time.Minute)
 
 	i := 0

--- a/interactive_setup.go
+++ b/interactive_setup.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/qualitymax/qmax-code/internal/api"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
@@ -13,9 +16,131 @@ import (
 	"time"
 )
 
+// LoginInteractive prompts the user to paste their API key.
+func LoginInteractive() (*api.AuthConfig, error) {
+	fmt.Println()
+	fmt.Println("  Get your API key from:")
+	fmt.Println("  https://app.qualitymax.io/settings → API Keys")
+	fmt.Println()
+	key := readSecret("  Paste your API key (qm-...): ")
+
+	if key == "" {
+		return nil, fmt.Errorf("no API key provided")
+	}
+
+	return api.LoginWithAPIKey(key)
+}
+
+// --- Browser-based login (Railway-style) ---
+
+type cliLoginResponse struct {
+	Code      string `json:"code"`
+	ExpiresAt string `json:"expires_at"`
+	AuthURL   string `json:"auth_url"`
+}
+
+type cliPollResponse struct {
+	Status string `json:"status"`
+	Token  string `json:"token,omitempty"`
+	Email  string `json:"email,omitempty"`
+	UserID string `json:"user_id,omitempty"`
+}
+
+// LoginViaBrowser performs Railway-style browser login:
+// 1. POST /api/auth/cli-login → get code + auth URL
+// 2. Open browser to auth URL
+// 3. Poll /api/auth/cli-poll until authorized or expired
+func LoginViaBrowser() (*api.AuthConfig, error) {
+	cloudURL := os.Getenv("QUALITYMAX_URL")
+	if cloudURL == "" {
+		cloudURL = api.DefaultCloudURL
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	// Step 1: Get a CLI auth code
+	req, err := http.NewRequest("POST", cloudURL+"/api/auth/cli-login", nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reach QualityMax: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("CLI login failed (HTTP %d)", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var loginResp cliLoginResponse
+	if err := json.Unmarshal(body, &loginResp); err != nil {
+		return nil, fmt.Errorf("invalid response: %w", err)
+	}
+
+	// Step 2: Open browser
+	fmt.Println()
+	fmt.Printf("  Your auth code: \033[1;35m%s\033[0m\n", loginResp.Code)
+	fmt.Println()
+	fmt.Println("  Opening browser to authorize...")
+	openBrowser(loginResp.AuthURL)
+	fmt.Println()
+	fmt.Printf("  If the browser didn't open, visit:\n  %s\n", loginResp.AuthURL)
+	fmt.Println()
+	fmt.Println("  Waiting for authorization...")
+
+	// Step 3: Poll until authorized (every 2 seconds, up to 10 minutes)
+	pollURL := cloudURL + "/api/auth/cli-poll?code=" + loginResp.Code
+	deadline := time.Now().Add(10 * time.Minute)
+
+	i := 0
+	for time.Now().Before(deadline) {
+		time.Sleep(2 * time.Second)
+
+		pollReq, _ := http.NewRequest("GET", pollURL, nil)
+		pollResp, err := client.Do(pollReq)
+		if err != nil {
+			// Network hiccup — keep trying
+			continue
+		}
+
+		pollBody, _ := io.ReadAll(pollResp.Body)
+		pollResp.Body.Close()
+
+		var poll cliPollResponse
+		if err := json.Unmarshal(pollBody, &poll); err != nil {
+			continue
+		}
+
+		switch poll.Status {
+		case "authorized":
+			cfg := &api.AuthConfig{
+				APIKey:   poll.Token,
+				Email:    poll.Email,
+				UserID:   poll.UserID,
+				CloudURL: cloudURL,
+			}
+			if err := api.SaveAuth(cfg); err != nil {
+				return cfg, fmt.Errorf("logged in but failed to save: %w", err)
+			}
+			return cfg, nil
+
+		case "expired":
+			return nil, fmt.Errorf("auth code expired — please try again")
+
+		default:
+			// Still pending — show spinner
+			fmt.Printf("\r  Waiting %s", SpinnerFrames[i%len(SpinnerFrames)])
+			i++
+		}
+	}
+
+	return nil, fmt.Errorf("timed out waiting for browser authorization")
+}
+
 // RunInteractiveSetup guides a first-time user through login and project selection.
-// Returns the AuthConfig and selected project ID.
-func RunInteractiveSetup() (*AuthConfig, int) {
+// Returns the api.AuthConfig and selected project ID.
+func RunInteractiveSetup() (*api.AuthConfig, int) {
 	fmt.Println()
 	AnimateMax(MoodWaving, GetMaxGreeting())
 	fmt.Println()
@@ -30,7 +155,7 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 		"I have an API key already",
 	})
 
-	var auth *AuthConfig
+	var auth *api.AuthConfig
 	var err error
 
 	switch choice {
@@ -79,7 +204,7 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 			[]string{"Yes, save it", "No, I'll pick per-call"},
 		)
 		if confirm == 0 {
-			cfg := LoadQMaxCodeConfig()
+			cfg := api.LoadQMaxCodeConfig()
 			cfg.DefaultFramework = detected
 			_ = cfg.Save()
 			fmt.Printf("  Saved. You can change it later by editing ~/.qmax-code/config.json.\n")
@@ -96,7 +221,7 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 	}
 
 	// Step 3: Anthropic key check
-	cfg := LoadQMaxCodeConfig()
+	cfg := api.LoadQMaxCodeConfig()
 	anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
 	if anthropicKey == "" {
 		anthropicKey = cfg.AnthropicKey
@@ -112,7 +237,7 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 		if key != "" {
 			os.Setenv("ANTHROPIC_API_KEY", key)
 			// Save to OS keychain
-			if err := SaveAnthropicKey(key); err != nil {
+			if err := api.SaveAnthropicKey(key); err != nil {
 				// Fallback: warn but continue
 				fmt.Printf("\n  Note: Could not save to keychain (%s)\n", err)
 				fmt.Println("  Key is set for this session. Set ANTHROPIC_API_KEY in your shell profile to persist.")
@@ -139,7 +264,7 @@ func RunInteractiveSetup() (*AuthConfig, int) {
 }
 
 // loginWithKeyPrompt asks the user to paste their API key.
-func loginWithKeyPrompt() (*AuthConfig, error) {
+func loginWithKeyPrompt() (*api.AuthConfig, error) {
 	key := readSecret("  Paste your API key (qm-...): ")
 
 	if key == "" {
@@ -164,7 +289,7 @@ func loginWithKeyPrompt() (*AuthConfig, error) {
 		}
 	}()
 
-	auth, err := LoginWithAPIKey(key)
+	auth, err := api.LoginWithAPIKey(key)
 	done <- true
 	fmt.Print("\r  Validating ")
 
@@ -178,14 +303,14 @@ func loginWithKeyPrompt() (*AuthConfig, error) {
 }
 
 // selectProject lists projects and lets the user pick one.
-func selectProject(auth *AuthConfig) int {
-	api := NewAPIClient(auth)
-	if api == nil {
+func selectProject(auth *api.AuthConfig) int {
+	client := api.NewAPIClient(auth)
+	if client == nil {
 		return 0
 	}
 
 	fmt.Println("  Loading projects...")
-	result := api.ListProjects(context.Background())
+	result := client.ListProjects(context.Background())
 
 	// Try to parse as JSON array
 	var projects []map[string]interface{}
@@ -218,7 +343,7 @@ func selectProject(auth *AuthConfig) int {
 	fmt.Printf("\n  Selected: %s\n", strVal2(projects[choice], "name"))
 
 	// Save to config
-	cfg := LoadQMaxCodeConfig()
+	cfg := api.LoadQMaxCodeConfig()
 	cfg.DefaultProject = id
 	_ = cfg.Save()
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"encoding/json"
@@ -20,7 +20,7 @@ type AuthConfig struct {
 }
 
 const authFileName = "auth.json"
-const defaultCloudURL = "https://app.qualitymax.io"
+const DefaultCloudURL = "https://app.qualitymax.io"
 
 // LoadAuth loads authentication from (in priority order):
 // 1. QUALITYMAX_API_KEY env var
@@ -31,7 +31,7 @@ func LoadAuth() *AuthConfig {
 	if key := os.Getenv("QUALITYMAX_API_KEY"); key != "" {
 		return &AuthConfig{
 			APIKey:   key,
-			CloudURL: envOr("QUALITYMAX_URL", defaultCloudURL),
+			CloudURL: envOr("QUALITYMAX_URL", DefaultCloudURL),
 		}
 	}
 
@@ -40,8 +40,10 @@ func LoadAuth() *AuthConfig {
 		return cfg
 	}
 
-	// 3. Legacy ~/.qamax/config.json
-	legacy := loadQMaxConfig()
+	// 3. Legacy ~/.qamax/config.json. We read it as a small local shape rather
+	// than importing the qmax-CLI QMaxConfig type, so this file has no
+	// dependencies on other root-package types.
+	legacy := loadLegacyQMaxAuth()
 	if legacy.Token != "" || legacy.APIKey != "" {
 		// Prefer JWT token over agent API key (hex key is for agent registration, not user auth)
 		key := legacy.Token
@@ -50,7 +52,7 @@ func LoadAuth() *AuthConfig {
 		}
 		url := legacy.CloudURL
 		if url == "" {
-			url = defaultCloudURL
+			url = DefaultCloudURL
 		}
 		cfg := &AuthConfig{
 			APIKey:   key,
@@ -83,7 +85,7 @@ func SaveAuth(cfg *AuthConfig) error {
 		return err
 	}
 
-	dir := filepath.Join(home, qmaxCodeConfigDir)
+	dir := filepath.Join(home, QmaxCodeConfigDir)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
@@ -104,14 +106,14 @@ func (a *AuthConfig) IsAuthenticated() bool {
 // GetCloudURL returns the QualityMax API URL.
 func (a *AuthConfig) GetCloudURL() string {
 	if a == nil || a.CloudURL == "" {
-		return defaultCloudURL
+		return DefaultCloudURL
 	}
 	return strings.TrimRight(a.CloudURL, "/")
 }
 
 // LoginWithAPIKey validates an API key against QualityMax and saves it.
 func LoginWithAPIKey(apiKey string) (*AuthConfig, error) {
-	cloudURL := envOr("QUALITYMAX_URL", defaultCloudURL)
+	cloudURL := envOr("QUALITYMAX_URL", DefaultCloudURL)
 
 	// Validate by calling /api/me
 	client := &http.Client{Timeout: 10 * time.Second}
@@ -150,125 +152,6 @@ func LoginWithAPIKey(apiKey string) (*AuthConfig, error) {
 	return cfg, nil
 }
 
-// LoginInteractive prompts the user to paste their API key.
-func LoginInteractive() (*AuthConfig, error) {
-	fmt.Println()
-	fmt.Println("  Get your API key from:")
-	fmt.Println("  https://app.qualitymax.io/settings → API Keys")
-	fmt.Println()
-	key := readSecret("  Paste your API key (qm-...): ")
-
-	if key == "" {
-		return nil, fmt.Errorf("no API key provided")
-	}
-
-	return LoginWithAPIKey(key)
-}
-
-// --- Browser-based login (Railway-style) ---
-
-type cliLoginResponse struct {
-	Code      string `json:"code"`
-	ExpiresAt string `json:"expires_at"`
-	AuthURL   string `json:"auth_url"`
-}
-
-type cliPollResponse struct {
-	Status string `json:"status"`
-	Token  string `json:"token,omitempty"`
-	Email  string `json:"email,omitempty"`
-	UserID string `json:"user_id,omitempty"`
-}
-
-// LoginViaBrowser performs Railway-style browser login:
-// 1. POST /api/auth/cli-login → get code + auth URL
-// 2. Open browser to auth URL
-// 3. Poll /api/auth/cli-poll until authorized or expired
-func LoginViaBrowser() (*AuthConfig, error) {
-	cloudURL := envOr("QUALITYMAX_URL", defaultCloudURL)
-	client := &http.Client{Timeout: 10 * time.Second}
-
-	// Step 1: Get a CLI auth code
-	req, err := http.NewRequest("POST", cloudURL+"/api/auth/cli-login", nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("cannot reach QualityMax: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("CLI login failed (HTTP %d)", resp.StatusCode)
-	}
-
-	body, _ := io.ReadAll(resp.Body)
-	var loginResp cliLoginResponse
-	if err := json.Unmarshal(body, &loginResp); err != nil {
-		return nil, fmt.Errorf("invalid response: %w", err)
-	}
-
-	// Step 2: Open browser
-	fmt.Println()
-	fmt.Printf("  Your auth code: \033[1;35m%s\033[0m\n", loginResp.Code)
-	fmt.Println()
-	fmt.Println("  Opening browser to authorize...")
-	openBrowser(loginResp.AuthURL)
-	fmt.Println()
-	fmt.Printf("  If the browser didn't open, visit:\n  %s\n", loginResp.AuthURL)
-	fmt.Println()
-	fmt.Println("  Waiting for authorization...")
-
-	// Step 3: Poll until authorized (every 2 seconds, up to 10 minutes)
-	pollURL := cloudURL + "/api/auth/cli-poll?code=" + loginResp.Code
-	deadline := time.Now().Add(10 * time.Minute)
-
-	i := 0
-	for time.Now().Before(deadline) {
-		time.Sleep(2 * time.Second)
-
-		pollReq, _ := http.NewRequest("GET", pollURL, nil)
-		pollResp, err := client.Do(pollReq)
-		if err != nil {
-			// Network hiccup — keep trying
-			continue
-		}
-
-		pollBody, _ := io.ReadAll(pollResp.Body)
-		pollResp.Body.Close()
-
-		var poll cliPollResponse
-		if err := json.Unmarshal(pollBody, &poll); err != nil {
-			continue
-		}
-
-		switch poll.Status {
-		case "authorized":
-			cfg := &AuthConfig{
-				APIKey:   poll.Token,
-				Email:    poll.Email,
-				UserID:   poll.UserID,
-				CloudURL: cloudURL,
-			}
-			if err := SaveAuth(cfg); err != nil {
-				return cfg, fmt.Errorf("logged in but failed to save: %w", err)
-			}
-			return cfg, nil
-
-		case "expired":
-			return nil, fmt.Errorf("auth code expired — please try again")
-
-		default:
-			// Still pending — show spinner
-			fmt.Printf("\r  Waiting %s", SpinnerFrames[i%len(SpinnerFrames)])
-			i++
-		}
-	}
-
-	return nil, fmt.Errorf("timed out waiting for browser authorization")
-}
-
 // --- helpers ---
 
 // fetchMe calls /api/me to get user info (email, id) from the API.
@@ -296,7 +179,7 @@ func loadAuthFile() *AuthConfig {
 		return nil
 	}
 
-	path := filepath.Join(home, qmaxCodeConfigDir, authFileName)
+	path := filepath.Join(home, QmaxCodeConfigDir, authFileName)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -321,4 +204,28 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// legacyQMaxAuth is the subset of fields from the qmax CLI config we care
+// about for the legacy auth fallback. Reading these inline avoids depending
+// on the (richer) QMaxConfig type defined in context.go.
+type legacyQMaxAuth struct {
+	CloudURL string `json:"api_url"`
+	Token    string `json:"token"`
+	Email    string `json:"email"`
+	APIKey   string `json:"api_key"`
+}
+
+func loadLegacyQMaxAuth() legacyQMaxAuth {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return legacyQMaxAuth{}
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".qamax", "config.json"))
+	if err != nil {
+		return legacyQMaxAuth{}
+	}
+	var cfg legacyQMaxAuth
+	_ = json.Unmarshal(data, &cfg)
+	return cfg
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"bytes"
@@ -95,10 +95,10 @@ func (c *APIClient) ListScripts(ctx context.Context, projectID, limit int) strin
 	return c.get(ctx, path)
 }
 
-// allowedFrameworks mirrors the public framework values accepted by the
+// AllowedFrameworks mirrors the public framework values accepted by the
 // QualityMax API. We validate client-side so bad values get rejected before
 // hitting the wire and the agent can show a clearer error message.
-var allowedFrameworks = map[string]bool{
+var AllowedFrameworks = map[string]bool{
 	"":           true, // omitted → server auto-detects
 	"playwright": true,
 	"pytest":     true,
@@ -113,7 +113,7 @@ var allowedFrameworks = map[string]bool{
 // outside the allow-list, or "" if OK. Callers can short-circuit before
 // doing the HTTP POST.
 func validateFramework(framework string) string {
-	if allowedFrameworks[framework] {
+	if AllowedFrameworks[framework] {
 		return ""
 	}
 	return jsonError(fmt.Sprintf(
@@ -155,8 +155,8 @@ func (c *APIClient) GenerateTestCode(ctx context.Context, testCaseID int, force 
 // port goes 502 by the time qmax-code's end-of-turn auto-launch fires.
 func (c *APIClient) RunTest(ctx context.Context, scriptID int, headless bool, browser, baseURL string, useCloudSandbox bool) string {
 	body := map[string]interface{}{
-		"headless":         headless,
-		"use_browserbase":  false,
+		"headless":        headless,
+		"use_browserbase": false,
 		// Always request keepalive: the server may use E2B even when not
 		// explicitly asked (e.g. per-script server-side policy). Without this,
 		// the websockify port is gone before the end-of-turn auto-launch fires.
@@ -437,61 +437,51 @@ func (c *APIClient) CompleteAgentSession(ctx context.Context, cloudID string, to
 	c.patch(ctx, "/api/agent-sessions/"+cloudID, body)
 }
 
-// maxSessionUploadBytes caps the serialized message payload to avoid server
+// MaxSessionUploadBytes caps the serialized event payload to avoid server
 // rejection or excessive upload times on very long sessions.
-const maxSessionUploadBytes = 4 * 1024 * 1024 // 4 MiB
+const MaxSessionUploadBytes = 4 * 1024 * 1024 // 4 MiB
 
-// UploadSessionMessages uploads the full conversation history to a cloud session.
-// Called alongside CompleteAgentSession so the cloud has complete context for
-// cross-session recall. If the payload exceeds maxSessionUploadBytes, older
-// messages are trimmed. Errors are silently dropped.
+// UploadSessionEvents POSTs a pre-built events list to the cloud session's
+// /events endpoint. Errors are silently dropped — best-effort sync.
 //
-// The server exposes a generic /events endpoint with a discriminated-union body:
+// The server expects a discriminated-union body:
 //
-//	{"events": [{"type": "message", "payload": <Message>}, ...]}
+//	{"events": [{"type": "message", "payload": <...>}, ...]}
 //
 // Valid event types per the server enum: file_edit, message, shell_cmd,
-// test_result, tool_call — we only emit "message" here. The body must use the
-// key "payload" (not "data"); other keys are silently dropped server-side and
-// the event lands with payload={}.
-func (c *APIClient) UploadSessionMessages(ctx context.Context, cloudID string, messages []Message) {
-	if len(messages) == 0 {
+// test_result, tool_call. Caller is responsible for shape and trimming —
+// see TrimEventsToFit for the standard size-based trimmer.
+func (c *APIClient) UploadSessionEvents(ctx context.Context, cloudID string, events []any) {
+	if len(events) == 0 {
 		return
-	}
-	msgs := trimMessagesToFit(messages, maxSessionUploadBytes)
-	events := make([]map[string]interface{}, 0, len(msgs))
-	for _, m := range msgs {
-		events = append(events, map[string]interface{}{
-			"type":    "message",
-			"payload": m,
-		})
 	}
 	body := map[string]interface{}{"events": events}
 	c.post(ctx, "/api/agent-sessions/"+cloudID+"/events", body)
 }
 
-// trimMessagesToFit drops oldest messages until the JSON-encoded payload fits
-// within maxBytes. Returns the original slice if it already fits.
-func trimMessagesToFit(messages []Message, maxBytes int) []Message {
-	data, err := json.Marshal(messages)
+// TrimEventsToFit drops oldest events until the JSON-encoded payload fits
+// within maxBytes. Returns the original slice if it already fits, or the
+// last event alone if no longer suffix fits.
+func TrimEventsToFit(events []any, maxBytes int) []any {
+	data, err := json.Marshal(events)
 	if err != nil || len(data) <= maxBytes {
-		return messages
+		return events
 	}
 	// Binary search for the largest suffix that fits.
-	lo, hi := 0, len(messages)
+	lo, hi := 0, len(events)
 	for lo < hi {
 		mid := (lo + hi) / 2
-		d, _ := json.Marshal(messages[mid:])
+		d, _ := json.Marshal(events[mid:])
 		if len(d) <= maxBytes {
 			hi = mid
 		} else {
 			lo = mid + 1
 		}
 	}
-	if lo >= len(messages) {
-		return messages[len(messages)-1:] // at minimum send the last message
+	if lo >= len(events) {
+		return events[len(events)-1:]
 	}
-	return messages[lo:]
+	return events[lo:]
 }
 
 // --- Script operations ---

--- a/internal/api/client_agent_session_test.go
+++ b/internal/api/client_agent_session_test.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"context"
@@ -175,9 +175,9 @@ func TestCompleteAgentSession_SilentOnServerError(t *testing.T) {
 
 // ---- patch() HTTP helper ----
 
-// ---- UploadSessionMessages ----
+// ---- UploadSessionEvents ----
 
-func TestUploadSessionMessages_PostsToCorrectEndpoint(t *testing.T) {
+func TestUploadSessionEvents_PostsToCorrectEndpoint(t *testing.T) {
 	var gotMethod, gotPath string
 	var gotBody map[string]interface{}
 
@@ -189,11 +189,11 @@ func TestUploadSessionMessages_PostsToCorrectEndpoint(t *testing.T) {
 		_, _ = w.Write([]byte(`{"appended":2}`))
 	})
 
-	msgs := []Message{
-		{Role: "user", Content: "hello"},
-		{Role: "assistant", Content: "world"},
+	events := []any{
+		map[string]any{"type": "message", "payload": map[string]any{"role": "user", "content": "hello"}},
+		map[string]any{"type": "message", "payload": map[string]any{"role": "assistant", "content": "world"}},
 	}
-	client.UploadSessionMessages(context.Background(), "sess-123", msgs)
+	client.UploadSessionEvents(context.Background(), "sess-123", events)
 
 	if gotMethod != "POST" {
 		t.Errorf("method: got %q, want POST", gotMethod)
@@ -203,96 +203,72 @@ func TestUploadSessionMessages_PostsToCorrectEndpoint(t *testing.T) {
 	if gotPath != "/api/agent-sessions/sess-123/events" {
 		t.Errorf("path: got %q, want /api/agent-sessions/sess-123/events", gotPath)
 	}
-	events, ok := gotBody["events"].([]interface{})
+	got, ok := gotBody["events"].([]interface{})
 	if !ok {
 		t.Fatalf("body missing 'events' array: %+v", gotBody)
 	}
-	if len(events) != 2 {
-		t.Fatalf("expected 2 events, got %d", len(events))
-	}
-	for i, ev := range events {
-		m, ok := ev.(map[string]interface{})
-		if !ok {
-			t.Fatalf("event %d not an object: %v", i, ev)
-		}
-		if m["type"] != "message" {
-			t.Errorf("event %d type: got %v, want \"message\"", i, m["type"])
-		}
-		// Server stores message bodies under "payload" — using "data" silently
-		// drops the content (event lands with payload={}). Guard against regression.
-		payload, ok := m["payload"].(map[string]interface{})
-		if !ok {
-			t.Fatalf("event %d missing payload object: %v", i, m)
-		}
-		if payload["role"] == nil || payload["content"] == nil {
-			t.Errorf("event %d payload missing role/content: %v", i, payload)
-		}
-		if _, hasData := m["data"]; hasData {
-			t.Errorf("event %d should not use 'data' key (server expects 'payload'): %v", i, m)
-		}
-	}
-	first := events[0].(map[string]interface{})["payload"].(map[string]interface{})
-	if first["role"] != "user" || first["content"] != "hello" {
-		t.Errorf("first event payload mismatch: %+v", first)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(got))
 	}
 }
 
-func TestUploadSessionMessages_SkipsWhenEmpty(t *testing.T) {
+func TestUploadSessionEvents_SkipsWhenEmpty(t *testing.T) {
 	calls := 0
 	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 		calls++
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	client.UploadSessionMessages(context.Background(), "sess-123", nil)
-	client.UploadSessionMessages(context.Background(), "sess-123", []Message{})
+	client.UploadSessionEvents(context.Background(), "sess-123", nil)
+	client.UploadSessionEvents(context.Background(), "sess-123", []any{})
 
 	if calls != 0 {
-		t.Errorf("expected 0 HTTP calls for empty messages, got %d", calls)
+		t.Errorf("expected 0 HTTP calls for empty events, got %d", calls)
 	}
 }
 
-// ---- trimMessagesToFit ----
+// ---- TrimEventsToFit ----
 
-func TestTrimMessagesToFit_NoTrimWhenUnderLimit(t *testing.T) {
-	msgs := []Message{
-		{Role: "user", Content: "hi"},
-		{Role: "assistant", Content: "hello"},
+func TestTrimEventsToFit_NoTrimWhenUnderLimit(t *testing.T) {
+	events := []any{
+		map[string]any{"type": "message", "payload": map[string]any{"role": "user", "content": "hi"}},
+		map[string]any{"type": "message", "payload": map[string]any{"role": "assistant", "content": "hello"}},
 	}
-	result := trimMessagesToFit(msgs, 1024*1024)
+	result := TrimEventsToFit(events, 1024*1024)
 	if len(result) != 2 {
-		t.Errorf("expected 2 messages, got %d", len(result))
+		t.Errorf("expected 2 events, got %d", len(result))
 	}
 }
 
-func TestTrimMessagesToFit_TrimsOldestMessages(t *testing.T) {
-	msgs := []Message{
-		{Role: "user", Content: strings.Repeat("A", 500)},
-		{Role: "assistant", Content: strings.Repeat("B", 500)},
-		{Role: "user", Content: strings.Repeat("C", 500)},
-		{Role: "assistant", Content: "short"},
+func TestTrimEventsToFit_TrimsOldestEvents(t *testing.T) {
+	bulky := func(role, c string) any {
+		return map[string]any{"type": "message", "payload": map[string]any{"role": role, "content": c}}
 	}
-	// Set a tight limit that can only fit the last 2 messages
-	result := trimMessagesToFit(msgs, 600)
-	if len(result) >= len(msgs) {
-		t.Errorf("expected trimming, got %d messages (same as input)", len(result))
+	events := []any{
+		bulky("user", strings.Repeat("A", 500)),
+		bulky("assistant", strings.Repeat("B", 500)),
+		bulky("user", strings.Repeat("C", 500)),
+		bulky("assistant", "short"),
 	}
-	// Last message should always be preserved
-	last := result[len(result)-1]
-	if last.Content != "short" {
-		t.Errorf("last message should be preserved, got content %q", last.Content)
+	result := TrimEventsToFit(events, 600)
+	if len(result) >= len(events) {
+		t.Errorf("expected trimming, got %d events (same as input)", len(result))
+	}
+	// Last event should always be preserved.
+	last := result[len(result)-1].(map[string]any)
+	if last["payload"].(map[string]any)["content"] != "short" {
+		t.Errorf("last event should be preserved, got %v", last)
 	}
 }
 
-func TestTrimMessagesToFit_ReturnsAtLeastLastMessage(t *testing.T) {
-	msgs := []Message{
-		{Role: "user", Content: strings.Repeat("X", 10000)},
-		{Role: "assistant", Content: strings.Repeat("Y", 10000)},
+func TestTrimEventsToFit_ReturnsAtLeastLastEvent(t *testing.T) {
+	events := []any{
+		map[string]any{"type": "message", "payload": map[string]any{"role": "user", "content": strings.Repeat("X", 10000)}},
+		map[string]any{"type": "message", "payload": map[string]any{"role": "assistant", "content": strings.Repeat("Y", 10000)}},
 	}
-	// Impossibly small limit
-	result := trimMessagesToFit(msgs, 10)
+	result := TrimEventsToFit(events, 10)
 	if len(result) < 1 {
-		t.Error("should return at least 1 message")
+		t.Error("should return at least 1 event")
 	}
 }
 

--- a/internal/api/client_native_test.go
+++ b/internal/api/client_native_test.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"context"

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -1,11 +1,9 @@
-package main
+package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // Config holds persistent user preferences for qmax-code.
@@ -82,17 +80,17 @@ type Config struct {
 	LiveFeed bool `json:"live_feed,omitempty"`
 }
 
-const qmaxCodeConfigDir = ".qmax-code"
+const QmaxCodeConfigDir = ".qmax-code"
 const qmaxCodeConfigFile = "config.json"
 
 // LoadQMaxCodeConfig reads persistent user preferences from ~/.qmax-code/config.json
 // and loads the Anthropic key from the OS keychain.
 func LoadQMaxCodeConfig() *Config {
-	cfg := defaultConfig()
+	cfg := DefaultConfig()
 
 	home, err := os.UserHomeDir()
 	if err == nil {
-		path := filepath.Join(home, qmaxCodeConfigDir, qmaxCodeConfigFile)
+		path := filepath.Join(home, QmaxCodeConfigDir, qmaxCodeConfigFile)
 		if data, err := os.ReadFile(path); err == nil {
 			_ = json.Unmarshal(data, cfg)
 		}
@@ -126,7 +124,7 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	dir := filepath.Join(home, qmaxCodeConfigDir)
+	dir := filepath.Join(home, QmaxCodeConfigDir)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return err
 	}
@@ -139,35 +137,7 @@ func (c *Config) Save() error {
 	return os.WriteFile(filepath.Join(dir, qmaxCodeConfigFile), data, 0600)
 }
 
-// SaveTheme persists the selected terminal color theme in the user's local
-// config file. The empty value clears the preference and restores the default.
-func (c *Config) SaveTheme(theme string) error {
-	if c == nil {
-		return fmt.Errorf("config not loaded")
-	}
-	if theme != "" {
-		valid := false
-		for _, name := range ThemeNames() {
-			if name == theme {
-				valid = true
-				break
-			}
-		}
-		if !valid {
-			return fmt.Errorf("invalid theme %q; available: %s", theme, strings.Join(ThemeNames(), ", "))
-		}
-	}
-
-	previous := c.Theme
-	c.Theme = theme
-	if err := c.Save(); err != nil {
-		c.Theme = previous
-		return err
-	}
-	return nil
-}
-
-func defaultConfig() *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		DefaultModel:   "auto",
 		AutoSave:       true,

--- a/internal/api/config_test.go
+++ b/internal/api/config_test.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"os"
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDefaultConfig(t *testing.T) {
-	cfg := defaultConfig()
+	cfg := DefaultConfig()
 	if cfg.DefaultModel != "auto" {
 		t.Errorf("DefaultModel: got %s, want auto", cfg.DefaultModel)
 	}
@@ -15,20 +15,6 @@ func TestDefaultConfig(t *testing.T) {
 	}
 	if cfg.MaxTokenBudget != 200000 {
 		t.Errorf("MaxTokenBudget: got %d, want 200000", cfg.MaxTokenBudget)
-	}
-}
-
-func TestResolveModelUsesCentralModelConstants(t *testing.T) {
-	cases := map[string]string{
-		"haiku":  ModelHaiku,
-		"sonnet": ModelSonnet,
-		"opus":   ModelOpus,
-		"custom": "custom",
-	}
-	for input, want := range cases {
-		if got := resolveModel(input); got != want {
-			t.Errorf("resolveModel(%q) = %q, want %q", input, got, want)
-		}
 	}
 }
 

--- a/internal/api/keychain.go
+++ b/internal/api/keychain.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"fmt"

--- a/live_feed_extra_test.go
+++ b/live_feed_extra_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/coder/websocket"
 
+	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 	"github.com/qualitymax/qmax-code/internal/vnc"
 )
@@ -340,7 +341,7 @@ func TestWaitForLiveFeedURLReturnsWhenURLAppears(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	api := &APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
+	api := &api.APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
 	start := time.Now()
 	got := waitForLiveFeedURL(api, "exec_test", 30*time.Second)
 	elapsed := time.Since(start)
@@ -366,7 +367,7 @@ func TestWaitForLiveFeedURLStopsOnFinalStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	api := &APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
+	api := &api.APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
 	start := time.Now()
 	got := waitForLiveFeedURL(api, "exec_test", 30*time.Second)
 	elapsed := time.Since(start)
@@ -389,7 +390,7 @@ func TestWaitForLiveFeedURLTimeout(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	api := &APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
+	api := &api.APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
 	// Use a very short timeout so the test doesn't take long.
 	got := waitForLiveFeedURL(api, "exec_test", 3*time.Second)
 	if got != "" {
@@ -416,7 +417,7 @@ func TestRunTestWithProgressLiveFeedFastReturn(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	api := &APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
+	api := &api.APIClient{BaseURL: srv.URL, HTTP: srv.Client()}
 	sctx := &SessionContext{LiveFeed: true, API: api}
 
 	result := runTestWithProgress(t.Context(), api, sctx, 42, true, "", "")

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 	"github.com/qualitymax/qmax-code/internal/vnc"
 )
@@ -77,13 +78,13 @@ func main() {
 		qualityMaxAPIKey := loginFlags.String("api-key", "", "QualityMax API key")
 		_ = loginFlags.Parse(os.Args[2:])
 
-		var cfg *AuthConfig
+		var cfg *api.AuthConfig
 		var err error
 		args := loginFlags.Args()
 		if *qualityMaxAPIKey != "" {
-			cfg, err = LoginWithAPIKey(*qualityMaxAPIKey)
+			cfg, err = api.LoginWithAPIKey(*qualityMaxAPIKey)
 		} else if len(args) > 0 && strings.HasPrefix(args[0], "qm-") {
-			cfg, err = LoginWithAPIKey(args[0])
+			cfg, err = api.LoginWithAPIKey(args[0])
 		} else {
 			// Browser-based login (Railway-style)
 			AnimateMax(MoodWaving, "Let's get you logged in!")
@@ -113,7 +114,7 @@ func main() {
 	}
 
 	// Load persistent user config
-	appConfig := LoadQMaxCodeConfig()
+	appConfig := api.LoadQMaxCodeConfig()
 
 	// Apply color theme before constructing any UI components.
 	ApplyTheme(ThemeByName(appConfig.Theme))
@@ -158,7 +159,7 @@ func main() {
 	}
 
 	// Load auth (new standalone mode)
-	auth := LoadAuth()
+	auth := api.LoadAuth()
 
 	// Load qmax config for cloud URL and auth token (legacy)
 	qmaxCfg := loadQMaxConfig()
@@ -170,16 +171,16 @@ func main() {
 	qmaxBin := discoverQMaxBinary()
 
 	// Initialize API client if authenticated (standalone mode)
-	var apiClient *APIClient
+	var apiClient *api.APIClient
 	if auth != nil && auth.IsAuthenticated() {
-		apiClient = NewAPIClient(auth)
+		apiClient = api.NewAPIClient(auth)
 	}
 
 	// If no qmax CLI and no API client, run full interactive setup
 	if qmaxBin == "" && apiClient == nil {
 		setupAuth, setupProjectID := RunInteractiveSetup()
 		auth = setupAuth
-		apiClient = NewAPIClient(auth)
+		apiClient = api.NewAPIClient(auth)
 		appConfig.DefaultProject = setupProjectID
 		if anthropicKey == "" {
 			anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
@@ -243,7 +244,7 @@ func main() {
 		if key != "" {
 			anthropicKey = key
 			os.Setenv("ANTHROPIC_API_KEY", key)
-			if err := SaveAnthropicKey(key); err == nil {
+			if err := api.SaveAnthropicKey(key); err == nil {
 				fmt.Println("  Saved to OS keychain.")
 			}
 		}
@@ -699,7 +700,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			// Show the unified model + effort TUI picker and apply the selection instantly.
 			cfg := agent.appConfig
 			if cfg == nil {
-				term.PrintError("Config not loaded.")
+				term.PrintError("api.Config not loaded.")
 				continue
 			}
 
@@ -799,14 +800,14 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		case input == "/theme":
 			cfg := agent.appConfig
 			if cfg == nil {
-				term.PrintError("Config not loaded.")
+				term.PrintError("api.Config not loaded.")
 				continue
 			}
 			chosen, ok := ShowThemePicker(cfg.Theme)
 			if !ok {
 				continue
 			}
-			if err := cfg.SaveTheme(chosen); err != nil {
+			if err := SaveTheme(cfg, chosen); err != nil {
 				term.PrintError(fmt.Sprintf("Failed to save config: %v", err))
 			} else {
 				ApplyTheme(ThemeByName(chosen))
@@ -817,7 +818,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		case input == "/cloudsync":
 			cfg := agent.appConfig
 			if cfg == nil {
-				term.PrintError("Config not loaded.")
+				term.PrintError("api.Config not loaded.")
 				continue
 			}
 			enabled, ok := ShowCloudSyncPicker(cfg.CloudSync)
@@ -843,7 +844,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			// Instant backend switching — no restart needed.
 			cfg := agent.appConfig
 			if cfg == nil {
-				term.PrintError("Config not loaded.")
+				term.PrintError("api.Config not loaded.")
 				continue
 			}
 
@@ -977,7 +978,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			arg := strings.TrimSpace(strings.TrimPrefix(input, "/live"))
 			cfg := agent.appConfig
 			if cfg == nil {
-				term.PrintError("Config not loaded.")
+				term.PrintError("api.Config not loaded.")
 				continue
 			}
 			applyLiveFeed := func(next bool) {
@@ -1379,7 +1380,7 @@ func maybeLaunchLiveFeed(sctx *SessionContext, term *Terminal, preStream *vnc.VN
 
 // waitForLiveFeedURL polls CheckTestStatus until live_browser_url appears or
 // the test ends without one. Returns the URL on success, "" on timeout/failure.
-func waitForLiveFeedURL(api *APIClient, execID string, timeout time.Duration) string {
+func waitForLiveFeedURL(api *api.APIClient, execID string, timeout time.Duration) string {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		time.Sleep(2 * time.Second)
@@ -1424,7 +1425,7 @@ func handleConnect(agent *Agent, term *Terminal) {
 
 	// Update session context in-place
 	ctx.Auth = auth
-	ctx.API = NewAPIClient(auth)
+	ctx.API = api.NewAPIClient(auth)
 
 	AnimateMax(MoodHappy, fmt.Sprintf("Connected as %s", auth.Email))
 	fmt.Println()
@@ -1446,7 +1447,7 @@ func handleDisconnect(agent *Agent, term *Terminal) {
 	// Remove saved auth files (both new and legacy)
 	home, _ := os.UserHomeDir()
 	if home != "" {
-		_ = os.Remove(filepath.Join(home, qmaxCodeConfigDir, "auth.json"))
+		_ = os.Remove(filepath.Join(home, api.QmaxCodeConfigDir, "auth.json"))
 		// Also clear legacy ~/.qamax/config.json token to prevent auto-reconnect
 		legacyPath := filepath.Join(home, ".qamax", "config.json")
 		if data, err := os.ReadFile(legacyPath); err == nil {
@@ -1472,7 +1473,7 @@ func toggleOutputVerbose(agent *Agent, cliAgent CLIAgent, term *Terminal) {
 	}
 	cfg := agent.appConfig
 	if cfg == nil {
-		cfg = defaultConfig()
+		cfg = api.DefaultConfig()
 		agent.appConfig = cfg
 	}
 	cfg.OutputVerbose = !cfg.OutputVerbose
@@ -1538,7 +1539,7 @@ func handleKeys(agent *Agent, term *Terminal) {
 		}
 		os.Setenv("ANTHROPIC_API_KEY", key)
 		agent.config.AnthropicKey = key
-		if err := SaveAnthropicKey(key); err != nil {
+		if err := api.SaveAnthropicKey(key); err != nil {
 			term.PrintSystem(fmt.Sprintf("Key set for this session (keychain unavailable: %s)", err))
 		} else {
 			AnimateMax(MoodHappy, "Key saved to OS keychain!")
@@ -1584,7 +1585,7 @@ Commands:
   /help          Show this help
   /quit          Exit
 
-Config examples:
+api.Config examples:
   /set model sonnet         Change default model
   /set project 42           Change default project
   /set professional true    Disable cat personality
@@ -1647,13 +1648,13 @@ func reconnectMCPTransport(cliAgent CLIAgent, term *Terminal) {
 	}
 }
 
-func printConfigInfo(cfg *Config, term *Terminal) {
+func printConfigInfo(cfg *api.Config, term *Terminal) {
 	if cfg == nil {
 		term.PrintSystem("No config loaded (using defaults).")
 		return
 	}
 	fmt.Println()
-	fmt.Printf("  %s\n", "qmax-code Config (~/.qmax-code/config.json)")
+	fmt.Printf("  %s\n", "qmax-code api.Config (~/.qmax-code/config.json)")
 	fmt.Printf("  %-20s %s\n", "Default model:", cfg.DefaultModel)
 	fmt.Printf("  %-20s %d\n", "Default project:", cfg.DefaultProject)
 	fmt.Printf("  %-20s %v\n", "Professional:", cfg.Professional)
@@ -1698,7 +1699,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 	value := parts[2]
 	cfg := agent.appConfig
 	if cfg == nil {
-		cfg = defaultConfig()
+		cfg = api.DefaultConfig()
 		agent.appConfig = cfg
 	}
 
@@ -1806,13 +1807,13 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 
 	case "apikey":
 		// Allow pasting API key directly: /set apikey qm-...
-		auth, err := LoginWithAPIKey(value)
+		auth, err := api.LoginWithAPIKey(value)
 		if err != nil {
 			term.PrintError(fmt.Sprintf("Invalid API key: %v", err))
 			return
 		}
 		agent.config.Context.Auth = auth
-		agent.config.Context.API = NewAPIClient(auth)
+		agent.config.Context.API = api.NewAPIClient(auth)
 		AnimateMax(MoodHappy, fmt.Sprintf("Connected as %s", auth.Email))
 		fmt.Println()
 		return // auth.json handles persistence
@@ -1886,7 +1887,7 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 		// Save Anthropic API key to OS keychain
 		os.Setenv("ANTHROPIC_API_KEY", value)
 		agent.config.AnthropicKey = value
-		if err := SaveAnthropicKey(value); err != nil {
+		if err := api.SaveAnthropicKey(value); err != nil {
 			term.PrintSystem(fmt.Sprintf("Key set for this session (keychain: %s)", err))
 		} else {
 			term.PrintSystem("Anthropic API key saved to OS keychain.")
@@ -1901,9 +1902,9 @@ func handleSetCommand(input string, agent *Agent, term *Terminal) {
 
 	// Persist to disk
 	if err := cfg.Save(); err != nil {
-		term.PrintError(fmt.Sprintf("Config updated in memory but failed to save: %v", err))
+		term.PrintError(fmt.Sprintf("api.Config updated in memory but failed to save: %v", err))
 	} else {
-		term.PrintSystem("Config saved to ~/.qmax-code/config.json")
+		term.PrintSystem("api.Config saved to ~/.qmax-code/config.json")
 	}
 }
 

--- a/mcp_server.go
+++ b/mcp_server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"github.com/qualitymax/qmax-code/internal/api"
 	"os"
 	"strconv"
 )
@@ -16,13 +17,13 @@ import (
 // The server exposes all qmax tools to Claude Code so CC can call them via
 // its native tool-use mechanism — no Anthropic API tokens consumed.
 func RunMCPServer() {
-	auth := LoadAuth()
-	var apiClient *APIClient
+	auth := api.LoadAuth()
+	var apiClient *api.APIClient
 	if auth != nil && auth.IsAuthenticated() {
-		apiClient = NewAPIClient(auth)
+		apiClient = api.NewAPIClient(auth)
 	}
 
-	appConfig := LoadQMaxCodeConfig()
+	appConfig := api.LoadQMaxCodeConfig()
 	sctx := &SessionContext{
 		QMaxCfg:   loadQMaxConfig(),
 		QMaxBin:   discoverQMaxBinary(),
@@ -136,7 +137,7 @@ func dispatchMCPRequest(req mcpRequest, sctx *SessionContext) mcpResponse {
 		// restarting the subprocess. ProjectID is read once at startup
 		// because it's plumbed via env; LiveFeed flips often enough
 		// during a session that a per-call disk read pays for itself.
-		if cfg := LoadQMaxCodeConfig(); cfg != nil {
+		if cfg := api.LoadQMaxCodeConfig(); cfg != nil {
 			sctx.LiveFeed = cfg.LiveFeed
 			if v := os.Getenv("QMAX_LIVE_FEED"); v == "1" || v == "true" {
 				sctx.LiveFeed = true

--- a/media.go
+++ b/media.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/qualitymax/qmax-code/internal/api"
 )
 
 const largePastedTextThreshold = 8 * 1024
@@ -109,7 +111,7 @@ func savePastedTextFile(text string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dir := filepath.Join(home, qmaxCodeConfigDir, "pastes")
+	dir := filepath.Join(home, api.QmaxCodeConfigDir, "pastes")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", err
 	}

--- a/ollama.go
+++ b/ollama.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/qualitymax/qmax-code/internal/api"
 	"io"
 	"net/http"
 	"net/url"
@@ -38,7 +39,7 @@ const (
 
 // NewOllamaClient creates a client if URL and model are configured.
 // Returns nil if not configured.
-func NewOllamaClient(cfg *Config) *OllamaClient {
+func NewOllamaClient(cfg *api.Config) *OllamaClient {
 	if cfg.OllamaURL == "" || cfg.OllamaModel == "" {
 		return nil
 	}

--- a/resolve_model_test.go
+++ b/resolve_model_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+func TestResolveModelUsesCentralModelConstants(t *testing.T) {
+	cases := map[string]string{
+		"haiku":  ModelHaiku,
+		"sonnet": ModelSonnet,
+		"opus":   ModelOpus,
+		"custom": "custom",
+	}
+	for input, want := range cases {
+		if got := resolveModel(input); got != want {
+			t.Errorf("resolveModel(%q) = %q, want %q", input, got, want)
+		}
+	}
+}

--- a/theme.go
+++ b/theme.go
@@ -1,6 +1,12 @@
 package main
 
-import "github.com/charmbracelet/lipgloss"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/qualitymax/qmax-code/internal/api"
+)
 
 // Theme defines the full color palette for the terminal UI.
 type Theme struct {
@@ -285,6 +291,35 @@ var allThemes = map[string]Theme{
 // ThemeNames returns available theme names in display order.
 func ThemeNames() []string {
 	return []string{"historic", "ocean", "neon", "ember", "aurora", "paper", "sky", "sparkling", "radiance", "goldenhour"}
+}
+
+// SaveTheme validates and persists the selected theme name on the config.
+// Empty value clears the preference (restoring the default). Lives here, not
+// on (*api.Config), so config.go has no dep on theme.go's name list.
+func SaveTheme(c *api.Config, theme string) error {
+	if c == nil {
+		return fmt.Errorf("config not loaded")
+	}
+	if theme != "" {
+		valid := false
+		for _, name := range ThemeNames() {
+			if name == theme {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return fmt.Errorf("invalid theme %q; available: %s", theme, strings.Join(ThemeNames(), ", "))
+		}
+	}
+
+	previous := c.Theme
+	c.Theme = theme
+	if err := c.Save(); err != nil {
+		c.Theme = previous
+		return err
+	}
+	return nil
 }
 
 // ThemeByName returns the named theme, defaulting to "historic".

--- a/tools.go
+++ b/tools.go
@@ -16,9 +16,19 @@ import (
 	"strings"
 	"time"
 
+	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/security"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 )
+
+// jsonError formats msg as a JSON-encoded error object after redaction.
+// Mirrors the helper in internal/api so tool handlers can return the same
+// shape without depending on api package internals.
+func jsonError(msg string) string {
+	msg = security.RedactSensitive(msg)
+	escaped, _ := json.Marshal(msg)
+	return fmt.Sprintf(`{"error": %s}`, string(escaped))
+}
 
 // limitWriter is an io.Writer that silently discards bytes once the cap is hit.
 // Use it as cmd.Stdout/Stderr to prevent unbounded memory growth from large
@@ -666,17 +676,17 @@ func ExecuteTool(name string, rawInput interface{}, sctx *SessionContext, ctx co
 // executeToolViaAPI handles tool execution through the QualityMax REST API.
 func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, ctx context.Context) string {
 	input := parseInput(rawInput)
-	api := sctx.API
+	client := sctx.API
 
 	switch name {
 	case "list_projects":
-		return api.ListProjects(ctx)
+		return client.ListProjects(ctx)
 
 	case "list_test_cases":
-		return api.ListTestCases(ctx, intVal(input, "project_id", sctx.ProjectID), intVal(input, "limit", 0), strVal(input, "search"))
+		return client.ListTestCases(ctx, intVal(input, "project_id", sctx.ProjectID), intVal(input, "limit", 0), strVal(input, "search"))
 
 	case "list_scripts":
-		return api.ListScripts(ctx, intVal(input, "project_id", sctx.ProjectID), intVal(input, "limit", 0))
+		return client.ListScripts(ctx, intVal(input, "project_id", sctx.ProjectID), intVal(input, "limit", 0))
 
 	case "generate_test_code":
 		// If the caller didn't pass a framework, fall back to the one the
@@ -693,75 +703,75 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 		// into the agent loop and trips up nearly every LLM.
 		fw := strVal(input, "framework")
 		if fw == "" {
-			if cfg := LoadQMaxCodeConfig(); cfg != nil {
+			if cfg := api.LoadQMaxCodeConfig(); cfg != nil {
 				fw = cfg.DefaultFramework
 			}
 		}
-		return api.GenerateTestCode(ctx, intVal(input, "test_case_id", 0), boolVal(input, "force"), fw)
+		return client.GenerateTestCode(ctx, intVal(input, "test_case_id", 0), boolVal(input, "force"), fw)
 
 	case "run_test":
-		return runTestWithProgress(ctx, api, sctx, intVal(input, "script_id", 0), boolVal(input, "headless"), strVal(input, "browser"), strVal(input, "base_url"))
+		return runTestWithProgress(ctx, client, sctx, intVal(input, "script_id", 0), boolVal(input, "headless"), strVal(input, "browser"), strVal(input, "base_url"))
 
 	case "run_native_test":
-		return api.RunNativeTest(ctx, intVal(input, "script_id", 0), strVal(input, "base_url"))
+		return client.RunNativeTest(ctx, intVal(input, "script_id", 0), strVal(input, "base_url"))
 
 	case "setup_cicd":
-		return api.SetupCICD(ctx, intVal(input, "repo_id", 0), strVal(input, "framework"), strVal(input, "target_branch"), strVal(input, "base_url"))
+		return client.SetupCICD(ctx, intVal(input, "repo_id", 0), strVal(input, "framework"), strVal(input, "target_branch"), strVal(input, "base_url"))
 
 	case "run_tests_batch":
-		return api.RunTestsBatch(ctx, strVal(input, "script_ids"), strVal(input, "base_url"), sctx.LiveFeed)
+		return client.RunTestsBatch(ctx, strVal(input, "script_ids"), strVal(input, "base_url"), sctx.LiveFeed)
 
 	case "check_test_status":
-		out := api.CheckTestStatus(ctx, strVal(input, "execution_id"))
+		out := client.CheckTestStatus(ctx, strVal(input, "execution_id"))
 		captureLiveURL(sctx, out)
 		return out
 
 	case "start_crawl":
-		return api.StartCrawl(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "url"),
+		return client.StartCrawl(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "url"),
 			intVal(input, "depth", 0), intVal(input, "pages", 0), strVal(input, "test_type"), strVal(input, "instructions"), sctx.LiveFeed)
 
 	case "crawl_status":
-		out := api.CrawlStatus(ctx, strVal(input, "crawl_id"))
+		out := client.CrawlStatus(ctx, strVal(input, "crawl_id"))
 		captureLiveURL(sctx, out)
 		return out
 
 	case "crawl_results":
-		return api.CrawlResults(ctx, strVal(input, "crawl_id"))
+		return client.CrawlResults(ctx, strVal(input, "crawl_id"))
 
 	case "list_crawl_jobs":
-		return api.ListCrawlJobs(ctx, intVal(input, "limit", 0))
+		return client.ListCrawlJobs(ctx, intVal(input, "limit", 0))
 
 	case "list_repos":
-		return api.ListRepos(ctx, intVal(input, "project_id", sctx.ProjectID))
+		return client.ListRepos(ctx, intVal(input, "project_id", sctx.ProjectID))
 
 	case "review_repo":
-		return api.ReviewRepo(ctx, intVal(input, "repo_id", 0))
+		return client.ReviewRepo(ctx, intVal(input, "repo_id", 0))
 
 	case "get_review_preferences":
-		return api.GetReviewPreferences(ctx, intVal(input, "repository_id", 0))
+		return client.GetReviewPreferences(ctx, intVal(input, "repository_id", 0))
 
 	case "set_review_preferences":
-		return api.SetReviewPreferences(ctx, strVal(input, "scope"), intVal(input, "repository_id", 0), input["preferences"])
+		return client.SetReviewPreferences(ctx, strVal(input, "scope"), intVal(input, "repository_id", 0), input["preferences"])
 
 	case "repo_coverage":
-		return api.RepoCoverage(ctx, intVal(input, "repo_id", 0))
+		return client.RepoCoverage(ctx, intVal(input, "repo_id", 0))
 
 	case "repo_quality":
-		return api.RepoQuality(ctx, intVal(input, "repo_id", 0))
+		return client.RepoQuality(ctx, intVal(input, "repo_id", 0))
 
 	case "import_repo":
-		return api.ImportRepo(ctx, strVal(input, "url"), intVal(input, "project_id", sctx.ProjectID),
+		return client.ImportRepo(ctx, strVal(input, "url"), intVal(input, "project_id", sctx.ProjectID),
 			boolVal(input, "create_project"), strVal(input, "project_name"), strVal(input, "base_url"), strVal(input, "training_consent"))
 
 	case "import_document":
-		return api.ImportDocument(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "text"), strVal(input, "source_name"))
+		return client.ImportDocument(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "text"), strVal(input, "source_name"))
 
 	case "create_pr":
-		prResp := api.CreatePR(ctx, intVal(input, "repo_id", 0), intVal(input, "project_id", sctx.ProjectID))
-		return chainSecurityAuditOnPR(ctx, api, sctx, prResp)
+		prResp := client.CreatePR(ctx, intVal(input, "repo_id", 0), intVal(input, "project_id", sctx.ProjectID))
+		return chainSecurityAuditOnPR(ctx, client, sctx, prResp)
 
 	case "get_script":
-		return api.GetScript(ctx, intVal(input, "script_id", 0))
+		return client.GetScript(ctx, intVal(input, "script_id", 0))
 
 	case "update_script":
 		code := strVal(input, "code")
@@ -772,83 +782,83 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 			return fmt.Sprintf(`{"error": "Security scan failed", "violations": %q}`, strings.Join(violations, "; "))
 		}
 		scriptID := intVal(input, "script_id", 0)
-		backup := api.GetScript(ctx, scriptID)
+		backup := client.GetScript(ctx, scriptID)
 		if !strings.HasPrefix(backup, `{"error"`) {
 			saveScriptBackup(fmt.Sprintf("%d", scriptID), backup)
 		}
-		return api.UpdateScript(ctx, scriptID, strVal(input, "name"), code)
+		return client.UpdateScript(ctx, scriptID, strVal(input, "name"), code)
 
 	case "check_job_status":
-		return api.CheckBackgroundJob(ctx, strVal(input, "job_id"))
+		return client.CheckBackgroundJob(ctx, strVal(input, "job_id"))
 
 	// --- k6 Performance Testing ---
 	case "k6_list_scripts":
-		return api.K6ListScripts(ctx, intVal(input, "project_id", sctx.ProjectID))
+		return client.K6ListScripts(ctx, intVal(input, "project_id", sctx.ProjectID))
 	case "k6_create_script":
-		return api.K6CreateScript(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "name"), strVal(input, "test_type"), strVal(input, "target_url"), strVal(input, "code"))
+		return client.K6CreateScript(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "name"), strVal(input, "test_type"), strVal(input, "target_url"), strVal(input, "code"))
 	case "k6_get_script":
-		return api.K6GetScript(ctx, intVal(input, "script_id", 0))
+		return client.K6GetScript(ctx, intVal(input, "script_id", 0))
 	case "k6_run_test":
-		return api.K6RunTest(ctx, intVal(input, "script_id", 0), intVal(input, "vus", 0), strVal(input, "duration"))
+		return client.K6RunTest(ctx, intVal(input, "script_id", 0), intVal(input, "vus", 0), strVal(input, "duration"))
 	case "k6_check_status":
-		return api.K6CheckStatus(ctx, strVal(input, "execution_id"))
+		return client.K6CheckStatus(ctx, strVal(input, "execution_id"))
 	case "k6_report":
-		return api.K6Report(ctx, strVal(input, "execution_id"))
+		return client.K6Report(ctx, strVal(input, "execution_id"))
 	case "k6_generate":
-		return api.K6Generate(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "target_url"), strVal(input, "test_type"), strVal(input, "endpoints"))
+		return client.K6Generate(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "target_url"), strVal(input, "test_type"), strVal(input, "endpoints"))
 	case "k6_convert":
-		return api.K6Convert(ctx, strVal(input, "source_code"), strVal(input, "source_framework"), strVal(input, "test_type"))
+		return client.K6Convert(ctx, strVal(input, "source_code"), strVal(input, "source_framework"), strVal(input, "test_type"))
 
 	// --- Test Case CRUD ---
 	case "create_test_case":
-		return api.CreateTestCase(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "title"), strVal(input, "description"), strVal(input, "category"), strVal(input, "priority"))
+		return client.CreateTestCase(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "title"), strVal(input, "description"), strVal(input, "category"), strVal(input, "priority"))
 	case "update_test_case":
-		return api.UpdateTestCase(ctx, intVal(input, "test_case_id", 0), strVal(input, "title"), strVal(input, "description"), strVal(input, "category"), strVal(input, "priority"), strVal(input, "status"))
+		return client.UpdateTestCase(ctx, intVal(input, "test_case_id", 0), strVal(input, "title"), strVal(input, "description"), strVal(input, "category"), strVal(input, "priority"), strVal(input, "status"))
 	case "delete_test_case":
-		return api.DeleteTestCase(ctx, intVal(input, "test_case_id", 0))
+		return client.DeleteTestCase(ctx, intVal(input, "test_case_id", 0))
 
 	// --- Project CRUD ---
 	case "create_project":
-		return api.CreateProject(ctx, strVal(input, "name"), strVal(input, "description"), strVal(input, "base_url"))
+		return client.CreateProject(ctx, strVal(input, "name"), strVal(input, "description"), strVal(input, "base_url"))
 	case "update_project":
-		return api.UpdateProject(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "name"), strVal(input, "description"), strVal(input, "base_url"))
+		return client.UpdateProject(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "name"), strVal(input, "description"), strVal(input, "base_url"))
 	case "delete_project":
-		return api.DeleteProject(ctx, intVal(input, "project_id", 0))
+		return client.DeleteProject(ctx, intVal(input, "project_id", 0))
 	case "get_project_by_slug":
-		return api.GetProjectBySlug(ctx, strVal(input, "slug"))
+		return client.GetProjectBySlug(ctx, strVal(input, "slug"))
 	case "get_project_summary":
-		return api.GetProjectSummary(ctx, intVal(input, "project_id", sctx.ProjectID))
+		return client.GetProjectSummary(ctx, intVal(input, "project_id", sctx.ProjectID))
 
 	// --- Framework Operations ---
 	case "trigger_framework_run":
-		return api.TriggerFrameworkRun(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "framework_type"))
+		return client.TriggerFrameworkRun(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "framework_type"))
 	case "export_framework":
-		return api.ExportFramework(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "framework"))
+		return client.ExportFramework(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "framework"))
 	case "get_install_command":
-		return api.GetInstallCommand(ctx, intVal(input, "project_id", sctx.ProjectID))
+		return client.GetInstallCommand(ctx, intVal(input, "project_id", sctx.ProjectID))
 
 	// --- AI-Powered ---
 	case "enhance_test_case":
-		return api.EnhanceTestCase(ctx, intVal(input, "test_case_id", 0))
+		return client.EnhanceTestCase(ctx, intVal(input, "test_case_id", 0))
 	case "generate_gap_tests":
-		return api.GenerateGapTests(ctx, intVal(input, "repo_id", 0))
+		return client.GenerateGapTests(ctx, intVal(input, "repo_id", 0))
 	case "start_crawl_from_test_case":
-		return api.StartCrawlFromTestCase(ctx, intVal(input, "test_case_id", 0))
+		return client.StartCrawlFromTestCase(ctx, intVal(input, "test_case_id", 0))
 
 	case "analyze_screenshot":
-		return analyzeScreenshot(ctx, api, strVal(input, "execution_id"), sctx)
+		return analyzeScreenshot(ctx, client, strVal(input, "execution_id"), sctx)
 	case "get_page_elements":
-		return getPageElements(ctx, api, strVal(input, "execution_id"), sctx)
+		return getPageElements(ctx, client, strVal(input, "execution_id"), sctx)
 
 	// --- QTML ---
 	case "export_qtml":
-		return api.ExportQTML(ctx, intVal(input, "project_id", sctx.ProjectID))
+		return client.ExportQTML(ctx, intVal(input, "project_id", sctx.ProjectID))
 	case "import_qtml":
-		return api.ImportQTML(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "content"))
+		return client.ImportQTML(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "content"))
 
 	// --- Deployment Testing ---
 	case "test_deployed_environment":
-		return api.TestDeployedEnvironment(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "url"))
+		return client.TestDeployedEnvironment(ctx, intVal(input, "project_id", sctx.ProjectID), strVal(input, "url"))
 
 	case "run_local_test":
 		return runLocalTest(ctx, sctx, intVal(input, "script_id", 0), strVal(input, "base_url"))
@@ -862,9 +872,9 @@ func executeToolViaAPI(name string, rawInput interface{}, sctx *SessionContext, 
 // When sctx.LiveFeed is true the test runs in a QM Cloud Sandbox; status
 // responses are scanned for `live_browser_url` and the freshest one is
 // stored on sctx for the REPL to auto-launch /browserfeed against.
-func runTestWithProgress(ctx context.Context, api *APIClient, sctx *SessionContext, scriptID int, headless bool, browser, baseURL string) string {
+func runTestWithProgress(ctx context.Context, client *api.APIClient, sctx *SessionContext, scriptID int, headless bool, browser, baseURL string) string {
 	// Start the test
-	raw := api.RunTest(ctx, scriptID, headless, browser, baseURL, sctx != nil && sctx.LiveFeed)
+	raw := client.RunTest(ctx, scriptID, headless, browser, baseURL, sctx != nil && sctx.LiveFeed)
 	if strings.HasPrefix(raw, `{"error"`) {
 		return raw
 	}
@@ -911,7 +921,7 @@ func runTestWithProgress(ctx context.Context, api *APIClient, sctx *SessionConte
 	for i := 0; i < 180; i++ { // max 6 minutes
 		time.Sleep(2 * time.Second)
 
-		statusRaw := api.CheckTestStatus(ctx, execID)
+		statusRaw := client.CheckTestStatus(ctx, execID)
 		captureLiveURL(sctx, statusRaw)
 		var status map[string]interface{}
 		if err := json.Unmarshal([]byte(statusRaw), &status); err != nil {
@@ -976,7 +986,7 @@ func runTestWithProgress(ctx context.Context, api *APIClient, sctx *SessionConte
 
 	ClearBrowserAnimation()
 	progress.Finish(false, "Timed out after 6 minutes")
-	final := api.CheckTestStatus(ctx, execID)
+	final := client.CheckTestStatus(ctx, execID)
 	captureLiveURL(sctx, final)
 	return annotateWithClientNote(final,
 		"Polling stopped after 6 minutes. Do NOT call check_test_status again — the run timed out.")
@@ -2397,12 +2407,12 @@ func obj(pp []propDef) map[string]interface{} {
 
 // analyzeScreenshot fetches the screenshot from a test execution and asks Claude Vision
 // to describe what's visible on the page.
-func analyzeScreenshot(ctx context.Context, api *APIClient, executionID string, sctx *SessionContext) string {
+func analyzeScreenshot(ctx context.Context, client *api.APIClient, executionID string, sctx *SessionContext) string {
 	if executionID == "" {
 		return jsonError("execution_id is required")
 	}
 
-	screenshotURL, err := getScreenshotURL(api, executionID, sctx)
+	screenshotURL, err := getScreenshotURL(client, executionID, sctx)
 	if err != "" {
 		return jsonError(err)
 	}
@@ -2419,12 +2429,12 @@ func analyzeScreenshot(ctx context.Context, api *APIClient, executionID string, 
 
 // getPageElements fetches the screenshot and asks Claude Vision to extract
 // interactive elements with suggested Playwright selectors.
-func getPageElements(ctx context.Context, api *APIClient, executionID string, sctx *SessionContext) string {
+func getPageElements(ctx context.Context, client *api.APIClient, executionID string, sctx *SessionContext) string {
 	if executionID == "" {
 		return jsonError("execution_id is required")
 	}
 
-	screenshotURL, err := getScreenshotURL(api, executionID, sctx)
+	screenshotURL, err := getScreenshotURL(client, executionID, sctx)
 	if err != "" {
 		return jsonError(err)
 	}
@@ -2440,8 +2450,8 @@ func getPageElements(ctx context.Context, api *APIClient, executionID string, sc
 }
 
 // getScreenshotURL fetches the screenshot URL from a test execution result.
-func getScreenshotURL(api *APIClient, executionID string, sctx *SessionContext) (string, string) {
-	raw := api.CheckTestStatus(context.Background(), executionID)
+func getScreenshotURL(client *api.APIClient, executionID string, sctx *SessionContext) (string, string) {
+	raw := client.CheckTestStatus(context.Background(), executionID)
 
 	var data map[string]interface{}
 	if err := json.Unmarshal([]byte(raw), &data); err != nil {
@@ -2550,7 +2560,7 @@ func callBackendVisionAnalysis(sctx *SessionContext, imageURL, prompt string) st
 
 // chainSecurityAuditOnPR fires a security audit PR check after create_pr succeeds
 // and appends the findings to the PR creation result so the agent can self-correct.
-func chainSecurityAuditOnPR(ctx context.Context, api *APIClient, sctx *SessionContext, prResp string) string {
+func chainSecurityAuditOnPR(ctx context.Context, client *api.APIClient, sctx *SessionContext, prResp string) string {
 	// Parse pr_number from the create_pr response.
 	var prData map[string]interface{}
 	prNumber := 0
@@ -2596,7 +2606,7 @@ func chainSecurityAuditOnPR(ctx context.Context, api *APIClient, sctx *SessionCo
 		return prResp // cannot determine base commit — skip security check
 	}
 
-	auditResp := api.SecurityAuditPRCheck(ctx, repoSlug, prNumber, baseSHA, headSHA)
+	auditResp := client.SecurityAuditPRCheck(ctx, repoSlug, prNumber, baseSHA, headSHA)
 
 	// Combine both results for the agent.
 	return fmt.Sprintf("%s\n\n--- Security Audit PR Check ---\n%s", prResp, auditResp)


### PR DESCRIPTION
## Summary

Phase 2 of the qmax-code package reorganization started in #81. Extracts the QualityMax/Anthropic backend layer into ${"`"}internal/api/${"`"} along Bodner's *Learning Go* boundaries: organize by what the package **provides**, not by what types it contains.

### Moved

| From | To |
|---|---|
| ${"`"}api_client.go${"`"} | ${"`"}internal/api/client.go${"`"} |
| ${"`"}auth.go${"`"} (slimmer — see below) | ${"`"}internal/api/auth.go${"`"} |
| ${"`"}keychain.go${"`"} | ${"`"}internal/api/keychain.go${"`"} |
| ${"`"}config.go${"`"} | ${"`"}internal/api/config.go${"`"} |
| ${"`"}api_client_*_test.go${"`"}, ${"`"}config_test.go${"`"} | ${"`"}internal/api/${"`"} |

### Pre-emptive refactors to avoid cycles

- **${"`"}UploadSessionMessages([]Message)${"`"} → ${"`"}UploadSessionEvents([]any)${"`"}.** The api package no longer references ${"`"}Message${"`"}. ${"`"}cloud_session.go${"`"} in main builds the discriminated-union events and trims via ${"`"}api.TrimEventsToFit${"`"} before upload.
- **${"`"}SaveTheme${"`"} moved off ${"`"}(*Config)${"`"}** to a free function in ${"`"}theme.go${"`"}, breaking the api → tui dep on ${"`"}ThemeNames${"`"}.
- **${"`"}Login{Interactive,ViaBrowser}${"`"} moved** from ${"`"}auth.go${"`"} into ${"`"}interactive_setup.go${"`"}. They need TUI helpers (${"`"}readSecret${"`"}, ${"`"}openBrowser${"`"}, ${"`"}SpinnerFrames${"`"}) that don't belong in api.
- **Legacy ${"`"}~/.qamax/config.json${"`"} fallback in ${"`"}LoadAuth${"`"}** reads a tiny inline struct instead of importing ${"`"}QMaxConfig${"`"} from ${"`"}context.go${"`"}.

### What stayed in main

- ${"`"}SessionContext${"`"} — its fields point into api (${"`"}*api.APIClient${"`"}, ${"`"}*api.AuthConfig${"`"}) so it lives where the **consumers** of api live. Not an api type.
- ${"`"}cloud_session.go${"`"} — uses ${"`"}Message${"`"}, owned by ${"`"}agent.go${"`"}.
- ${"`"}tools.go${"`"}, ${"`"}agent.go${"`"}, terminal/tui — Phase 3+.

### What didn't get created

- **No ${"`"}internal/core${"`"} or ${"`"}internal/types${"`"} package.** Bodner explicitly calls those out as code smells (${"`"}util${"`"} / ${"`"}common${"`"} / ${"`"}types${"`"} = "you haven't found the right organization"). Wire types stay where they're owned by behavior.

## Test plan
- [x] ${"`"}go build ./...${"`"} clean
- [x] ${"`"}go test ./...${"`"} all packages green
- [x] ${"`"}go vet ./...${"`"} clean
- [ ] Smoke test: ${"`"}qmax-code login${"`"} flow (browser auth + interactive key)
- [ ] Smoke test: cloud session upload survives a real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)