### PR TITLE
chore: bump version to 1.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.16.4] - 2026-05-09
+
+### Changed
+- Phase 2 step 3 of the package reorg: extracted `internal/session` (session save/load, prompt queue, cloud-session tracker, platform stdin readers). Anthropic Messages API wire types (`Message`, `ContentBlock`, `ImageSource`, `APIRequest/Response/Usage`, `ToolDef`) moved to `internal/api/messages.go` so session, agent, mcp, and cloud upload all share one definition. No user-visible behavior change.
+
 ## [1.16.3] - 2026-05-09
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.3"
+var Version = "1.16.4"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- Bumps `Version` to 1.16.4 to ship the `internal/session` extraction from #87.
- No user-visible behavior change.
- CHANGELOG entry added.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] After merge: tag `v1.16.4` from main; release workflow builds binaries and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)