### PR TITLE
chore: bump version to 1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.16.2] - 2026-05-08
+
+### Changed
+- Phase 2 of the package reorg: extracted `internal/api` (api client, auth, keychain, config). `UploadSessionMessages([]Message)` is now `UploadSessionEvents([]any)` — the api package no longer references `Message`. `LoginInteractive` / `LoginViaBrowser` moved to `interactive_setup.go` since they need TUI helpers. Defensively `url.QueryEscape` the server-supplied auth code in the cli-poll URL. No user-visible behavior change.
+
 ## [1.16.1] - 2026-05-07
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.1"
+var Version = "1.16.2"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps `Version` to 1.16.2 to ship the `internal/api` extraction from #83.
- No user-visible behavior change.
- CHANGELOG entry added.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] After merge: tag `v1.16.2` from main; release workflow builds binaries and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)