### PR TITLE
chore: bump version to 1.16.7

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.6"
+var Version = "1.16.7"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Bumps version string to 1.16.7 ahead of the v1.16.7 release tag.

## What's in this release

- fix: input blocked during agent thinking — characters no longer overwritten by spinner `\r` rewrites
- fix: Enter now interrupts the running agent and queues the typed prompt for immediate processing
- fix: Option+←/→ word-jump works correctly on macOS (Terminal.app and iTerm2/xterm)
- fix: data race on `Agent.cancel` — all write sites now hold `cancelMu`
- fix: ESC sequences from Option+Arrow no longer insert stray `b`/`f` characters into the queue-reader input line

🤖 Generated with [Claude Code](https://claude.com/claude-code)