### PR TITLE
chore: bump version to 1.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.16.3] - 2026-05-09
+
+### Changed
+- Phase 2 step 2 of the package reorg: extracted `internal/tui` (terminal, theme, input, progress, term_*, max_ascii, media, tui_backend), and moved the runtime context types (`SessionContext`, `TokenUsage`, `QMaxConfig`, `GitInfo`) plus Anthropic model constants into `internal/api`. `maskURL` consolidated into `internal/sysutil.MaskURL`. `ShowModelPicker` now takes a `ModelPickerOpts` struct. No user-visible behavior change.
+
 ## [1.16.2] - 2026-05-08
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.2"
+var Version = "1.16.3"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps `Version` to 1.16.3 to ship the `internal/tui` extraction from #85.
- No user-visible behavior change.
- CHANGELOG entry added.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] After merge: tag `v1.16.3` from main; release workflow builds binaries and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)