### PR TITLE
fix: update Anthropic model IDs to valid API names

### DIFF
--- a/internal/api/anthropic.go
+++ b/internal/api/anthropic.go
@@ -5,6 +5,6 @@ const (
 	AnthropicMessagesURL = "https://api.anthropic.com/v1/messages"
 	AnthropicVersion     = "2023-06-01"
 	ModelHaiku           = "claude-haiku-4-5-20251001"
-	ModelSonnet          = "claude-sonnet-4-20250514"
-	ModelOpus            = "claude-opus-4-20250514"
+	ModelSonnet          = "claude-sonnet-4-6"
+	ModelOpus            = "claude-opus-4-7"
 )

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.5"
+var Version = "1.16.6"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- `claude-sonnet-4-20250514` and `claude-opus-4-20250514` are not valid Anthropic API model IDs — every API call using them returned 404
- Updated to `claude-sonnet-4-6` and `claude-opus-4-7` (the correct current IDs)
- `claude-haiku-4-5-20251001` was already correct, left unchanged

## Test plan
- [ ] Verify `qmax` can make a successful Anthropic API call after the fix
- [ ] Confirm repo import flow works (the 500 errors in the reported session were downstream of this 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)