### PR TITLE
refactor: extract internal/setup (Phase 2 step 6)

### DIFF
--- a/internal/setup/consent.go
+++ b/internal/setup/consent.go
@@ -1,4 +1,4 @@
-package main
+package setup
 
 import (
 	"bufio"
@@ -9,8 +9,8 @@ import (
 	"github.com/qualitymax/qmax-code/internal/api"
 )
 
-// orchConsentResult is what activateBackend gets back from the consent prompt.
-type orchConsentResult struct {
+// ConsentResult is what activateBackend gets back from the consent prompt.
+type ConsentResult struct {
 	Proceed        bool   // user said yes; false means cancel activation
 	PermissionMode string // "standard" | "unattended"
 	GlobalInstall  bool   // ok to write into ~/.claude/settings.json or ~/.codex/config.toml
@@ -22,7 +22,7 @@ type orchConsentResult struct {
 //
 // Conductor's safety model: the user is the principal. We never sneak privilege
 // escalation behind a backend switch. Mode choices are explicit and persisted.
-func promptOrchConsent(cfg *api.Config, backend string) orchConsentResult {
+func PromptOrchConsent(cfg *api.Config, backend string) ConsentResult {
 	cliName := "Claude Code"
 	globalConfigPath := "~/.claude/settings.json"
 	if backend == "codex" {
@@ -30,7 +30,7 @@ func promptOrchConsent(cfg *api.Config, backend string) orchConsentResult {
 		globalConfigPath = "~/.codex/config.toml"
 	}
 
-	res := orchConsentResult{
+	res := ConsentResult{
 		PermissionMode: cfg.OrchPermissionMode,
 		GlobalInstall:  cfg.OrchGlobalInstall,
 	}
@@ -69,16 +69,16 @@ func promptOrchConsent(cfg *api.Config, backend string) orchConsentResult {
 			ans2 := strings.ToLower(strings.TrimSpace(line))
 			if ans2 != "y" && ans2 != "yes" {
 				fmt.Println("  Cancelled.")
-				return orchConsentResult{Proceed: false}
+				return ConsentResult{Proceed: false}
 			}
 		default:
 			fmt.Println("  Cancelled.")
-			return orchConsentResult{Proceed: false}
+			return ConsentResult{Proceed: false}
 		}
 	}
 
 	// Second prompt: global install. Only ask if not previously consented and not already done.
-	if !res.GlobalInstall && !IsOrchSetupDone(backend) {
+	if !res.GlobalInstall && !IsOrchInstalled(backend) {
 		fmt.Println()
 		fmt.Printf("  Optional: register qmax tools globally in %s\n", globalConfigPath)
 		fmt.Printf("  so they appear in every `%s` session, not just qmax-code.\n", strings.ToLower(cliName))

--- a/internal/setup/framework_detect_test.go
+++ b/internal/setup/framework_detect_test.go
@@ -1,4 +1,4 @@
-package main
+package setup
 
 import (
 	"os"

--- a/internal/setup/interactive.go
+++ b/internal/setup/interactive.go
@@ -1,4 +1,4 @@
-package main
+package setup
 
 import (
 	"bufio"
@@ -25,7 +25,7 @@ func LoginInteractive() (*api.AuthConfig, error) {
 	fmt.Println("  Get your API key from:")
 	fmt.Println("  https://app.qualitymax.io/settings → API Keys")
 	fmt.Println()
-	key := readSecret("  Paste your API key (qm-...): ")
+	key := ReadSecret("  Paste your API key (qm-...): ")
 
 	if key == "" {
 		return nil, fmt.Errorf("no API key provided")
@@ -146,7 +146,7 @@ func LoginViaBrowser() (*api.AuthConfig, error) {
 
 // RunInteractiveSetup guides a first-time user through login and project selection.
 // Returns the api.AuthConfig and selected project ID.
-func RunInteractiveSetup() (*api.AuthConfig, int) {
+func RunInteractive() (*api.AuthConfig, int) {
 	fmt.Println()
 	tui.AnimateMax(tui.MoodWaving, tui.GetMaxGreeting())
 	fmt.Println()
@@ -155,7 +155,7 @@ func RunInteractiveSetup() (*api.AuthConfig, int) {
 	fmt.Println()
 
 	// Step 1: Account check
-	choice := promptChoice("  Do you have a QualityMax account?", []string{
+	choice := PromptChoice("  Do you have a QualityMax account?", []string{
 		"Yes, log me in (opens browser)",
 		"No, create one (free)",
 		"I have an API key already",
@@ -205,7 +205,7 @@ func RunInteractiveSetup() (*api.AuthConfig, int) {
 	if detected != "" {
 		fmt.Println()
 		fmt.Printf("  Detected a %s project in this directory.\n", prettyFrameworkName(detected))
-		confirm := promptChoice(
+		confirm := PromptChoice(
 			fmt.Sprintf("  Save %s as the default framework for future test generation?", detected),
 			[]string{"Yes, save it", "No, I'll pick per-call"},
 		)
@@ -239,7 +239,7 @@ func RunInteractiveSetup() (*api.AuthConfig, int) {
 		fmt.Println("  I need an Anthropic API key to think (that's my brain!).")
 		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
 		fmt.Println()
-		key := readSecret("  Paste your Anthropic key (sk-ant-...): ")
+		key := ReadSecret("  Paste your Anthropic key (sk-ant-...): ")
 		if key != "" {
 			os.Setenv("ANTHROPIC_API_KEY", key)
 			// Save to OS keychain
@@ -271,7 +271,7 @@ func RunInteractiveSetup() (*api.AuthConfig, int) {
 
 // loginWithKeyPrompt asks the user to paste their API key.
 func loginWithKeyPrompt() (*api.AuthConfig, error) {
-	key := readSecret("  Paste your API key (qm-...): ")
+	key := ReadSecret("  Paste your API key (qm-...): ")
 
 	if key == "" {
 		return nil, fmt.Errorf("no API key provided")
@@ -339,7 +339,7 @@ func selectProject(auth *api.AuthConfig) int {
 	}
 	options = append(options, "Skip — I'll choose later")
 
-	choice := promptChoice("  Which project do you want to work with?", options)
+	choice := PromptChoice("  Which project do you want to work with?", options)
 
 	if choice >= len(projects) {
 		return 0
@@ -356,9 +356,9 @@ func selectProject(auth *api.AuthConfig) int {
 	return id
 }
 
-// readSecret reads a line of input with characters hidden (replaced with dots).
+// ReadSecret reads a line of input with characters hidden (replaced with dots).
 // Shows a masked preview after completion.
-func readSecret(prompt string) string {
+func ReadSecret(prompt string) string {
 	fmt.Print(prompt)
 
 	// Switch terminal to raw mode to hide input
@@ -420,8 +420,8 @@ func maskKey(key string) string {
 
 // --- UI helpers ---
 
-// promptChoice shows an interactive menu and returns the selected index.
-func promptChoice(prompt string, options []string) int {
+// PromptChoice shows an interactive menu and returns the selected index.
+func PromptChoice(prompt string, options []string) int {
 	fmt.Println(prompt)
 	for i, opt := range options {
 		if i == 0 {

--- a/internal/setup/orch.go
+++ b/internal/setup/orch.go
@@ -1,4 +1,4 @@
-package main
+package setup
 
 import (
 	"encoding/json"
@@ -11,8 +11,8 @@ import (
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
-// OrchSetupResult describes what autosetup did so the caller can display it.
-type OrchSetupResult struct {
+// InstallResult describes what autosetup did so the caller can display it.
+type InstallResult struct {
 	MCPWritten    bool
 	MCPPath       string
 	AlreadyHadMCP bool
@@ -25,7 +25,7 @@ type OrchSetupResult struct {
 //   - CC gets all qmax QA tools (list, run, generate, crawl, review…)
 //   - When qmax-code is the host, CC's own tools (bash, file ops, web) are
 //     also fully active and the system prompt instructs CC to use both.
-func SetupCCIntegration() (*OrchSetupResult, error) {
+func InstallCC() (*InstallResult, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func SetupCCIntegration() (*OrchSetupResult, error) {
 // SetupCodexIntegration writes the qmax MCP server into ~/.codex/config.toml
 // so Codex picks up qmax tools whenever the user invokes `codex` directly,
 // in addition to when qmax-code spawns it.
-func SetupCodexIntegration() (*OrchSetupResult, error) {
+func InstallCodex() (*InstallResult, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
@@ -61,7 +61,7 @@ func SetupCodexIntegration() (*OrchSetupResult, error) {
 // writeMCPEntry merges the qmax MCP entry into a JSON config file.
 // Existing keys are preserved; only the "qmax" entry under "mcpServers" is
 // added or updated.
-func writeMCPEntry(path string) (*OrchSetupResult, error) {
+func writeMCPEntry(path string) (*InstallResult, error) {
 	// Load existing config (may not exist yet).
 	cfg := map[string]interface{}{}
 	if data, err := os.ReadFile(path); err == nil {
@@ -93,7 +93,7 @@ func writeMCPEntry(path string) (*OrchSetupResult, error) {
 		return nil, err
 	}
 
-	return &OrchSetupResult{
+	return &InstallResult{
 		MCPWritten:    true,
 		MCPPath:       path,
 		AlreadyHadMCP: alreadyHad,
@@ -101,13 +101,13 @@ func writeMCPEntry(path string) (*OrchSetupResult, error) {
 }
 
 // writeCodexMCPEntry wraps agent.WriteCodexMCPEntry, packaging the
-// already-had flag into an OrchSetupResult.
-func writeCodexMCPEntry(path string, env map[string]string) (*OrchSetupResult, error) {
+// already-had flag into an InstallResult.
+func writeCodexMCPEntry(path string, env map[string]string) (*InstallResult, error) {
 	alreadyHad, err := agent.WriteCodexMCPEntry(path, env)
 	if err != nil {
 		return nil, err
 	}
-	return &OrchSetupResult{
+	return &InstallResult{
 		MCPWritten:    true,
 		MCPPath:       path,
 		AlreadyHadMCP: alreadyHad,
@@ -116,11 +116,11 @@ func writeCodexMCPEntry(path string, env map[string]string) (*OrchSetupResult, e
 
 // RunOrchSetup runs the one-time integration setup for the chosen backend,
 // printing progress to the terminal.
-func RunOrchSetup(backend string, term *tui.Terminal) {
+func RunOrch(backend string, term *tui.Terminal) {
 	switch backend {
 	case "cc":
 		term.PrintSystem("Setting up Claude Code integration…")
-		res, err := SetupCCIntegration()
+		res, err := InstallCC()
 		if err != nil {
 			term.PrintError(fmt.Sprintf("CC setup failed: %v", err))
 			return
@@ -135,7 +135,7 @@ func RunOrchSetup(backend string, term *tui.Terminal) {
 
 	case "codex":
 		term.PrintSystem("Setting up Codex integration…")
-		res, err := SetupCodexIntegration()
+		res, err := InstallCodex()
 		if err != nil {
 			term.PrintError(fmt.Sprintf("Codex setup failed: %v", err))
 			return
@@ -151,7 +151,7 @@ func RunOrchSetup(backend string, term *tui.Terminal) {
 
 // IsOrchSetupDone returns true if the qmax MCP entry already exists in the
 // CLI's config file. Used to skip the setup banner on subsequent launches.
-func IsOrchSetupDone(backend string) bool {
+func IsOrchInstalled(backend string) bool {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return false

--- a/internal/setup/orch_test.go
+++ b/internal/setup/orch_test.go
@@ -1,4 +1,4 @@
-package main
+package setup
 
 import (
 	"os"
@@ -7,16 +7,23 @@ import (
 	"testing"
 )
 
-// Tests for the main-package wrappers around internal/agent's TOML-merging
-// primitives. The primitives themselves are tested in
-// internal/agent/setup_orch_test.go.
+// withTempHome points $HOME at a fresh temp dir for the test and restores it
+// in cleanup. Local copy of the helper used by other test files in the repo.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	orig := os.Getenv("HOME")
+	tmp := t.TempDir()
+	os.Setenv("HOME", tmp)
+	t.Cleanup(func() { os.Setenv("HOME", orig) })
+	return tmp
+}
 
-func TestSetupCodexIntegrationWritesConfigTOML(t *testing.T) {
+func TestInstallCodexWritesConfigTOML(t *testing.T) {
 	home := withTempHome(t)
 
-	res, err := SetupCodexIntegration()
+	res, err := InstallCodex()
 	if err != nil {
-		t.Fatalf("SetupCodexIntegration: %v", err)
+		t.Fatalf("InstallCodex: %v", err)
 	}
 	if res.MCPPath != filepath.Join(home, ".codex", "config.toml") {
 		t.Fatalf("MCPPath = %q, want config.toml under temp home", res.MCPPath)
@@ -33,8 +40,8 @@ func TestSetupCodexIntegrationWritesConfigTOML(t *testing.T) {
 	if !strings.Contains(text, "[mcp_servers.qmax]") {
 		t.Fatalf("missing qmax table:\n%s", text)
 	}
-	if !IsOrchSetupDone("codex") {
-		t.Fatal("IsOrchSetupDone(codex) should detect config.toml qmax entry")
+	if !IsOrchInstalled("codex") {
+		t.Fatal("IsOrchInstalled(codex) should detect config.toml qmax entry")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/mcp"
 	"github.com/qualitymax/qmax-code/internal/session"
+	"github.com/qualitymax/qmax-code/internal/setup"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 	"github.com/qualitymax/qmax-code/internal/tui"
 	"github.com/qualitymax/qmax-code/internal/vnc"
@@ -92,7 +93,7 @@ func main() {
 		} else {
 			// Browser-based login (Railway-style)
 			tui.AnimateMax(tui.MoodWaving, "Let's get you logged in!")
-			cfg, err = LoginViaBrowser()
+			cfg, err = setup.LoginViaBrowser()
 		}
 		if err != nil {
 			tui.AnimateMax(tui.MoodSad, "Login failed: "+err.Error())
@@ -182,7 +183,7 @@ func main() {
 
 	// If no qmax CLI and no API client, run full interactive setup
 	if qmaxBin == "" && apiClient == nil {
-		setupAuth, setupProjectID := RunInteractiveSetup()
+		setupAuth, setupProjectID := setup.RunInteractive()
 		auth = setupAuth
 		apiClient = api.NewAPIClient(auth)
 		appConfig.DefaultProject = setupProjectID
@@ -206,7 +207,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  Or switch backend: qmax-code config set backend api")
 			os.Exit(1)
 		}
-		consent := promptOrchConsent(appConfig, "cc")
+		consent := setup.PromptOrchConsent(appConfig, "cc")
 		if !consent.Proceed {
 			fmt.Fprintln(os.Stderr, "  CC backend not activated. Falling back to direct API.")
 			cliBackend = ""
@@ -225,7 +226,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  Or switch backend: qmax-code config set backend api")
 			os.Exit(1)
 		}
-		consent := promptOrchConsent(appConfig, "codex")
+		consent := setup.PromptOrchConsent(appConfig, "codex")
 		if !consent.Proceed {
 			fmt.Fprintln(os.Stderr, "  Codex backend not activated. Falling back to direct API.")
 			cliBackend = ""
@@ -244,7 +245,7 @@ func main() {
 		fmt.Println("  Anthropic API key needed (this powers the AI).")
 		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
 		fmt.Println()
-		key := readSecret("  Paste your Anthropic key: ")
+		key := setup.ReadSecret("  Paste your Anthropic key: ")
 		if key != "" {
 			anthropicKey = key
 			os.Setenv("ANTHROPIC_API_KEY", key)
@@ -319,15 +320,15 @@ func main() {
 	// performed only when the user opted into it during the consent prompt.
 	switch cliBackend {
 	case "cc":
-		if appConfig.OrchGlobalInstall && !IsOrchSetupDone("cc") {
-			if res, err := SetupCCIntegration(); err == nil && !res.AlreadyHadMCP {
+		if appConfig.OrchGlobalInstall && !setup.IsOrchInstalled("cc") {
+			if res, err := setup.InstallCC(); err == nil && !res.AlreadyHadMCP {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
 			}
 		}
 		cliAgent = agent.NewCCAgent(agent.FindClaudeCode(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, appConfig.OutputVerbose, ctx)
 	case "codex":
-		if appConfig.OrchGlobalInstall && !IsOrchSetupDone("codex") {
-			if res, err := SetupCodexIntegration(); err == nil && !res.AlreadyHadMCP {
+		if appConfig.OrchGlobalInstall && !setup.IsOrchInstalled("codex") {
+			if res, err := setup.InstallCodex(); err == nil && !res.AlreadyHadMCP {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
 			}
 		}
@@ -771,15 +772,15 @@ func runREPL(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool) {
 
 			// Consent gate: required before activating CC/Codex (autonomous shell + edits).
 			if result.Backend != "" {
-				consent := promptOrchConsent(cfg, result.Backend)
+				consent := setup.PromptOrchConsent(cfg, result.Backend)
 				if !consent.Proceed {
 					term.PrintSystem("Backend not changed.")
 					continue
 				}
 				cfg.OrchPermissionMode = consent.PermissionMode
 				cfg.OrchGlobalInstall = consent.GlobalInstall
-				if consent.GlobalInstall && !IsOrchSetupDone(result.Backend) {
-					RunOrchSetup(result.Backend, term)
+				if consent.GlobalInstall && !setup.IsOrchInstalled(result.Backend) {
+					setup.RunOrch(result.Backend, term)
 				}
 			}
 
@@ -893,15 +894,15 @@ func runREPL(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool) {
 					term.PrintSystem("  https://claude.ai/download")
 					continue
 				}
-				consent := promptOrchConsent(cfg, "cc")
+				consent := setup.PromptOrchConsent(cfg, "cc")
 				if !consent.Proceed {
 					term.PrintSystem("Backend not changed.")
 					continue
 				}
 				cfg.OrchPermissionMode = consent.PermissionMode
 				cfg.OrchGlobalInstall = consent.GlobalInstall
-				if consent.GlobalInstall && !IsOrchSetupDone("cc") {
-					RunOrchSetup("cc", term)
+				if consent.GlobalInstall && !setup.IsOrchInstalled("cc") {
+					setup.RunOrch("cc", term)
 				}
 				cliAgent = agent.NewCCAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, ag.Cfg.Context)
 				cfg.Backend = "cc"
@@ -915,15 +916,15 @@ func runREPL(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool) {
 					term.PrintSystem("  npm install -g @openai/codex")
 					continue
 				}
-				consent := promptOrchConsent(cfg, "codex")
+				consent := setup.PromptOrchConsent(cfg, "codex")
 				if !consent.Proceed {
 					term.PrintSystem("Backend not changed.")
 					continue
 				}
 				cfg.OrchPermissionMode = consent.PermissionMode
 				cfg.OrchGlobalInstall = consent.GlobalInstall
-				if consent.GlobalInstall && !IsOrchSetupDone("codex") {
-					RunOrchSetup("codex", term)
+				if consent.GlobalInstall && !setup.IsOrchInstalled("codex") {
+					setup.RunOrch("codex", term)
 				}
 				ca := agent.NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, ag.Cfg.Context)
 				if err := ca.WriteMCPConfig(); err != nil {
@@ -1430,7 +1431,7 @@ func handleConnect(ag *agent.Agent, term *tui.Terminal) {
 	tui.AnimateMax(tui.MoodWaving, "Let's connect you to QualityMax!")
 	fmt.Println()
 
-	auth, err := LoginViaBrowser()
+	auth, err := setup.LoginViaBrowser()
 	if err != nil {
 		tui.AnimateMax(tui.MoodSad, "Connection failed: "+err.Error())
 		fmt.Println()
@@ -1536,7 +1537,7 @@ func handleKeys(ag *agent.Agent, term *tui.Terminal) {
 	}
 	fmt.Println()
 
-	choice := promptChoice("  What would you like to do?", []string{
+	choice := setup.PromptChoice("  What would you like to do?", []string{
 		"Set Anthropic API key",
 		"Connect to QualityMax (browser)",
 		"Disconnect from QualityMax",
@@ -1548,7 +1549,7 @@ func handleKeys(ag *agent.Agent, term *tui.Terminal) {
 		fmt.Println()
 		fmt.Println("  Get your key at: https://console.anthropic.com/settings/keys")
 		fmt.Println()
-		key := readSecret("  Paste your Anthropic key: ")
+		key := setup.ReadSecret("  Paste your Anthropic key: ")
 		if key == "" {
 			term.PrintSystem("Cancelled.")
 			return


### PR DESCRIPTION
## Summary
- Move the first-run wizard, MCP-installer, and autonomy-consent prompt from package main into a new `internal/setup` package. Tests move alongside.
- Drop redundant `Setup` prefixes now that the package name carries them — `SetupCCIntegration` → `setup.InstallCC`, `RunOrchSetup` → `setup.RunOrch`, `IsOrchSetupDone` → `setup.IsOrchInstalled`, `RunInteractiveSetup` → `setup.RunInteractive`, etc.
- Export `readSecret` and `promptChoice` as `setup.ReadSecret` / `setup.PromptChoice` since `main.go`'s `/keys` handler reuses them.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages green, including new `internal/setup` tests (`TestInstallCodex*`, `TestDetectProjectFramework`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)