### PR TITLE
refactor: extract internal/session (Phase 2 step 3)

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/qualitymax/qmax-code/internal/api"
+	"github.com/qualitymax/qmax-code/internal/session"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
@@ -52,8 +53,8 @@ func (m OllamaMode) String() string {
 type Agent struct {
 	config          AgentConfig
 	appConfig       *api.Config // persistent user preferences
-	history         []Message
-	tools           []ToolDef
+	history         []api.Message
+	tools           []api.ToolDef
 	client          *http.Client
 	usage           api.TokenUsage
 	cancel          context.CancelFunc // cancel the current streaming request
@@ -64,72 +65,21 @@ type Agent struct {
 	sessionsFetched bool          // true once loadPriorSessions has run
 }
 
-// Message represents a conversation message.
-type Message struct {
-	Role    string      `json:"role"`
-	Content interface{} `json:"content"` // string or []ContentBlock
-}
-
-// ContentBlock is a typed content block in a message.
-type ContentBlock struct {
-	Type      string       `json:"type"`
-	Text      string       `json:"text,omitempty"`
-	ID        string       `json:"id,omitempty"`
-	Name      string       `json:"name,omitempty"`
-	Input     interface{}  `json:"input,omitempty"`
-	ToolUseID string       `json:"tool_use_id,omitempty"`
-	Content   string       `json:"content,omitempty"`
-	Source    *ImageSource `json:"source,omitempty"` // for type="image"
-}
-
-// ImageSource is the source data for an image content block.
-type ImageSource struct {
-	Type      string `json:"type"`       // "base64"
-	MediaType string `json:"media_type"` // "image/png", "image/jpeg", "image/gif", "image/webp"
-	Data      string `json:"data"`       // base64-encoded image data
-}
-
-// APIRequest is the Claude API request body.
-type APIRequest struct {
-	Model     string    `json:"model"`
-	MaxTokens int       `json:"max_tokens"`
-	System    string    `json:"system"`
-	Messages  []Message `json:"messages"`
-	Tools     []ToolDef `json:"tools"`
-	Stream    bool      `json:"stream"`
-}
-
-// APIResponse is the Claude API response (non-streaming).
-type APIResponse struct {
-	ID         string         `json:"id"`
-	Type       string         `json:"type"`
-	Role       string         `json:"role"`
-	Content    []ContentBlock `json:"content"`
-	StopReason string         `json:"stop_reason"`
-	Usage      APIUsage       `json:"usage"`
-}
-
-// APIUsage tracks token usage.
-type APIUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
-}
-
 // SSE event types from Anthropic streaming API
 type sseMessageStart struct {
 	Type    string `json:"type"`
 	Message struct {
-		ID         string   `json:"id"`
-		Role       string   `json:"role"`
-		StopReason *string  `json:"stop_reason"`
-		Usage      APIUsage `json:"usage"`
+		ID         string       `json:"id"`
+		Role       string       `json:"role"`
+		StopReason *string      `json:"stop_reason"`
+		Usage      api.APIUsage `json:"usage"`
 	} `json:"message"`
 }
 
 type sseContentBlockStart struct {
-	Type         string       `json:"type"`
-	Index        int          `json:"index"`
-	ContentBlock ContentBlock `json:"content_block"`
+	Type         string           `json:"type"`
+	Index        int              `json:"index"`
+	ContentBlock api.ContentBlock `json:"content_block"`
 }
 
 type sseContentBlockDelta struct {
@@ -156,7 +106,7 @@ type sseMessageDelta struct {
 func NewAgent(cfg AgentConfig) *Agent {
 	return &Agent{
 		config:  cfg,
-		history: []Message{},
+		history: []api.Message{},
 		tools:   BuildToolDefs(),
 		client:  &http.Client{Timeout: 300 * time.Second},
 	}
@@ -164,7 +114,7 @@ func NewAgent(cfg AgentConfig) *Agent {
 
 // ClearHistory resets conversation history.
 func (a *Agent) ClearHistory() {
-	a.history = []Message{}
+	a.history = []api.Message{}
 }
 
 // CancelCurrent cancels the current streaming request if one is in progress.
@@ -177,7 +127,7 @@ func (a *Agent) CancelCurrent() {
 // Run executes a prompt through the agent loop and returns the final text response.
 // Used for non-interactive (one-shot) mode.
 func (a *Agent) Run(prompt string) (string, error) {
-	a.history = append(a.history, Message{
+	a.history = append(a.history, api.Message{
 		Role:    "user",
 		Content: prompt,
 	})
@@ -188,14 +138,14 @@ func (a *Agent) Run(prompt string) (string, error) {
 			return "", fmt.Errorf("API call failed: %w", err)
 		}
 
-		a.history = append(a.history, Message{
+		a.history = append(a.history, api.Message{
 			Role:    "assistant",
 			Content: resp.Content,
 		})
 
 		if resp.StopReason == "tool_use" {
 			toolResults := a.executeToolCalls(resp.Content, context.Background())
-			a.history = append(a.history, Message{
+			a.history = append(a.history, api.Message{
 				Role:    "user",
 				Content: toolResults,
 			})
@@ -245,7 +195,7 @@ func (a *Agent) compressHistory() {
 			} else {
 				summary.WriteString(fmt.Sprintf("%s: %s\n", role, v))
 			}
-		case []ContentBlock:
+		case []api.ContentBlock:
 			for _, block := range v {
 				if block.Type == "text" && block.Text != "" {
 					text := block.Text
@@ -267,17 +217,17 @@ func (a *Agent) compressHistory() {
 	}
 
 	// Replace history with summary + recent messages.
-	// Use []ContentBlock for assistant to avoid API validation issues.
-	compressed := []Message{
+	// Use []api.ContentBlock for assistant to avoid API validation issues.
+	compressed := []api.Message{
 		{Role: "user", Content: summary.String()},
-		{Role: "assistant", Content: []ContentBlock{{Type: "text", Text: "Got it, I have the context from our earlier conversation."}}},
+		{Role: "assistant", Content: []api.ContentBlock{{Type: "text", Text: "Got it, I have the context from our earlier conversation."}}},
 	}
 	// Keep last 6 messages, but ensure tool_result messages stay paired with their tool_use
 	keep := a.history[len(a.history)-6:]
 	// If the first kept message is a user tool_result without a preceding assistant tool_use,
 	// skip it to avoid orphaned tool_results
 	if len(keep) > 0 && keep[0].Role == "user" {
-		if blocks, ok := keep[0].Content.([]ContentBlock); ok && len(blocks) > 0 && blocks[0].Type == "tool_result" {
+		if blocks, ok := keep[0].Content.([]api.ContentBlock); ok && len(blocks) > 0 && blocks[0].Type == "tool_result" {
 			keep = keep[1:] // skip orphaned tool_result
 		}
 	}
@@ -288,12 +238,12 @@ func (a *Agent) compressHistory() {
 // RunStreaming executes a prompt with real-time SSE streaming to the terminal.
 // BuildUserContent creates a content payload for a user message.
 // estimateMessageChars estimates the character count of a message's content,
-// handling both typed []ContentBlock and deserialized []interface{} from JSON.
-func estimateMessageChars(msg Message) int {
+// handling both typed []api.ContentBlock and deserialized []interface{} from JSON.
+func estimateMessageChars(msg api.Message) int {
 	switch v := msg.Content.(type) {
 	case string:
 		return len(v)
-	case []ContentBlock:
+	case []api.ContentBlock:
 		n := 0
 		for _, block := range v {
 			n += len(block.Text) + len(block.Content)
@@ -323,11 +273,11 @@ func BuildUserContent(text string, images []tui.ImageAttachment) interface{} {
 	if len(images) == 0 {
 		return text
 	}
-	blocks := make([]ContentBlock, 0, len(images)+1)
+	blocks := make([]api.ContentBlock, 0, len(images)+1)
 	for _, img := range images {
-		blocks = append(blocks, ContentBlock{
+		blocks = append(blocks, api.ContentBlock{
 			Type: "image",
-			Source: &ImageSource{
+			Source: &api.ImageSource{
 				Type:      "base64",
 				MediaType: img.MediaType,
 				Data:      img.Data,
@@ -335,7 +285,7 @@ func BuildUserContent(text string, images []tui.ImageAttachment) interface{} {
 		})
 	}
 	if text != "" {
-		blocks = append(blocks, ContentBlock{
+		blocks = append(blocks, api.ContentBlock{
 			Type: "text",
 			Text: text,
 		})
@@ -345,7 +295,7 @@ func BuildUserContent(text string, images []tui.ImageAttachment) interface{} {
 
 // RunStreamingWithImages is like RunStreaming but supports image attachments.
 func (a *Agent) RunStreamingWithImages(prompt string, images []tui.ImageAttachment, term *tui.Terminal) (string, error) {
-	a.history = append(a.history, Message{
+	a.history = append(a.history, api.Message{
 		Role:    "user",
 		Content: BuildUserContent(prompt, images),
 	})
@@ -354,7 +304,7 @@ func (a *Agent) RunStreamingWithImages(prompt string, images []tui.ImageAttachme
 }
 
 func (a *Agent) RunStreaming(prompt string, term *tui.Terminal) (string, error) {
-	a.history = append(a.history, Message{
+	a.history = append(a.history, api.Message{
 		Role:    "user",
 		Content: prompt,
 	})
@@ -365,7 +315,7 @@ func (a *Agent) RunStreaming(prompt string, term *tui.Terminal) (string, error) 
 func (a *Agent) runStreamingLoop(term *tui.Terminal) (string, error) {
 	for iterations := 0; iterations < maxIterations; iterations++ {
 		// Sanitize + compress history before each API call
-		sanitizeSessionMessages(a.history)
+		session.SanitizeSessionMessages(a.history)
 		a.compressHistory()
 		model := a.modelForIteration(iterations)
 		if a.config.Verbose {
@@ -398,9 +348,9 @@ func (a *Agent) runStreamingLoop(term *tui.Terminal) (string, error) {
 				a.cancel = nil
 				cancel()
 				if ollamaErr == nil && ollamaText != "" {
-					a.history = append(a.history, Message{
+					a.history = append(a.history, api.Message{
 						Role:    "assistant",
-						Content: []ContentBlock{{Type: "text", Text: ollamaText}},
+						Content: []api.ContentBlock{{Type: "text", Text: ollamaText}},
 					})
 					term.FinishMarkdown(ollamaText)
 					return ollamaText, nil
@@ -420,14 +370,14 @@ func (a *Agent) runStreamingLoop(term *tui.Terminal) (string, error) {
 		}
 
 		// Add assistant response to history
-		a.history = append(a.history, Message{
+		a.history = append(a.history, api.Message{
 			Role:    "assistant",
 			Content: content,
 		})
 
 		// If stop reason is tool_use, execute tools and loop
 		if stopReason == "tool_use" {
-			var toolCalls []ContentBlock
+			var toolCalls []api.ContentBlock
 			for _, block := range content {
 				if block.Type == "tool_use" {
 					toolCalls = append(toolCalls, block)
@@ -440,7 +390,7 @@ func (a *Agent) runStreamingLoop(term *tui.Terminal) (string, error) {
 			a.cancel = nil
 			cancel()
 
-			a.history = append(a.history, Message{
+			a.history = append(a.history, api.Message{
 				Role:    "user",
 				Content: toolResults,
 			})
@@ -517,14 +467,14 @@ func (a *Agent) modelForIteration(iteration int) string {
 }
 
 // callStreamingAPI makes a streaming request to the Claude API and processes SSE events.
-func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]ContentBlock, string, error) {
+func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]api.ContentBlock, string, error) {
 	systemPrompt := a.buildSystemPrompt()
 
 	// Sanitize messages — ensure Content is always a valid type for the API.
 	// Claude API accepts: string OR array of content blocks.
-	// After JSON round-trips, []ContentBlock can become []interface{} — that's still valid
+	// After JSON round-trips, []api.ContentBlock can become []interface{} — that's still valid
 	// as json.Marshal will serialize it correctly. Only fix nil/unexpected scalars.
-	sanitized := make([]Message, len(a.history))
+	sanitized := make([]api.Message, len(a.history))
 	for i, msg := range a.history {
 		sanitized[i] = msg
 		switch v := sanitized[i].Content.(type) {
@@ -534,12 +484,12 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]ContentBlo
 			// a bare string causes "Input should be a valid list" errors.
 			// Wrap it in a content block array.
 			if msg.Role == "user" && strings.Contains(v, "tool_result") {
-				sanitized[i].Content = []ContentBlock{{Type: "text", Text: v}}
+				sanitized[i].Content = []api.ContentBlock{{Type: "text", Text: v}}
 			}
-		case []ContentBlock:
+		case []api.ContentBlock:
 			// valid — structured content blocks
 		case []interface{}:
-			// valid — this is []ContentBlock after JSON deserialization via interface{}
+			// valid — this is []api.ContentBlock after JSON deserialization via interface{}
 			// json.Marshal will serialize it correctly as an array
 		case nil:
 			sanitized[i].Content = ""
@@ -547,7 +497,7 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]ContentBlo
 			// Unknown type — wrap in a content block array to satisfy the API
 			_ = v
 			data, _ := json.Marshal(sanitized[i].Content)
-			sanitized[i].Content = []ContentBlock{{Type: "text", Text: string(data)}}
+			sanitized[i].Content = []api.ContentBlock{{Type: "text", Text: string(data)}}
 		}
 	}
 
@@ -563,7 +513,7 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]ContentBlo
 	// text blocks.
 	sanitized = stripOrphanedToolUse(sanitized)
 
-	reqBody := APIRequest{
+	reqBody := api.APIRequest{
 		Model:     model,
 		MaxTokens: 8192,
 		System:    systemPrompt,
@@ -624,7 +574,7 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]ContentBlo
 
 	// Parse SSE stream
 	var (
-		content      []ContentBlock
+		content      []api.ContentBlock
 		currentIndex = -1
 		currentText  strings.Builder
 		currentJSON  strings.Builder
@@ -692,7 +642,7 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]ContentBlo
 				case "tool_use":
 					currentJSON.Reset()
 					// Add placeholder block — will fill Input after accumulating JSON
-					content = append(content, ContentBlock{
+					content = append(content, api.ContentBlock{
 						Type: "tool_use",
 						ID:   ev.ContentBlock.ID,
 						Name: ev.ContentBlock.Name,
@@ -764,18 +714,18 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]ContentBlo
 }
 
 // finalizeTextBlock adds a completed text block to content.
-func (a *Agent) finalizeTextBlock(content []ContentBlock, index int, text string) []ContentBlock {
-	return append(content, ContentBlock{
+func (a *Agent) finalizeTextBlock(content []api.ContentBlock, index int, text string) []api.ContentBlock {
+	return append(content, api.ContentBlock{
 		Type: "text",
 		Text: text,
 	})
 }
 
 // callAPI makes a non-streaming request to the Claude API (used for one-shot mode).
-func (a *Agent) callAPI() (*APIResponse, error) {
+func (a *Agent) callAPI() (*api.APIResponse, error) {
 	systemPrompt := a.buildSystemPrompt()
 
-	reqBody := APIRequest{
+	reqBody := api.APIRequest{
 		Model:     a.config.Model,
 		MaxTokens: 8192,
 		System:    systemPrompt,
@@ -816,7 +766,7 @@ func (a *Agent) callAPI() (*APIResponse, error) {
 		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(body))
 	}
 
-	var apiResp APIResponse
+	var apiResp api.APIResponse
 	if err := json.Unmarshal(body, &apiResp); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
@@ -835,14 +785,14 @@ func (a *Agent) callAPI() (*APIResponse, error) {
 }
 
 // executeToolCalls runs tool calls and returns results (non-interactive mode).
-func (a *Agent) executeToolCalls(content []ContentBlock, ctx context.Context) []ContentBlock {
-	var results []ContentBlock
+func (a *Agent) executeToolCalls(content []api.ContentBlock, ctx context.Context) []api.ContentBlock {
+	var results []api.ContentBlock
 	for _, block := range content {
 		if block.Type != "tool_use" {
 			continue
 		}
 		output := ExecuteTool(block.Name, block.Input, a.config.Context, ctx)
-		results = append(results, ContentBlock{
+		results = append(results, api.ContentBlock{
 			Type:      "tool_result",
 			ToolUseID: block.ID,
 			Content:   output,
@@ -852,15 +802,15 @@ func (a *Agent) executeToolCalls(content []ContentBlock, ctx context.Context) []
 }
 
 // executeToolCallsWithUI runs tool calls with terminal feedback.
-func (a *Agent) executeToolCallsWithUI(toolCalls []ContentBlock, term *tui.Terminal, ctx context.Context) []ContentBlock {
-	var results []ContentBlock
+func (a *Agent) executeToolCallsWithUI(toolCalls []api.ContentBlock, term *tui.Terminal, ctx context.Context) []api.ContentBlock {
+	var results []api.ContentBlock
 	for _, block := range toolCalls {
 		a.logger.Info("tool", block.Name, map[string]interface{}{"cost": ToolCost(block.Name)})
 		output := ExecuteTool(block.Name, block.Input, a.config.Context, ctx)
 		summarized := SummarizeToolResult(block.Name, output)
 		term.PrintToolResult(block.Name, summarized)
 
-		results = append(results, ContentBlock{
+		results = append(results, api.ContentBlock{
 			Type:      "tool_result",
 			ToolUseID: block.ID,
 			Content:   summarized,
@@ -871,7 +821,7 @@ func (a *Agent) executeToolCallsWithUI(toolCalls []ContentBlock, term *tui.Termi
 
 // extractText pulls text content from response blocks.
 func (a *Agent) extractText(content interface{}) string {
-	blocks, ok := content.([]ContentBlock)
+	blocks, ok := content.([]api.ContentBlock)
 	if !ok {
 		// Try to extract from interface
 		if s, ok := content.(string); ok {
@@ -1090,7 +1040,7 @@ You MUST call list_projects first to get the slug. Never guess it.
 
 	// Add session context
 	if a.config.Context.ProjectID > 0 {
-		prompt += fmt.Sprintf("\n## Active Session\n- Project ID: %d\n", a.config.Context.ProjectID)
+		prompt += fmt.Sprintf("\n## Active session.Session\n- Project ID: %d\n", a.config.Context.ProjectID)
 	}
 	if cloudURL != "" {
 		prompt += fmt.Sprintf("- QualityMax API: %s\n", cloudURL)
@@ -1108,7 +1058,7 @@ You MUST call list_projects first to get the slug. Never guess it.
 		budgetThreshold = a.appConfig.MaxTokenBudget * 40 / 100 // warn at 40% of budget
 	}
 	if a.usage.TotalTokens() > budgetThreshold {
-		prompt += fmt.Sprintf("\n⚠️ HIGH TOKEN USAGE: Session has used %d tokens. Be extra concise.\n", a.usage.TotalTokens())
+		prompt += fmt.Sprintf("\n⚠️ HIGH TOKEN USAGE: session.Session has used %d tokens. Be extra concise.\n", a.usage.TotalTokens())
 	}
 
 	prompt += outputStyleDirective(a.config.OutputVerbose)
@@ -1146,13 +1096,13 @@ You MUST call list_projects first to get the slug. Never guess it.
 // tool_use blocks from the assistant message (keeping text). Edge case:
 // if this leaves the assistant message empty, insert a placeholder text
 // block so the API doesn't reject the message for being empty.
-func stripOrphanedToolUse(messages []Message) []Message {
+func stripOrphanedToolUse(messages []api.Message) []api.Message {
 	// Helper: extract block types + tool_use_ids from a Content value.
-	// Handles both []ContentBlock (typed) and []interface{} (post-JSON).
+	// Handles both []api.ContentBlock (typed) and []interface{} (post-JSON).
 	collectIDs := func(content interface{}, blockType string) []string {
 		var ids []string
 		switch v := content.(type) {
-		case []ContentBlock:
+		case []api.ContentBlock:
 			for _, b := range v {
 				if b.Type == blockType {
 					switch blockType {
@@ -1190,8 +1140,8 @@ func stripOrphanedToolUse(messages []Message) []Message {
 	// value. Preserves block type (typed vs interface list).
 	pruneToolUse := func(content interface{}) interface{} {
 		switch v := content.(type) {
-		case []ContentBlock:
-			kept := make([]ContentBlock, 0, len(v))
+		case []api.ContentBlock:
+			kept := make([]api.ContentBlock, 0, len(v))
 			for _, b := range v {
 				if b.Type == "tool_use" {
 					continue
@@ -1261,8 +1211,8 @@ func stripOrphanedToolUse(messages []Message) []Message {
 // placeholders emitted by pruneToolUse stay in sync.
 const orphanPlaceholderText = "[tool call dropped — no matching result]"
 
-func orphanPlaceholderTyped() ContentBlock {
-	return ContentBlock{Type: "text", Text: orphanPlaceholderText}
+func orphanPlaceholderTyped() api.ContentBlock {
+	return api.ContentBlock{Type: "text", Text: orphanPlaceholderText}
 }
 
 func orphanPlaceholderMap() map[string]interface{} {

--- a/cc_agent_session_test.go
+++ b/cc_agent_session_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/qualitymax/qmax-code/internal/api"
+	"github.com/qualitymax/qmax-code/internal/session"
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
@@ -47,14 +48,14 @@ func (m *mockCLIAgent) SetOutputVerbose(bool) {}
 // historyAfterCLITurns simulates the fixed main-loop path for N turns:
 // calls mockCLIAgent.Run() and mirrors each successful turn into history.
 // This is the exact logic added to main.go in the fix.
-func historyAfterCLITurns(agent *mockCLIAgent, turns []string) []Message {
-	var history []Message
+func historyAfterCLITurns(agent *mockCLIAgent, turns []string) []api.Message {
+	var history []api.Message
 	for _, userMsg := range turns {
 		result, err := agent.Run(userMsg, nil)
 		if err == nil {
 			history = append(history,
-				Message{Role: "user", Content: userMsg},
-				Message{Role: "assistant", Content: result},
+				api.Message{Role: "user", Content: userMsg},
+				api.Message{Role: "assistant", Content: result},
 			)
 		}
 	}
@@ -109,19 +110,19 @@ func TestCLIAgentSessionSavedWithCorrectTurns(t *testing.T) {
 	if len(history) == 0 {
 		t.Fatal("history is empty — mirroring fix not applied, autoSave would no-op")
 	}
-	if err := SaveSession(sessionID, history, 0, api.TokenUsage{}, "cc"); err != nil {
+	if err := session.SaveSession(sessionID, history, 0, api.TokenUsage{}, "cc"); err != nil {
 		t.Fatalf("SaveSession: %v", err)
 	}
 
-	session, err := LoadSession(sessionID)
+	sess, err := session.LoadSession(sessionID)
 	if err != nil {
 		t.Fatalf("LoadSession: %v", err)
 	}
-	if session.Turns != 2 {
-		t.Errorf("Turns: got %d, want 2", session.Turns)
+	if sess.Turns != 2 {
+		t.Errorf("Turns: got %d, want 2", sess.Turns)
 	}
-	if len(session.Messages) != 4 {
-		t.Errorf("Messages: got %d, want 4", len(session.Messages))
+	if len(sess.Messages) != 4 {
+		t.Errorf("Messages: got %d, want 4", len(sess.Messages))
 	}
 }
 
@@ -147,26 +148,26 @@ func TestCLIAgentMultiTurnSessionAccumulates(t *testing.T) {
 	agent := &mockCLIAgent{responses: []string{"r1", "r2", "r3", "r4", "r5"}}
 	sessionID := "multi-turn-cli"
 
-	var history []Message
+	var history []api.Message
 	for i, msg := range []string{"t1", "t2", "t3", "t4", "t5"} {
 		result, err := agent.Run(msg, nil)
 		if err == nil {
 			history = append(history,
-				Message{Role: "user", Content: msg},
-				Message{Role: "assistant", Content: result},
+				api.Message{Role: "user", Content: msg},
+				api.Message{Role: "assistant", Content: result},
 			)
 		}
-		if err := SaveSession(sessionID, history, 0, api.TokenUsage{}, "cc"); err != nil {
+		if err := session.SaveSession(sessionID, history, 0, api.TokenUsage{}, "cc"); err != nil {
 			t.Fatalf("turn %d: SaveSession: %v", i+1, err)
 		}
 
-		session, err := LoadSession(sessionID)
+		sess, err := session.LoadSession(sessionID)
 		if err != nil {
 			t.Fatalf("turn %d: LoadSession: %v", i+1, err)
 		}
 		want := i + 1
-		if session.Turns != want {
-			t.Errorf("after turn %d: Turns = %d, want %d", i+1, session.Turns, want)
+		if sess.Turns != want {
+			t.Errorf("after turn %d: Turns = %d, want %d", i+1, sess.Turns, want)
 		}
 	}
 }

--- a/internal/api/messages.go
+++ b/internal/api/messages.go
@@ -1,0 +1,63 @@
+package api
+
+// Anthropic Messages API wire types. Kept in this package because they're
+// the on-the-wire shape of /v1/messages requests and responses, and because
+// session persistence + agent + cloud upload all need to round-trip them.
+
+// Message represents a conversation message.
+type Message struct {
+	Role    string      `json:"role"`
+	Content interface{} `json:"content"` // string or []ContentBlock
+}
+
+// ContentBlock is a typed content block in a message.
+type ContentBlock struct {
+	Type      string       `json:"type"`
+	Text      string       `json:"text,omitempty"`
+	ID        string       `json:"id,omitempty"`
+	Name      string       `json:"name,omitempty"`
+	Input     interface{}  `json:"input,omitempty"`
+	ToolUseID string       `json:"tool_use_id,omitempty"`
+	Content   string       `json:"content,omitempty"`
+	Source    *ImageSource `json:"source,omitempty"` // for type="image"
+}
+
+// ImageSource is the source data for an image content block.
+type ImageSource struct {
+	Type      string `json:"type"`       // "base64"
+	MediaType string `json:"media_type"` // "image/png", "image/jpeg", "image/gif", "image/webp"
+	Data      string `json:"data"`       // base64-encoded image data
+}
+
+// APIRequest is the Claude API request body.
+type APIRequest struct {
+	Model     string    `json:"model"`
+	MaxTokens int       `json:"max_tokens"`
+	System    string    `json:"system"`
+	Messages  []Message `json:"messages"`
+	Tools     []ToolDef `json:"tools"`
+	Stream    bool      `json:"stream"`
+}
+
+// APIResponse is the Claude API response (non-streaming).
+type APIResponse struct {
+	ID         string         `json:"id"`
+	Type       string         `json:"type"`
+	Role       string         `json:"role"`
+	Content    []ContentBlock `json:"content"`
+	StopReason string         `json:"stop_reason"`
+	Usage      APIUsage       `json:"usage"`
+}
+
+// APIUsage tracks token usage on a single request/response.
+type APIUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// ToolDef is a Claude API tool definition.
+type ToolDef struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	InputSchema map[string]interface{} `json:"input_schema"`
+}

--- a/internal/session/cloud_session.go
+++ b/internal/session/cloud_session.go
@@ -1,4 +1,4 @@
-package main
+package session
 
 import (
 	"context"
@@ -9,13 +9,13 @@ import (
 	"github.com/qualitymax/qmax-code/internal/api"
 )
 
-// promptCloudSyncConsent asks the user once whether they want sessions synced
+// PromptCloudSyncConsent asks the user once whether they want sessions synced
 // to the QualityMax cloud. The answer is persisted in cfg so the prompt never
 // appears again. Returns true if the user opted in.
 //
 // readLine must use the active readline instance (e.g. term.ReadConsent) so
 // that it works correctly when readline already owns the terminal in raw mode.
-func promptCloudSyncConsent(cfg *api.Config, readLine func() (string, error)) bool {
+func PromptCloudSyncConsent(cfg *api.Config, readLine func() (string, error)) bool {
 	fmt.Println()
 	fmt.Println("  ┌─ Cloud session sync ──────────────────────────────────────────┐")
 	fmt.Println("  │  qmax-code can sync your sessions to the QualityMax cloud so  │")
@@ -28,7 +28,7 @@ func promptCloudSyncConsent(cfg *api.Config, readLine func() (string, error)) bo
 
 	line, _ := readLine()
 
-	enabled := applyCloudSyncChoice(cfg, line)
+	enabled := ApplyCloudSyncChoice(cfg, line)
 	if enabled {
 		fmt.Println("  Cloud session sync enabled.")
 	} else {
@@ -38,10 +38,10 @@ func promptCloudSyncConsent(cfg *api.Config, readLine func() (string, error)) bo
 	return enabled
 }
 
-// applyCloudSyncChoice parses a raw answer line, updates cfg.CloudSync, and
-// persists it. Extracted from promptCloudSyncConsent so it can be unit-tested
+// ApplyCloudSyncChoice parses a raw answer line, updates cfg.CloudSync, and
+// persists it. Extracted from PromptCloudSyncConsent so it can be unit-tested
 // without touching stdin/stdout.
-func applyCloudSyncChoice(cfg *api.Config, line string) bool {
+func ApplyCloudSyncChoice(cfg *api.Config, line string) bool {
 	ans := strings.ToLower(strings.TrimSpace(line))
 	enabled := ans == "" || ans == "y" || ans == "yes"
 	v := enabled
@@ -50,15 +50,15 @@ func applyCloudSyncChoice(cfg *api.Config, line string) bool {
 	return enabled
 }
 
-// cloudSessionTracker manages the lifecycle of a cloud-tracked agent session.
+// CloudSessionTracker manages the lifecycle of a cloud-tracked agent session.
 // Zero value is ready to use — no initialisation needed.
-type cloudSessionTracker struct {
+type CloudSessionTracker struct {
 	cloudID string
 }
 
 // Start opens a cloud session the first time it is called with a valid API
 // client and non-zero project ID. Subsequent calls are no-ops (idempotent).
-func (t *cloudSessionTracker) Start(client *api.APIClient, projectID int, model string) {
+func (t *CloudSessionTracker) Start(client *api.APIClient, projectID int, model string) {
 	if client == nil || projectID == 0 || t.cloudID != "" {
 		return
 	}
@@ -70,7 +70,7 @@ func (t *cloudSessionTracker) Start(client *api.APIClient, projectID int, model 
 // Complete patches the cloud session as finished and uploads the full message
 // history. No-op if Start was never called successfully (cloudID is empty) or
 // client is nil.
-func (t *cloudSessionTracker) Complete(client *api.APIClient, totalTokens int, summary string, messages []Message) {
+func (t *CloudSessionTracker) Complete(client *api.APIClient, totalTokens int, summary string, messages []api.Message) {
 	if client == nil || t.cloudID == "" {
 		return
 	}

--- a/internal/session/cloud_session_test.go
+++ b/internal/session/cloud_session_test.go
@@ -1,9 +1,10 @@
-package main
+package session
 
 import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/qualitymax/qmax-code/internal/api"
@@ -24,18 +25,29 @@ func newTestClient(t *testing.T, handler http.HandlerFunc) (*api.APIClient, *htt
 	}, srv
 }
 
-// ---- applyCloudSyncChoice ----
+// withTempHome points $HOME at a fresh temp dir for the test and restores it
+// in cleanup. Local copy of the helper in main package's config_command_test.go.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	orig := os.Getenv("HOME")
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	t.Cleanup(func() { os.Setenv("HOME", orig) })
+	return tmp
+}
+
+// ---- ApplyCloudSyncChoice ----
 
 func TestApplyCloudSyncChoice_YesVariants(t *testing.T) {
 	for _, line := range []string{"y\n", "Y\n", "yes\n", "YES\n", "\n", "  \n"} {
 		withTempHome(t)
 		cfg := api.DefaultConfig()
-		got := applyCloudSyncChoice(cfg, line)
+		got := ApplyCloudSyncChoice(cfg, line)
 		if !got {
-			t.Errorf("applyCloudSyncChoice(%q): got false, want true", line)
+			t.Errorf("ApplyCloudSyncChoice(%q): got false, want true", line)
 		}
 		if cfg.CloudSync == nil || !*cfg.CloudSync {
-			t.Errorf("applyCloudSyncChoice(%q): cfg.CloudSync not set to true", line)
+			t.Errorf("ApplyCloudSyncChoice(%q): cfg.CloudSync not set to true", line)
 		}
 	}
 }
@@ -44,12 +56,12 @@ func TestApplyCloudSyncChoice_NoVariants(t *testing.T) {
 	for _, line := range []string{"n\n", "N\n", "no\n", "NO\n"} {
 		withTempHome(t)
 		cfg := api.DefaultConfig()
-		got := applyCloudSyncChoice(cfg, line)
+		got := ApplyCloudSyncChoice(cfg, line)
 		if got {
-			t.Errorf("applyCloudSyncChoice(%q): got true, want false", line)
+			t.Errorf("ApplyCloudSyncChoice(%q): got true, want false", line)
 		}
 		if cfg.CloudSync == nil || *cfg.CloudSync {
-			t.Errorf("applyCloudSyncChoice(%q): cfg.CloudSync not set to false", line)
+			t.Errorf("ApplyCloudSyncChoice(%q): cfg.CloudSync not set to false", line)
 		}
 	}
 }
@@ -57,7 +69,7 @@ func TestApplyCloudSyncChoice_NoVariants(t *testing.T) {
 func TestApplyCloudSyncChoice_PersistsToDisk(t *testing.T) {
 	withTempHome(t)
 	cfg := api.DefaultConfig()
-	applyCloudSyncChoice(cfg, "y\n")
+	ApplyCloudSyncChoice(cfg, "y\n")
 
 	loaded := api.LoadQMaxCodeConfig()
 	if loaded.CloudSync == nil || !*loaded.CloudSync {
@@ -103,11 +115,11 @@ func TestConfigCloudSync_FalsePersistedAndLoaded(t *testing.T) {
 	}
 }
 
-// ---- cloudSessionTracker.Start ----
+// ---- CloudSessionTracker.Start ----
 
 func TestCloudTracker_Start_SkipsWhenAPIIsNil(t *testing.T) {
 	calls := 0
-	var tracker cloudSessionTracker
+	var tracker CloudSessionTracker
 	// Passing nil api — real Start must bail out before making any HTTP call.
 	// We verify indirectly: cloudID stays empty.
 	tracker.Start(nil, 184, "claude-sonnet-4-6")
@@ -124,7 +136,7 @@ func TestCloudTracker_Start_SkipsWhenProjectIDIsZero(t *testing.T) {
 		_, _ = w.Write([]byte(`{"session_id":"should-not-see-this"}`))
 	})
 
-	var tracker cloudSessionTracker
+	var tracker CloudSessionTracker
 	tracker.Start(client, 0, "claude-sonnet-4-6")
 
 	if calls != 0 {
@@ -140,7 +152,7 @@ func TestCloudTracker_Start_HappyPath(t *testing.T) {
 		_, _ = w.Write([]byte(`{"session_id":"cloud-xyz"}`))
 	})
 
-	var tracker cloudSessionTracker
+	var tracker CloudSessionTracker
 	tracker.Start(client, 184, "claude-sonnet-4-6")
 
 	if tracker.cloudID != "cloud-xyz" {
@@ -155,7 +167,7 @@ func TestCloudTracker_Start_Idempotent(t *testing.T) {
 		_, _ = w.Write([]byte(`{"session_id":"cloud-first"}`))
 	})
 
-	var tracker cloudSessionTracker
+	var tracker CloudSessionTracker
 	tracker.Start(client, 184, "claude-sonnet-4-6")
 	tracker.Start(client, 184, "claude-sonnet-4-6") // second call — must be a no-op
 	tracker.Start(client, 184, "claude-sonnet-4-6") // third call  — same
@@ -174,7 +186,7 @@ func TestCloudTracker_Start_CloudIDEmptyOnServerError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":"boom"}`))
 	})
 
-	var tracker cloudSessionTracker
+	var tracker CloudSessionTracker
 	tracker.Start(client, 184, "claude-sonnet-4-6")
 
 	if tracker.cloudID != "" {
@@ -182,7 +194,7 @@ func TestCloudTracker_Start_CloudIDEmptyOnServerError(t *testing.T) {
 	}
 }
 
-// ---- cloudSessionTracker.Complete ----
+// ---- CloudSessionTracker.Complete ----
 
 func TestCloudTracker_Complete_SkipsWhenCloudIDEmpty(t *testing.T) {
 	calls := 0
@@ -191,7 +203,7 @@ func TestCloudTracker_Complete_SkipsWhenCloudIDEmpty(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	var tracker cloudSessionTracker // cloudID == ""
+	var tracker CloudSessionTracker // cloudID == ""
 	tracker.Complete(client, 500, "some summary", nil)
 
 	if calls != 0 {
@@ -201,7 +213,7 @@ func TestCloudTracker_Complete_SkipsWhenCloudIDEmpty(t *testing.T) {
 
 func TestCloudTracker_Complete_SkipsWhenAPIIsNil(t *testing.T) {
 	// Manually set cloudID to simulate a started session, then pass nil api.
-	tracker := cloudSessionTracker{cloudID: "cloud-abc"}
+	tracker := CloudSessionTracker{cloudID: "cloud-abc"}
 	// Should not panic.
 	tracker.Complete(nil, 100, "summary", nil)
 }
@@ -214,7 +226,7 @@ func TestCloudTracker_Complete_PatchesWithCloudID(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	tracker := cloudSessionTracker{cloudID: "cloud-abc"}
+	tracker := CloudSessionTracker{cloudID: "cloud-abc"}
 	tracker.Complete(client, 200, "did stuff  [2 turns]", nil)
 
 	if gotMethod != "PATCH" {
@@ -231,7 +243,7 @@ func TestCloudTracker_Complete_SilentOnServerError(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":"boom"}`))
 	})
 
-	tracker := cloudSessionTracker{cloudID: "cloud-abc"}
+	tracker := CloudSessionTracker{cloudID: "cloud-abc"}
 	// Must not panic or block.
 	tracker.Complete(client, 100, "summary", nil)
 }
@@ -252,7 +264,7 @@ func TestCloudTracker_StartThenComplete_UsesCorrectCloudID(t *testing.T) {
 		}
 	})
 
-	var tracker cloudSessionTracker
+	var tracker CloudSessionTracker
 	tracker.Start(client, 184, "claude-sonnet-4-6")
 	tracker.Complete(client, 750, "lifecycle test  [5 turns]", nil)
 
@@ -270,12 +282,12 @@ func TestCloudTracker_Complete_UploadsMessages(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "hello"},
 		{Role: "assistant", Content: "hi there"},
 	}
 
-	tracker := cloudSessionTracker{cloudID: "cloud-xyz"}
+	tracker := CloudSessionTracker{cloudID: "cloud-xyz"}
 	tracker.Complete(client, 300, "test upload", msgs)
 
 	if len(paths) != 2 {
@@ -299,7 +311,7 @@ func TestCloudTracker_Complete_SkipsUploadWhenNoMessages(t *testing.T) {
 		_, _ = w.Write([]byte(`{}`))
 	})
 
-	tracker := cloudSessionTracker{cloudID: "cloud-xyz"}
+	tracker := CloudSessionTracker{cloudID: "cloud-xyz"}
 	tracker.Complete(client, 100, "empty session", nil)
 
 	// Only the PATCH to complete, no POST for messages

--- a/internal/session/queue.go
+++ b/internal/session/queue.go
@@ -1,21 +1,21 @@
-package main
+package session
 
 import "sync"
 
-// promptQueue is a thread-safe FIFO for prompts submitted while the agent
+// PromptQueue is a thread-safe FIFO for prompts submitted while the agent
 // is already processing a previous request.
-type promptQueue struct {
+type PromptQueue struct {
 	mu    sync.Mutex
 	items []string
 }
 
-func (q *promptQueue) push(s string) {
+func (q *PromptQueue) Push(s string) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.items = append(q.items, s)
 }
 
-func (q *promptQueue) pop() (string, bool) {
+func (q *PromptQueue) Pop() (string, bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if len(q.items) == 0 {
@@ -26,7 +26,7 @@ func (q *promptQueue) pop() (string, bool) {
 	return s, true
 }
 
-func (q *promptQueue) peek() []string {
+func (q *PromptQueue) Peek() []string {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	out := make([]string, len(q.items))
@@ -34,7 +34,7 @@ func (q *promptQueue) peek() []string {
 	return out
 }
 
-func (q *promptQueue) len() int {
+func (q *PromptQueue) Len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	return len(q.items)

--- a/internal/session/queue_test.go
+++ b/internal/session/queue_test.go
@@ -1,4 +1,4 @@
-package main
+package session
 
 import (
 	"sync"
@@ -6,97 +6,97 @@ import (
 )
 
 func TestPromptQueue_EmptyByDefault(t *testing.T) {
-	var q promptQueue
-	if q.len() != 0 {
-		t.Errorf("new queue len: got %d, want 0", q.len())
+	var q PromptQueue
+	if q.Len() != 0 {
+		t.Errorf("new queue len: got %d, want 0", q.Len())
 	}
 }
 
 func TestPromptQueue_PushIncreasesLen(t *testing.T) {
-	var q promptQueue
-	q.push("a")
-	if q.len() != 1 {
-		t.Errorf("len after one push: got %d, want 1", q.len())
+	var q PromptQueue
+	q.Push("a")
+	if q.Len() != 1 {
+		t.Errorf("len after one push: got %d, want 1", q.Len())
 	}
-	q.push("b")
-	if q.len() != 2 {
-		t.Errorf("len after two pushes: got %d, want 2", q.len())
+	q.Push("b")
+	if q.Len() != 2 {
+		t.Errorf("len after two pushes: got %d, want 2", q.Len())
 	}
 }
 
 func TestPromptQueue_PopFIFO(t *testing.T) {
-	var q promptQueue
-	q.push("first")
-	q.push("second")
-	q.push("third")
+	var q PromptQueue
+	q.Push("first")
+	q.Push("second")
+	q.Push("third")
 
-	got, ok := q.pop()
+	got, ok := q.Pop()
 	if !ok || got != "first" {
 		t.Errorf("pop 1: got (%q, %v), want (\"first\", true)", got, ok)
 	}
-	got, ok = q.pop()
+	got, ok = q.Pop()
 	if !ok || got != "second" {
 		t.Errorf("pop 2: got (%q, %v), want (\"second\", true)", got, ok)
 	}
-	got, ok = q.pop()
+	got, ok = q.Pop()
 	if !ok || got != "third" {
 		t.Errorf("pop 3: got (%q, %v), want (\"third\", true)", got, ok)
 	}
 }
 
 func TestPromptQueue_PopEmptyReturnsFalse(t *testing.T) {
-	var q promptQueue
-	got, ok := q.pop()
+	var q PromptQueue
+	got, ok := q.Pop()
 	if ok || got != "" {
 		t.Errorf("pop on empty: got (%q, %v), want (\"\", false)", got, ok)
 	}
 }
 
 func TestPromptQueue_PopDecrementsLen(t *testing.T) {
-	var q promptQueue
-	q.push("x")
-	q.push("y")
-	q.pop()
-	if q.len() != 1 {
-		t.Errorf("len after pop: got %d, want 1", q.len())
+	var q PromptQueue
+	q.Push("x")
+	q.Push("y")
+	q.Pop()
+	if q.Len() != 1 {
+		t.Errorf("len after pop: got %d, want 1", q.Len())
 	}
-	q.pop()
-	if q.len() != 0 {
+	q.Pop()
+	if q.Len() != 0 {
 		t.Error("queue should be empty after all items popped")
 	}
 }
 
 func TestPromptQueue_PeekDoesNotRemove(t *testing.T) {
-	var q promptQueue
-	q.push("a")
-	q.push("b")
+	var q PromptQueue
+	q.Push("a")
+	q.Push("b")
 
-	snap := q.peek()
+	snap := q.Peek()
 	if len(snap) != 2 || snap[0] != "a" || snap[1] != "b" {
 		t.Errorf("peek: got %v, want [a b]", snap)
 	}
-	if q.len() != 2 {
-		t.Errorf("len after peek: got %d, want 2 (peek must not remove items)", q.len())
+	if q.Len() != 2 {
+		t.Errorf("len after peek: got %d, want 2 (peek must not remove items)", q.Len())
 	}
 }
 
 func TestPromptQueue_PeekReturnsCopy(t *testing.T) {
-	var q promptQueue
-	q.push("a")
+	var q PromptQueue
+	q.Push("a")
 
-	snap := q.peek()
+	snap := q.Peek()
 	snap[0] = "mutated"
 
 	// The queue itself must be unaffected.
-	second := q.peek()
+	second := q.Peek()
 	if second[0] != "a" {
 		t.Errorf("modifying peek result mutated the queue; got %q, want \"a\"", second[0])
 	}
 }
 
 func TestPromptQueue_PeekEmpty(t *testing.T) {
-	var q promptQueue
-	snap := q.peek()
+	var q PromptQueue
+	snap := q.Peek()
 	if snap == nil {
 		t.Error("peek on empty queue returned nil, want empty slice")
 	}
@@ -106,7 +106,7 @@ func TestPromptQueue_PeekEmpty(t *testing.T) {
 }
 
 func TestPromptQueue_ConcurrentPush(t *testing.T) {
-	var q promptQueue
+	var q PromptQueue
 	const goroutines = 50
 	const perGoroutine = 20
 
@@ -116,20 +116,20 @@ func TestPromptQueue_ConcurrentPush(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < perGoroutine; j++ {
-				q.push("item")
+				q.Push("item")
 			}
 		}()
 	}
 	wg.Wait()
 
 	want := goroutines * perGoroutine
-	if got := q.len(); got != want {
+	if got := q.Len(); got != want {
 		t.Errorf("concurrent push len: got %d, want %d", got, want)
 	}
 }
 
 func TestPromptQueue_ConcurrentPushPop(t *testing.T) {
-	var q promptQueue
+	var q PromptQueue
 	const count = 200
 
 	var wg sync.WaitGroup
@@ -139,7 +139,7 @@ func TestPromptQueue_ConcurrentPushPop(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < count; i++ {
-			q.push("item")
+			q.Push("item")
 		}
 	}()
 
@@ -150,7 +150,7 @@ func TestPromptQueue_ConcurrentPushPop(t *testing.T) {
 		defer wg.Done()
 		total := 0
 		for total < count {
-			if _, ok := q.pop(); ok {
+			if _, ok := q.Pop(); ok {
 				total++
 			}
 		}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,4 +1,4 @@
-package main
+package session
 
 import (
 	"crypto/rand"
@@ -21,7 +21,7 @@ type Session struct {
 	UpdatedAt time.Time      `json:"updated_at"`
 	ProjectID int            `json:"project_id,omitempty"`
 	Model     string         `json:"model,omitempty"`
-	Messages  []Message      `json:"messages"`
+	Messages  []api.Message  `json:"messages"`
 	Usage     api.TokenUsage `json:"usage"`
 	Turns     int            `json:"turns"`
 }
@@ -29,8 +29,8 @@ type Session struct {
 const sessionsSubDir = "sessions"
 const sessionTTL = 7 * 24 * time.Hour // 7 days
 
-// generateSessionID creates a short random hex ID like Claude Code uses.
-func generateSessionID() string {
+// GenerateSessionID creates a short random hex ID like Claude Code uses.
+func GenerateSessionID() string {
 	b := make([]byte, 4) // 8 hex chars
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
@@ -56,7 +56,7 @@ func sessionFilePath(id string) string {
 
 // SaveSession persists the current conversation to disk.
 // Called after every message exchange for crash safety.
-func SaveSession(sessionID string, history []Message, projectID int, usage api.TokenUsage, model string) error {
+func SaveSession(sessionID string, history []api.Message, projectID int, usage api.TokenUsage, model string) error {
 	dir := sessionDirPath()
 	if dir == "" {
 		return fmt.Errorf("cannot determine home directory")
@@ -66,7 +66,7 @@ func SaveSession(sessionID string, history []Message, projectID int, usage api.T
 	}
 
 	// Sanitize before saving to prevent persisting corruption
-	sanitizeSessionMessages(history)
+	SanitizeSessionMessages(history)
 
 	// Count user turns
 	turns := 0
@@ -119,16 +119,16 @@ func LoadSession(id string) (*Session, error) {
 	}
 
 	// Sanitize loaded messages — fix corrupted tool_use blocks
-	sanitizeSessionMessages(session.Messages)
+	SanitizeSessionMessages(session.Messages)
 
 	return &session, nil
 }
 
-// sanitizeSessionMessages fixes common corruption issues in saved sessions:
+// SanitizeSessionMessages fixes common corruption issues in saved sessions:
 // - tool_use blocks missing Input field (causes Anthropic API 400 errors)
 // - text blocks with extra Input field (causes "Extra inputs are not permitted")
 // - tool_result blocks with nil Content
-func sanitizeSessionMessages(messages []Message) {
+func SanitizeSessionMessages(messages []api.Message) {
 	for i := range messages {
 		blocks, ok := messages[i].Content.([]interface{})
 		if !ok {
@@ -246,7 +246,7 @@ func ListSessions(limit int) ([]SessionSummary, error) {
 // sessionSummary builds a short human-readable summary from the conversation
 // history to upload with cloud sessions. It takes the first user message as the
 // topic and appends the turn count.
-func sessionSummary(history []Message) string {
+func SummaryFor(history []api.Message) string {
 	if len(history) == 0 {
 		return ""
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,4 +1,4 @@
-package main
+package session
 
 import (
 	"os"
@@ -11,8 +11,8 @@ import (
 )
 
 func TestGenerateSessionID(t *testing.T) {
-	id1 := generateSessionID()
-	id2 := generateSessionID()
+	id1 := GenerateSessionID()
+	id2 := GenerateSessionID()
 	if id1 == id2 {
 		t.Error("Session IDs should be unique")
 	}
@@ -28,7 +28,7 @@ func TestSaveAndLoadSession(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", origHome)
 
-	history := []Message{
+	history := []api.Message{
 		{Role: "user", Content: "hello"},
 		{Role: "assistant", Content: "hi there"},
 	}
@@ -65,11 +65,11 @@ func TestListSessions(t *testing.T) {
 	defer os.Setenv("HOME", origHome)
 
 	// Create 3 sessions
-	_ = SaveSession("aaa", []Message{{Role: "user", Content: "1"}}, 1, api.TokenUsage{}, "sonnet")
+	_ = SaveSession("aaa", []api.Message{{Role: "user", Content: "1"}}, 1, api.TokenUsage{}, "sonnet")
 	time.Sleep(10 * time.Millisecond)
-	_ = SaveSession("bbb", []Message{{Role: "user", Content: "2"}}, 2, api.TokenUsage{}, "sonnet")
+	_ = SaveSession("bbb", []api.Message{{Role: "user", Content: "2"}}, 2, api.TokenUsage{}, "sonnet")
 	time.Sleep(10 * time.Millisecond)
-	_ = SaveSession("ccc", []Message{{Role: "user", Content: "3"}}, 3, api.TokenUsage{}, "sonnet")
+	_ = SaveSession("ccc", []api.Message{{Role: "user", Content: "3"}}, 3, api.TokenUsage{}, "sonnet")
 
 	sessions, err := ListSessions(10)
 	if err != nil {
@@ -90,9 +90,9 @@ func TestListSessions_Limit(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", origHome)
 
-	_ = SaveSession("a1", []Message{{Role: "user", Content: "1"}}, 0, api.TokenUsage{}, "")
-	_ = SaveSession("a2", []Message{{Role: "user", Content: "2"}}, 0, api.TokenUsage{}, "")
-	_ = SaveSession("a3", []Message{{Role: "user", Content: "3"}}, 0, api.TokenUsage{}, "")
+	_ = SaveSession("a1", []api.Message{{Role: "user", Content: "1"}}, 0, api.TokenUsage{}, "")
+	_ = SaveSession("a2", []api.Message{{Role: "user", Content: "2"}}, 0, api.TokenUsage{}, "")
+	_ = SaveSession("a3", []api.Message{{Role: "user", Content: "3"}}, 0, api.TokenUsage{}, "")
 
 	sessions, err := ListSessions(2)
 	if err != nil {
@@ -143,9 +143,9 @@ func TestLoadLastSession(t *testing.T) {
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", origHome)
 
-	_ = SaveSession("first", []Message{{Role: "user", Content: "old"}}, 1, api.TokenUsage{}, "")
+	_ = SaveSession("first", []api.Message{{Role: "user", Content: "old"}}, 1, api.TokenUsage{}, "")
 	time.Sleep(10 * time.Millisecond)
-	_ = SaveSession("second", []Message{{Role: "user", Content: "new"}}, 2, api.TokenUsage{}, "")
+	_ = SaveSession("second", []api.Message{{Role: "user", Content: "new"}}, 2, api.TokenUsage{}, "")
 
 	session, err := LoadLastSession()
 	if err != nil {
@@ -159,45 +159,45 @@ func TestLoadLastSession(t *testing.T) {
 // ---- sessionSummary ----
 
 func TestSessionSummary_EmptyHistory(t *testing.T) {
-	if got := sessionSummary(nil); got != "" {
+	if got := SummaryFor(nil); got != "" {
 		t.Errorf("expected empty string for nil history, got %q", got)
 	}
-	if got := sessionSummary([]Message{}); got != "" {
+	if got := SummaryFor([]api.Message{}); got != "" {
 		t.Errorf("expected empty string for empty history, got %q", got)
 	}
 }
 
 func TestSessionSummary_StringContent(t *testing.T) {
-	history := []Message{
+	history := []api.Message{
 		{Role: "user", Content: "hello world"},
 	}
-	got := sessionSummary(history)
+	got := SummaryFor(history)
 	if got != "hello world  [1 turns]" {
 		t.Errorf("got %q, want %q", got, "hello world  [1 turns]")
 	}
 }
 
 func TestSessionSummary_BlockContent(t *testing.T) {
-	history := []Message{
+	history := []api.Message{
 		{Role: "user", Content: []interface{}{
 			map[string]interface{}{"type": "text", "text": "fix the bug"},
 		}},
 	}
-	got := sessionSummary(history)
+	got := SummaryFor(history)
 	if got != "fix the bug  [1 turns]" {
 		t.Errorf("got %q, want %q", got, "fix the bug  [1 turns]")
 	}
 }
 
 func TestSessionSummary_MultiTurn(t *testing.T) {
-	history := []Message{
+	history := []api.Message{
 		{Role: "user", Content: "first"},
 		{Role: "assistant", Content: "reply1"},
 		{Role: "user", Content: "second"},
 		{Role: "assistant", Content: "reply2"},
 		{Role: "user", Content: "third"},
 	}
-	got := sessionSummary(history)
+	got := SummaryFor(history)
 	if got != "first  [3 turns]" {
 		t.Errorf("got %q, want %q", got, "first  [3 turns]")
 	}
@@ -205,8 +205,8 @@ func TestSessionSummary_MultiTurn(t *testing.T) {
 
 func TestSessionSummary_TruncatesLongMessage(t *testing.T) {
 	long := strings.Repeat("a", 250)
-	history := []Message{{Role: "user", Content: long}}
-	got := sessionSummary(history)
+	history := []api.Message{{Role: "user", Content: long}}
+	got := SummaryFor(history)
 	// Should be 200 bytes of 'a' + "…" + "  [1 turns]"
 	if !strings.HasPrefix(got, strings.Repeat("a", 200)+"…") {
 		t.Errorf("expected truncation at 200 chars + ellipsis, got %q", got[:min(len(got), 30)])
@@ -217,24 +217,24 @@ func TestSessionSummary_TruncatesLongMessage(t *testing.T) {
 }
 
 func TestSessionSummary_NoUserMessages(t *testing.T) {
-	history := []Message{
+	history := []api.Message{
 		{Role: "assistant", Content: "hi"},
 		{Role: "assistant", Content: "bye"},
 	}
-	got := sessionSummary(history)
+	got := SummaryFor(history)
 	if got != "0 turns" {
 		t.Errorf("got %q, want %q", got, "0 turns")
 	}
 }
 
 func TestSessionSummary_BlockContent_SkipsNonTextBlocks(t *testing.T) {
-	history := []Message{
+	history := []api.Message{
 		{Role: "user", Content: []interface{}{
 			map[string]interface{}{"type": "image", "source": "..."},
 			map[string]interface{}{"type": "text", "text": "look at this"},
 		}},
 	}
-	got := sessionSummary(history)
+	got := SummaryFor(history)
 	if got != "look at this  [1 turns]" {
 		t.Errorf("got %q, want %q", got, "look at this  [1 turns]")
 	}
@@ -242,7 +242,7 @@ func TestSessionSummary_BlockContent_SkipsNonTextBlocks(t *testing.T) {
 
 func TestSanitizeSessionMessages(t *testing.T) {
 	// Simulate corrupted messages as they come from JSON deserialization
-	messages := []Message{
+	messages := []api.Message{
 		{
 			Role: "assistant",
 			Content: []interface{}{
@@ -266,7 +266,7 @@ func TestSanitizeSessionMessages(t *testing.T) {
 		},
 	}
 
-	sanitizeSessionMessages(messages)
+	SanitizeSessionMessages(messages)
 
 	// Check text block — input should be removed
 	blocks0 := messages[0].Content.([]interface{})

--- a/internal/session/stdin_queue_unix.go
+++ b/internal/session/stdin_queue_unix.go
@@ -1,6 +1,6 @@
 //go:build darwin || linux
 
-package main
+package session
 
 import (
 	"fmt"
@@ -13,13 +13,13 @@ import (
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
-// startQueueReader starts a background goroutine that reads lines from stdin
+// StartQueueReader starts a background goroutine that reads lines from stdin
 // (using OS canonical mode — full-line buffering with echo) while the agent
 // is processing.  Each non-empty line is pushed onto pq.
 //
 // Returns a stop function that must be called before the next tui.ReadInput so
 // that no stdin data is consumed by two readers simultaneously.
-func startQueueReader(pq *promptQueue, term *tui.Terminal) func() {
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal) func() {
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -69,8 +69,8 @@ func startQueueReader(pq *promptQueue, term *tui.Terminal) func() {
 				if line == "" {
 					continue
 				}
-				pq.push(line)
-				pos := pq.len()
+				pq.Push(line)
+				pos := pq.Len()
 				// Print confirmation on its own line so it doesn't corrupt
 				// mid-stream token output.
 				fmt.Printf("\n  %s✓ queued [%d]:%s %s\n",

--- a/internal/session/stdin_queue_windows.go
+++ b/internal/session/stdin_queue_windows.go
@@ -1,11 +1,11 @@
 //go:build windows
 
-package main
+package session
 
 import "github.com/qualitymax/qmax-code/internal/tui"
 
-// startQueueReader is a no-op on Windows; the prompt queue still works via
+// StartQueueReader is a no-op on Windows; the prompt queue still works via
 // /queue but concurrent stdin reading while streaming is not supported.
-func startQueueReader(pq *promptQueue, term *tui.Terminal) func() {
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal) func() {
 	return func() {}
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/qualitymax/qmax-code/internal/api"
+	"github.com/qualitymax/qmax-code/internal/session"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 	"github.com/qualitymax/qmax-code/internal/tui"
 	"github.com/qualitymax/qmax-code/internal/vnc"
@@ -101,7 +102,7 @@ func main() {
 	}
 
 	if *listSessions {
-		sessions, err := ListSessions(20)
+		sessions, err := session.ListSessions(20)
 		if err != nil || len(sessions) == 0 {
 			fmt.Println("No sessions found.")
 			os.Exit(0)
@@ -360,27 +361,27 @@ func main() {
 
 	// Handle --resume flag
 	if *resumeID != "" {
-		var session *Session
+		var sess *session.Session
 		var loadErr error
 		if *resumeID == "last" {
-			session, loadErr = LoadLastSession()
+			sess, loadErr = session.LoadLastSession()
 		} else {
-			session, loadErr = LoadSession(*resumeID)
+			sess, loadErr = session.LoadSession(*resumeID)
 		}
 		if loadErr != nil {
 			fmt.Fprintf(os.Stderr, "Cannot resume session %q: %v\n", *resumeID, loadErr)
 			os.Exit(1)
 		}
-		agent.history = session.Messages
-		agent.usage = session.Usage
-		if session.ProjectID > 0 {
-			agent.config.Context.ProjectID = session.ProjectID
+		agent.history = sess.Messages
+		agent.usage = sess.Usage
+		if sess.ProjectID > 0 {
+			agent.config.Context.ProjectID = sess.ProjectID
 		}
-		fmt.Printf("Resumed session %s (%d turns)\n", session.ID, session.Turns)
+		fmt.Printf("Resumed session %s (%d turns)\n", sess.ID, sess.Turns)
 	}
 
 	// Clean up old sessions (>7 days)
-	if removed := CleanupOldSessions(); removed > 0 && *verbose {
+	if removed := session.CleanupOldSessions(); removed > 0 && *verbose {
 		fmt.Printf("[cleanup] Removed %d old sessions\n", removed)
 	}
 
@@ -413,17 +414,17 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 	}
 
 	// Prompt queue — collects prompts typed while the agent is running.
-	pq := &promptQueue{}
+	pq := &session.PromptQueue{}
 
-	// Session ID for this conversation
-	sessionID := generateSessionID()
+	// session.Session ID for this conversation
+	sessionID := session.GenerateSessionID()
 
 	// Initialize structured logger
 	agent.logger = sysutil.NewLogger(sessionID)
 	defer agent.logger.Close()
 
 	// Cloud session tracking — created once when projectID is known.
-	var tracker cloudSessionTracker
+	var tracker session.CloudSessionTracker
 	startCloudSession := func() {
 		api := agent.config.Context.API
 		projectID := agent.config.Context.ProjectID
@@ -433,7 +434,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		cfg := agent.appConfig
 		// First eligible session: ask the user once and persist their choice.
 		if cfg != nil && cfg.CloudSync == nil {
-			promptCloudSyncConsent(cfg, term.ReadConsent)
+			session.PromptCloudSyncConsent(cfg, term.ReadConsent)
 		}
 		if cfg == nil || cfg.CloudSync == nil || !*cfg.CloudSync {
 			return
@@ -445,7 +446,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		if cfg == nil || cfg.CloudSync == nil || !*cfg.CloudSync {
 			return
 		}
-		tracker.Complete(agent.config.Context.API, agent.usage.TotalTokens(), sessionSummary(agent.history), agent.history)
+		tracker.Complete(agent.config.Context.API, agent.usage.TotalTokens(), session.SummaryFor(agent.history), agent.history)
 	}
 
 	// Graceful interrupt handling
@@ -456,14 +457,14 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 
 	autoSave := func() {
 		if len(agent.history) > 0 && (agent.appConfig == nil || agent.appConfig.AutoSave) {
-			_ = SaveSession(sessionID, agent.history, agent.config.Context.ProjectID, agent.usage, agent.config.Model)
+			_ = session.SaveSession(sessionID, agent.history, agent.config.Context.ProjectID, agent.usage, agent.config.Model)
 		}
 	}
 
 	saveAndExit := func() {
-		_ = SaveSession(sessionID, agent.history, agent.config.Context.ProjectID, agent.usage, agent.config.Model)
+		_ = session.SaveSession(sessionID, agent.history, agent.config.Context.ProjectID, agent.usage, agent.config.Model)
 		completeCloudSession()
-		fmt.Fprintf(os.Stderr, "Session %s saved.\n", sessionID)
+		fmt.Fprintf(os.Stderr, "session.Session %s saved.\n", sessionID)
 	}
 
 	sigCh := make(chan os.Signal, 1)
@@ -504,7 +505,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		fmt.Printf("  %sSession: %s%s\n", tui.ColorDim, sessionID, tui.ColorReset)
 
 		// Hint about recent session if one exists
-		if recent, err := ListSessions(1); err == nil && len(recent) > 0 {
+		if recent, err := session.ListSessions(1); err == nil && len(recent) > 0 {
 			age := time.Since(recent[0].UpdatedAt)
 			if age < 24*time.Hour {
 				fmt.Printf("  %sRecent session: %s (%d turns, %s ago) — type /resume to continue%s\n",
@@ -527,9 +528,9 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 
 		// Drain the prompt queue before blocking on interactive input.
 		// This processes prompts the user typed while the agent was running.
-		if queued, ok := pq.pop(); ok {
+		if queued, ok := pq.Pop(); ok {
 			input = queued
-			remaining := pq.len()
+			remaining := pq.Len()
 			fmt.Println()
 			if remaining > 0 {
 				term.PrintSystem(fmt.Sprintf("processing queued prompt  (%d more in queue)", remaining))
@@ -610,31 +611,31 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		case input == "/resume" || strings.HasPrefix(input, "/resume "):
 			resumeTarget := strings.TrimPrefix(input, "/resume ")
 			resumeTarget = strings.TrimSpace(resumeTarget)
-			var session *Session
+			var sess *session.Session
 			var loadErr error
 			if resumeTarget == "" || resumeTarget == "/resume" || resumeTarget == "last" {
-				session, loadErr = LoadLastSession()
+				sess, loadErr = session.LoadLastSession()
 			} else {
-				session, loadErr = LoadSession(resumeTarget)
+				sess, loadErr = session.LoadSession(resumeTarget)
 			}
 			if loadErr != nil {
 				term.PrintError(fmt.Sprintf("Cannot resume: %v", loadErr))
 				term.PrintSystem("Use /sessions to see available sessions")
 			} else {
-				sanitizeSessionMessages(session.Messages)
-				agent.history = session.Messages
-				agent.usage = session.Usage
-				sessionID = session.ID
-				if session.ProjectID > 0 {
-					agent.config.Context.ProjectID = session.ProjectID
+				session.SanitizeSessionMessages(sess.Messages)
+				agent.history = sess.Messages
+				agent.usage = sess.Usage
+				sessionID = sess.ID
+				if sess.ProjectID > 0 {
+					agent.config.Context.ProjectID = sess.ProjectID
 				}
 				term.SetSessionPrompt(sessionID)
 				term.PrintSystem(fmt.Sprintf("Resumed session %s (%d turns, project #%d)",
-					session.ID, session.Turns, session.ProjectID))
+					sess.ID, sess.Turns, sess.ProjectID))
 			}
 			continue
 		case input == "/sessions":
-			sessions, err := ListSessions(10)
+			sessions, err := session.ListSessions(10)
 			if err != nil || len(sessions) == 0 {
 				term.PrintSystem("No saved sessions.")
 				continue
@@ -647,24 +648,24 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			if !ok {
 				continue
 			}
-			session, loadErr := LoadSession(chosenID)
+			sess, loadErr := session.LoadSession(chosenID)
 			if loadErr != nil {
 				term.PrintError(fmt.Sprintf("Cannot resume: %v", loadErr))
 			} else {
-				sanitizeSessionMessages(session.Messages)
-				agent.history = session.Messages
-				agent.usage = session.Usage
-				sessionID = session.ID
-				if session.ProjectID > 0 {
-					agent.config.Context.ProjectID = session.ProjectID
+				session.SanitizeSessionMessages(sess.Messages)
+				agent.history = sess.Messages
+				agent.usage = sess.Usage
+				sessionID = sess.ID
+				if sess.ProjectID > 0 {
+					agent.config.Context.ProjectID = sess.ProjectID
 				}
 				term.SetSessionPrompt(sessionID)
 				term.PrintSystem(fmt.Sprintf("Resumed session %s (%d turns, project #%d)",
-					session.ID, session.Turns, session.ProjectID))
+					sess.ID, sess.Turns, sess.ProjectID))
 			}
 			continue
 		case input == "/save":
-			if err := SaveSession(sessionID, agent.history, agent.config.Context.ProjectID, agent.usage, agent.config.Model); err != nil {
+			if err := session.SaveSession(sessionID, agent.history, agent.config.Context.ProjectID, agent.usage, agent.config.Model); err != nil {
 				term.PrintError(fmt.Sprintf("Failed to save: %v", err))
 			} else {
 				term.PrintSystem(fmt.Sprintf("Session %s saved.", sessionID))
@@ -679,7 +680,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 			continue
 
 		case input == "/queue":
-			items := pq.peek()
+			items := pq.Peek()
 			if len(items) == 0 {
 				term.PrintSystem("Queue is empty. Type /queue <prompt> to add, or just type while the agent is running.")
 			} else {
@@ -697,8 +698,8 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		case strings.HasPrefix(input, "/queue "):
 			queued := strings.TrimSpace(strings.TrimPrefix(input, "/queue "))
 			if queued != "" {
-				pq.push(queued)
-				term.PrintSystem(fmt.Sprintf("queued [%d]: %s", pq.len(), queued))
+				pq.Push(queued)
+				term.PrintSystem(fmt.Sprintf("queued [%d]: %s", pq.Len(), queued))
 			}
 			continue
 		case input == "/orch":
@@ -1127,7 +1128,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		// Start the queue reader so the user can type the next prompt while
 		// the agent is working.  It is stopped (and fully drained) before
 		// the next tui.ReadInput call so stdin is never shared between readers.
-		stopQueueReader := startQueueReader(pq, term)
+		stopQueueReader := session.StartQueueReader(pq, term)
 
 		// CC mode: delegate entirely to Claude Code subprocess (uses CC subscription).
 		// Normal mode: use direct Anthropic API.
@@ -1202,8 +1203,8 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 				// CCAgent/CodexAgent manage their own subprocess state; qmax's
 				// history would otherwise stay empty and autoSave would no-op.
 				agent.history = append(agent.history,
-					Message{Role: "user", Content: cleanInput},
-					Message{Role: "assistant", Content: llmResult},
+					api.Message{Role: "user", Content: cleanInput},
+					api.Message{Role: "assistant", Content: llmResult},
 				)
 			}
 		} else if len(images) > 0 {
@@ -1225,7 +1226,7 @@ func runREPL(agent *Agent, cliAgent CLIAgent, quietMode bool) {
 		stopQueueReader()
 
 		// If prompts were queued during this run, surface them.
-		if n := pq.len(); n > 0 {
+		if n := pq.Len(); n > 0 {
 			fmt.Println()
 			term.PrintSystem(fmt.Sprintf("%d prompt(s) queued — processing next automatically", n))
 		}

--- a/ollama.go
+++ b/ollama.go
@@ -59,7 +59,7 @@ func NewOllamaClient(cfg *api.Config) *OllamaClient {
 }
 
 // ChatStreamingWithModel is like ChatStreaming but uses a specific model.
-func (o *OllamaClient) ChatStreamingWithModel(ctx context.Context, model, system string, history []Message, term *tui.Terminal) (string, error) {
+func (o *OllamaClient) ChatStreamingWithModel(ctx context.Context, model, system string, history []api.Message, term *tui.Terminal) (string, error) {
 	savedModel := o.model
 	o.model = model
 	defer func() { o.model = savedModel }()
@@ -121,7 +121,7 @@ type ollamaChatChunk struct {
 
 // ChatStreaming sends a chat request to Ollama and streams the response.
 // Returns the full text, or an error (caller should fall back to Claude).
-func (o *OllamaClient) ChatStreaming(ctx context.Context, system string, history []Message, term *tui.Terminal) (string, error) {
+func (o *OllamaClient) ChatStreaming(ctx context.Context, system string, history []api.Message, term *tui.Terminal) (string, error) {
 	// Convert Anthropic-style messages to OpenAI-style
 	messages := make([]ollamaChatMessage, 0, len(history)+1)
 	if system != "" {
@@ -213,12 +213,12 @@ func (o *OllamaClient) ChatStreaming(ctx context.Context, system string, history
 	return result, nil
 }
 
-// extractPlainText pulls text from a message Content (string or []ContentBlock).
+// extractPlainText pulls text from a message Content (string or []api.ContentBlock).
 func extractPlainText(content interface{}) string {
 	switch v := content.(type) {
 	case string:
 		return v
-	case []ContentBlock:
+	case []api.ContentBlock:
 		var parts []string
 		for _, b := range v {
 			if b.Type == "text" && b.Text != "" {

--- a/ollama_agent.go
+++ b/ollama_agent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
@@ -72,9 +73,9 @@ func (a *Agent) RunOllamaAgent(term *tui.Terminal) (string, bool) {
 	action, params, remaining := parseActionBlock(ollamaText)
 	if action == "" {
 		// Pure chat response — no tool needed
-		a.history = append(a.history, Message{
+		a.history = append(a.history, api.Message{
 			Role:    "assistant",
-			Content: []ContentBlock{{Type: "text", Text: ollamaText}},
+			Content: []api.ContentBlock{{Type: "text", Text: ollamaText}},
 		})
 		term.FinishMarkdown(ollamaText)
 		return ollamaText, true
@@ -93,11 +94,11 @@ func (a *Agent) RunOllamaAgent(term *tui.Terminal) (string, bool) {
 	term.PrintToolResult(action, tui.TruncateStr(toolResult, 200))
 
 	// Phase 3: Feed results back to the local model for formatting.
-	a.history = append(a.history, Message{
+	a.history = append(a.history, api.Message{
 		Role:    "assistant",
-		Content: []ContentBlock{{Type: "text", Text: remaining}},
+		Content: []api.ContentBlock{{Type: "text", Text: remaining}},
 	})
-	a.history = append(a.history, Message{
+	a.history = append(a.history, api.Message{
 		Role:    "user",
 		Content: fmt.Sprintf("[Tool result for %s]:\n%s\n\nSummarize these results for the user concisely.", action, truncateToolResult(toolResult)),
 	})
@@ -113,9 +114,9 @@ func (a *Agent) RunOllamaAgent(term *tui.Terminal) (string, bool) {
 		summary = toolResult
 	}
 
-	a.history = append(a.history, Message{
+	a.history = append(a.history, api.Message{
 		Role:    "assistant",
-		Content: []ContentBlock{{Type: "text", Text: summary}},
+		Content: []api.ContentBlock{{Type: "text", Text: summary}},
 	})
 	term.FinishMarkdown(summary)
 	return summary, true

--- a/orphaned_tool_use_test.go
+++ b/orphaned_tool_use_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
 )
 
 // Regression for the "messages.13.content: Input should be a valid list"
@@ -11,21 +13,21 @@ import (
 // matching tool_result list.
 
 func TestStripOrphanedToolUse_NoOp_WhenPaired(t *testing.T) {
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "run foo"},
-		{Role: "assistant", Content: []ContentBlock{
+		{Role: "assistant", Content: []api.ContentBlock{
 			{Type: "text", Text: "calling foo"},
 			{Type: "tool_use", ID: "t1", Name: "foo", Input: map[string]interface{}{}},
 		}},
-		{Role: "user", Content: []ContentBlock{
+		{Role: "user", Content: []api.ContentBlock{
 			{Type: "tool_result", ToolUseID: "t1", Content: "ok"},
 		}},
 	}
 	out := stripOrphanedToolUse(msgs)
 	// The assistant message must still have its tool_use intact.
-	blocks, ok := out[1].Content.([]ContentBlock)
+	blocks, ok := out[1].Content.([]api.ContentBlock)
 	if !ok {
-		t.Fatalf("expected []ContentBlock, got %T", out[1].Content)
+		t.Fatalf("expected []api.ContentBlock, got %T", out[1].Content)
 	}
 	if len(blocks) != 2 || blocks[1].Type != "tool_use" {
 		t.Errorf("expected tool_use preserved when paired; got %+v", blocks)
@@ -35,18 +37,18 @@ func TestStripOrphanedToolUse_NoOp_WhenPaired(t *testing.T) {
 func TestStripOrphanedToolUse_Drops_WhenFollowedByFreshUserPrompt(t *testing.T) {
 	// User interrupted mid-tool-loop with a new prompt — tool_use has no
 	// matching tool_result. Must be stripped or Anthropic rejects.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "run foo"},
-		{Role: "assistant", Content: []ContentBlock{
+		{Role: "assistant", Content: []api.ContentBlock{
 			{Type: "text", Text: "calling foo"},
 			{Type: "tool_use", ID: "t1", Name: "foo"},
 		}},
 		{Role: "user", Content: "forget that, do something else"},
 	}
 	out := stripOrphanedToolUse(msgs)
-	blocks, ok := out[1].Content.([]ContentBlock)
+	blocks, ok := out[1].Content.([]api.ContentBlock)
 	if !ok {
-		t.Fatalf("expected []ContentBlock, got %T", out[1].Content)
+		t.Fatalf("expected []api.ContentBlock, got %T", out[1].Content)
 	}
 	for _, b := range blocks {
 		if b.Type == "tool_use" {
@@ -63,15 +65,15 @@ func TestStripOrphanedToolUse_InsertsPlaceholder_WhenMessageWouldBeEmpty(t *test
 	// Assistant emitted only tool_use blocks (no text). After stripping
 	// them the message would be empty, which Anthropic also rejects.
 	// Ensure a placeholder text block is inserted.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "run foo"},
-		{Role: "assistant", Content: []ContentBlock{
+		{Role: "assistant", Content: []api.ContentBlock{
 			{Type: "tool_use", ID: "t1", Name: "foo"},
 		}},
 		{Role: "user", Content: "do something else"},
 	}
 	out := stripOrphanedToolUse(msgs)
-	blocks := out[1].Content.([]ContentBlock)
+	blocks := out[1].Content.([]api.ContentBlock)
 	if len(blocks) == 0 {
 		t.Fatal("expected placeholder block, got empty content")
 	}
@@ -81,10 +83,10 @@ func TestStripOrphanedToolUse_InsertsPlaceholder_WhenMessageWouldBeEmpty(t *test
 }
 
 func TestStripOrphanedToolUse_HandlesInterfaceContent(t *testing.T) {
-	// After JSON deserialization (session load), typed []ContentBlock
+	// After JSON deserialization (session load), typed []api.ContentBlock
 	// becomes []interface{} with map[string]interface{} items. The
 	// pruner must handle that shape too.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "x"},
 		{Role: "assistant", Content: []interface{}{
 			map[string]interface{}{"type": "text", "text": "calling"},
@@ -108,19 +110,19 @@ func TestStripOrphanedToolUse_HandlesInterfaceContent(t *testing.T) {
 func TestStripOrphanedToolUse_PartialMatch_TreatedAsOrphaned(t *testing.T) {
 	// Assistant called two tools but tool_result only covers one. Anthropic
 	// requires ALL tool_uses to be answered, so partial match = strip.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "multi"},
-		{Role: "assistant", Content: []ContentBlock{
+		{Role: "assistant", Content: []api.ContentBlock{
 			{Type: "tool_use", ID: "t1", Name: "foo"},
 			{Type: "tool_use", ID: "t2", Name: "bar"},
 		}},
-		{Role: "user", Content: []ContentBlock{
+		{Role: "user", Content: []api.ContentBlock{
 			{Type: "tool_result", ToolUseID: "t1", Content: "ok"},
 			// t2 missing!
 		}},
 	}
 	out := stripOrphanedToolUse(msgs)
-	blocks := out[1].Content.([]ContentBlock)
+	blocks := out[1].Content.([]api.ContentBlock)
 	for _, b := range blocks {
 		if b.Type == "tool_use" {
 			t.Errorf("partially-answered tool_use set should be stripped; got %+v", blocks)
@@ -131,14 +133,14 @@ func TestStripOrphanedToolUse_PartialMatch_TreatedAsOrphaned(t *testing.T) {
 func TestStripOrphanedToolUse_LastMessageIsAssistantToolUse(t *testing.T) {
 	// Edge: assistant ended on tool_use but no user message follows yet
 	// (in-flight call). Strip — the API won't accept it in this shape.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "x"},
-		{Role: "assistant", Content: []ContentBlock{
+		{Role: "assistant", Content: []api.ContentBlock{
 			{Type: "tool_use", ID: "t1", Name: "foo"},
 		}},
 	}
 	out := stripOrphanedToolUse(msgs)
-	blocks := out[1].Content.([]ContentBlock)
+	blocks := out[1].Content.([]api.ContentBlock)
 	for _, b := range blocks {
 		if b.Type == "tool_use" {
 			t.Errorf("trailing unanswered tool_use should be stripped; got %+v", blocks)
@@ -149,7 +151,7 @@ func TestStripOrphanedToolUse_LastMessageIsAssistantToolUse(t *testing.T) {
 func TestStripOrphanedToolUse_EmptyHistory(t *testing.T) {
 	// Defensive: empty history is a valid input (fresh session, first turn).
 	// Must not panic, must return empty slice.
-	out := stripOrphanedToolUse([]Message{})
+	out := stripOrphanedToolUse([]api.Message{})
 	if len(out) != 0 {
 		t.Errorf("empty input should return empty output, got %v", out)
 	}
@@ -165,19 +167,19 @@ func TestStripOrphanedToolUse_MultipleSeparateToolLoops(t *testing.T) {
 	// The function must not conflate tool_result from loop A with tool_use
 	// from loop B — even though matching is ID-exact, this guards against
 	// future regressions in the collector/matcher logic.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "run A"},
-		{Role: "assistant", Content: []ContentBlock{{Type: "tool_use", ID: "A1", Name: "a"}}},
-		{Role: "user", Content: []ContentBlock{{Type: "tool_result", ToolUseID: "A1", Content: "ok"}}},
-		{Role: "assistant", Content: []ContentBlock{{Type: "text", Text: "done"}}},
+		{Role: "assistant", Content: []api.ContentBlock{{Type: "tool_use", ID: "A1", Name: "a"}}},
+		{Role: "user", Content: []api.ContentBlock{{Type: "tool_result", ToolUseID: "A1", Content: "ok"}}},
+		{Role: "assistant", Content: []api.ContentBlock{{Type: "text", Text: "done"}}},
 		{Role: "user", Content: "run B"},
-		{Role: "assistant", Content: []ContentBlock{{Type: "tool_use", ID: "B1", Name: "b"}}},
-		{Role: "user", Content: []ContentBlock{{Type: "tool_result", ToolUseID: "B1", Content: "ok"}}},
+		{Role: "assistant", Content: []api.ContentBlock{{Type: "tool_use", ID: "B1", Name: "b"}}},
+		{Role: "user", Content: []api.ContentBlock{{Type: "tool_result", ToolUseID: "B1", Content: "ok"}}},
 	}
 	out := stripOrphanedToolUse(msgs)
 	// Both assistant messages with tool_use should keep them intact.
 	for _, i := range []int{1, 5} {
-		blocks := out[i].Content.([]ContentBlock)
+		blocks := out[i].Content.([]api.ContentBlock)
 		hasToolUse := false
 		for _, b := range blocks {
 			if b.Type == "tool_use" {
@@ -197,10 +199,10 @@ func TestStripOrphanedToolUse_OrphanedToolResultLeftAlone(t *testing.T) {
 	// function's job is only to strip orphaned tool_USE — orphaned
 	// tool_RESULT is the session sanitizer's job (session.go). Make
 	// sure we don't touch those.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: "start"},
-		{Role: "assistant", Content: []ContentBlock{{Type: "text", Text: "hi"}}},
-		{Role: "user", Content: []ContentBlock{
+		{Role: "assistant", Content: []api.ContentBlock{{Type: "text", Text: "hi"}}},
+		{Role: "user", Content: []api.ContentBlock{
 			{Type: "tool_result", ToolUseID: "orphan-1", Content: "ghost"},
 		}},
 	}
@@ -208,9 +210,9 @@ func TestStripOrphanedToolUse_OrphanedToolResultLeftAlone(t *testing.T) {
 	// User message at index 2 must still have its tool_result block —
 	// the Anthropic server will reject it eventually, but that's not
 	// this function's concern.
-	blocks, ok := out[2].Content.([]ContentBlock)
+	blocks, ok := out[2].Content.([]api.ContentBlock)
 	if !ok {
-		t.Fatalf("expected []ContentBlock at msg 2, got %T", out[2].Content)
+		t.Fatalf("expected []api.ContentBlock at msg 2, got %T", out[2].Content)
 	}
 	if len(blocks) != 1 || blocks[0].Type != "tool_result" {
 		t.Errorf("orphaned tool_result was unexpectedly modified: %+v", blocks)
@@ -220,7 +222,7 @@ func TestStripOrphanedToolUse_OrphanedToolResultLeftAlone(t *testing.T) {
 func TestStripOrphanedToolUse_NilContent(t *testing.T) {
 	// After session save/load there have been cases where Content ends
 	// up nil (e.g. corrupted row). Must not panic.
-	msgs := []Message{
+	msgs := []api.Message{
 		{Role: "user", Content: nil},
 		{Role: "assistant", Content: nil},
 	}

--- a/tools.go
+++ b/tools.go
@@ -110,13 +110,6 @@ func boolVal(input map[string]interface{}, key string) bool {
 	return false
 }
 
-// ToolDef is a Claude API tool definition.
-type ToolDef struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description"`
-	InputSchema map[string]interface{} `json:"input_schema"`
-}
-
 // experimentalToolNames lists tools that are gated behind QMAX_EXPERIMENTAL=1.
 // These surfaces work but lack public docs / support guarantees, per
 // OPEN_SOURCE_SCOPE.md Phase 2. Set QMAX_EXPERIMENTAL=1 to expose them to the
@@ -145,12 +138,12 @@ var experimentalToolNames = map[string]bool{
 // BuildToolDefs returns the public tool definitions exposed to the LLM agent
 // and via the MCP server. Experimental tools are filtered out unless
 // QMAX_EXPERIMENTAL=1 is set.
-func BuildToolDefs() []ToolDef {
+func BuildToolDefs() []api.ToolDef {
 	all := buildAllToolDefs()
 	if sysutil.EnvEnabled("QMAX_EXPERIMENTAL") {
 		return all
 	}
-	out := make([]ToolDef, 0, len(all))
+	out := make([]api.ToolDef, 0, len(all))
 	for _, d := range all {
 		if !experimentalToolNames[d.Name] {
 			out = append(out, d)
@@ -162,8 +155,8 @@ func BuildToolDefs() []ToolDef {
 // buildAllToolDefs returns every tool definition, including experimental ones.
 // Used internally; public callers go through BuildToolDefs which applies the
 // QMAX_EXPERIMENTAL gate.
-func buildAllToolDefs() []ToolDef {
-	return []ToolDef{
+func buildAllToolDefs() []api.ToolDef {
+	return []api.ToolDef{
 		// --- Project operations ---
 		{
 			Name:        "list_projects",


### PR DESCRIPTION
## Summary

Phase 2 step 3 of the package reorg. Moves session persistence, prompt queue, cloud-session tracker, and platform stdin readers into ${"`"}internal/session/${"`"}. Also moves the Anthropic Messages API wire types from agent.go/tools.go into ${"`"}internal/api/messages.go${"`"}.

### Moved into ${"`"}internal/session/${"`"}
- ${"`"}session.go${"`"} (Save/Load/List, Session/SessionSummary types)
- ${"`"}queue.go${"`"} (PromptQueue)
- ${"`"}cloud_session.go${"`"} (CloudSessionTracker, consent prompt)
- ${"`"}stdin_queue_*.go${"`"} (platform stdin readers)
- + matching test files

### Moved into ${"`"}internal/api/${"`"} (wire types)
${"`"}Message${"`"}, ${"`"}ContentBlock${"`"}, ${"`"}ImageSource${"`"}, ${"`"}APIRequest${"`"}, ${"`"}APIResponse${"`"}, ${"`"}APIUsage${"`"}, ${"`"}ToolDef${"`"} — these are the Anthropic Messages API wire format. Putting them with the rest of the api package (which already owns ${"`"}APIClient${"`"}, ${"`"}AuthConfig${"`"}, ${"`"}SessionContext${"`"}, ${"`"}TokenUsage${"`"}, model constants) lets ${"`"}session${"`"}, ${"`"}agent${"`"}, ${"`"}mcp${"`"}, and cloud-upload all import them from one place.

### Exports forced by the move (were package-private)
- ${"`"}promptQueue${"`"} → ${"`"}PromptQueue${"`"} + ${"`"}Push${"`"}/${"`"}Pop${"`"}/${"`"}Peek${"`"}/${"`"}Len${"`"}
- ${"`"}cloudSessionTracker${"`"} → ${"`"}CloudSessionTracker${"`"}
- ${"`"}generateSessionID${"`"} → ${"`"}GenerateSessionID${"`"}
- ${"`"}sanitizeSessionMessages${"`"} → ${"`"}SanitizeSessionMessages${"`"}
- ${"`"}sessionSummary${"`"} → ${"`"}SummaryFor${"`"}
- ${"`"}promptCloudSyncConsent${"`"} / ${"`"}applyCloudSyncChoice${"`"} / ${"`"}startQueueReader${"`"}

### Local-var shadow fixes
${"`"}main.go${"`"} and ${"`"}cc_agent_session_test.go${"`"} used ${"`"}session${"`"} as a local var, which now shadows the imported package — renamed to ${"`"}sess${"`"}.

### What didn't move
${"`"}tools.go${"`"}, ${"`"}agent.go${"`"}, ${"`"}mcp_server.go${"`"} remain in main — Phase 2 step 4+.

## Test plan
- [x] ${"`"}go build ./...${"`"} clean
- [x] ${"`"}go test ./...${"`"} all packages green (api, session, security, sysutil, tui, vnc, root)
- [x] ${"`"}go vet ./...${"`"} clean
- [ ] Smoke test: ${"`"}/sessions${"`"} picker, ${"`"}/resume${"`"}, ${"`"}/save${"`"}, cloud session sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)