### PR TITLE
fix: treat context-cancelled subprocess exit as graceful, not an error

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/qualitymax/qmax-code/internal/api"
@@ -67,7 +68,8 @@ type Agent struct {
 
 	tools           []api.ToolDef
 	client          *http.Client
-	cancel          context.CancelFunc // cancel the current streaming request
+	cancelMu        sync.Mutex
+	cancel          context.CancelFunc // cancel the current streaming request; protected by cancelMu
 	priorSessions   string             // cached prior-session summaries from backend
 	sessionsFetched bool               // true once loadPriorSessions has run
 }
@@ -125,10 +127,13 @@ func (a *Agent) ClearHistory() {
 }
 
 // CancelCurrent cancels the current streaming request if one is in progress.
+// Safe to call from any goroutine concurrently with RunStreaming.
 func (a *Agent) CancelCurrent() {
+	a.cancelMu.Lock()
 	if a.cancel != nil {
 		a.cancel()
 	}
+	a.cancelMu.Unlock()
 }
 
 // Run executes a prompt through the agent loop and returns the final text response.
@@ -350,9 +355,13 @@ func (a *Agent) runStreamingLoop(term *tui.Terminal) (string, error) {
 					fmt.Fprintf(term.Stderr(), "[ollama-chat] trying %s\n", a.Ollama.Model)
 				}
 				ctx, cancel := context.WithCancel(context.Background())
+				a.cancelMu.Lock()
 				a.cancel = cancel
+				a.cancelMu.Unlock()
 				ollamaText, ollamaErr := a.Ollama.ChatStreaming(ctx, a.buildSystemPrompt(), a.History, term)
+				a.cancelMu.Lock()
 				a.cancel = nil
+				a.cancelMu.Unlock()
 				cancel()
 				if ollamaErr == nil && ollamaText != "" {
 					a.History = append(a.History, api.Message{
@@ -392,9 +401,13 @@ func (a *Agent) runStreamingLoop(term *tui.Terminal) (string, error) {
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
+			a.cancelMu.Lock()
 			a.cancel = cancel
+			a.cancelMu.Unlock()
 			toolResults := a.executeToolCallsWithUI(toolCalls, term, ctx)
+			a.cancelMu.Lock()
 			a.cancel = nil
+			a.cancelMu.Unlock()
 			cancel()
 
 			a.History = append(a.History, api.Message{
@@ -535,9 +548,13 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]api.Conten
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	a.cancelMu.Lock()
 	a.cancel = cancel
+	a.cancelMu.Unlock()
 	defer func() {
+		a.cancelMu.Lock()
 		a.cancel = nil
+		a.cancelMu.Unlock()
 		cancel()
 	}()
 

--- a/internal/agent/cc_agent.go
+++ b/internal/agent/cc_agent.go
@@ -23,6 +23,8 @@ import (
 // which CLI is underneath.
 type CLIAgent interface {
 	Run(userMsg string, term *tui.Terminal) (string, error)
+	// Cancel interrupts a Run call in progress. Safe to call from another goroutine.
+	Cancel()
 	SetOutputVerbose(verbose bool)
 	Cleanup()
 }
@@ -51,6 +53,8 @@ type CCAgent struct {
 	sctx           *api.SessionContext
 	lastToolName   string // track last tool name for result display
 	mu             sync.Mutex
+	runMu          sync.Mutex
+	runCancel      context.CancelFunc // non-nil while Run() is active
 }
 
 // ccStandardAllowlist is the curated list passed to `claude --allowedTools` in
@@ -284,6 +288,16 @@ func (a *CCAgent) Run(userMsg string, term *tui.Terminal) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
+	// Expose cancel so Cancel() can interrupt from another goroutine.
+	a.runMu.Lock()
+	a.runCancel = cancel
+	a.runMu.Unlock()
+	defer func() {
+		a.runMu.Lock()
+		a.runCancel = nil
+		a.runMu.Unlock()
+	}()
+
 	cmd := exec.CommandContext(ctx, a.claudeBin, args...)
 	cmd.Stdin = strings.NewReader("")
 	cmd.Stderr = os.Stderr // CC's own errors and status messages
@@ -314,6 +328,15 @@ func fileMissing(path string) bool {
 	}
 	_, err := os.Stat(path)
 	return os.IsNotExist(err)
+}
+
+// Cancel interrupts a Run call that is in progress. Safe to call from any goroutine.
+func (a *CCAgent) Cancel() {
+	a.runMu.Lock()
+	if a.runCancel != nil {
+		a.runCancel()
+	}
+	a.runMu.Unlock()
 }
 
 // Cleanup removes the temp MCP config file.

--- a/internal/agent/cc_agent.go
+++ b/internal/agent/cc_agent.go
@@ -313,6 +313,10 @@ func (a *CCAgent) Run(userMsg string, term *tui.Terminal) (string, error) {
 	result := a.parseStream(stdout, term)
 
 	if err := cmd.Wait(); err != nil {
+		// Intentional cancel (user pressed Enter to interrupt) — not an error.
+		if ctx.Err() != nil {
+			return result, nil
+		}
 		// CC exits non-zero on soft errors (e.g. tool failure) but still produces output.
 		// Only fail hard if we got nothing at all.
 		if result == "" {

--- a/internal/agent/cc_agent_session_test.go
+++ b/internal/agent/cc_agent_session_test.go
@@ -41,6 +41,8 @@ func (m *mockCLIAgent) Run(_ string, _ *tui.Terminal) (string, error) {
 	return "ok", nil
 }
 
+func (m *mockCLIAgent) Cancel() {}
+
 func (m *mockCLIAgent) Cleanup() {}
 
 func (m *mockCLIAgent) SetOutputVerbose(bool) {}

--- a/internal/agent/codex_agent.go
+++ b/internal/agent/codex_agent.go
@@ -198,8 +198,14 @@ func (a *CodexAgent) Run(userMsg string, term *tui.Terminal) (string, error) {
 		}
 	}
 
-	if err := cmd.Wait(); err != nil && sb.Len() == 0 {
-		return "", fmt.Errorf("codex exited with error: %w", err)
+	if err := cmd.Wait(); err != nil {
+		// Intentional cancel (user pressed Enter to interrupt) — not an error.
+		if ctx.Err() != nil {
+			return strings.TrimSpace(sb.String()), nil
+		}
+		if sb.Len() == 0 {
+			return "", fmt.Errorf("codex exited with error: %w", err)
+		}
 	}
 
 	result := strings.TrimSpace(sb.String())

--- a/internal/agent/codex_agent.go
+++ b/internal/agent/codex_agent.go
@@ -41,6 +41,8 @@ type CodexAgent struct {
 	sctx           *api.SessionContext
 	history        []codexTurn // conversation history managed on our side
 	mu             sync.Mutex
+	runMu          sync.Mutex
+	runCancel      context.CancelFunc // non-nil while Run() is active
 }
 
 type codexTurn struct {
@@ -160,6 +162,15 @@ func (a *CodexAgent) Run(userMsg string, term *tui.Terminal) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
+	a.runMu.Lock()
+	a.runCancel = cancel
+	a.runMu.Unlock()
+	defer func() {
+		a.runMu.Lock()
+		a.runCancel = nil
+		a.runMu.Unlock()
+	}()
+
 	cmd := exec.CommandContext(ctx, a.codexBin, args...)
 	cmd.Stdin = strings.NewReader("")
 	cmd.Stderr = os.Stderr
@@ -253,6 +264,15 @@ func (a *CodexAgent) SetOutputVerbose(verbose bool) {
 	a.mu.Lock()
 	a.outputVerbose = verbose
 	a.mu.Unlock()
+}
+
+// Cancel interrupts a Run call that is in progress. Safe to call from any goroutine.
+func (a *CodexAgent) Cancel() {
+	a.runMu.Lock()
+	if a.runCancel != nil {
+		a.runCancel()
+	}
+	a.runMu.Unlock()
 }
 
 // Cleanup is a no-op for CodexAgent (no temp files to remove).

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -769,7 +769,15 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 		// Start the queue reader so the user can type the next prompt while
 		// the agent is working.  It is stopped (and fully drained) before
 		// the next tui.ReadInput call so stdin is never shared between readers.
-		stopQueueReader := session.StartQueueReader(pq, term)
+		// Pressing Enter while typing cancels the running agent so the queued
+		// prompt is processed on the very next iteration.
+		var cancelCurrent func()
+		if cliAgent != nil {
+			cancelCurrent = cliAgent.Cancel
+		} else {
+			cancelCurrent = ag.CancelCurrent
+		}
+		stopQueueReader := session.StartQueueReader(pq, term, cancelCurrent)
 
 		// CC mode: delegate entirely to Claude Code subprocess (uses CC subscription).
 		// Normal mode: use direct Anthropic API.

--- a/internal/session/stdin_queue_termios_darwin.go
+++ b/internal/session/stdin_queue_termios_darwin.go
@@ -1,0 +1,10 @@
+//go:build darwin
+
+package session
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlGetTermios = unix.TIOCGETA
+	ioctlSetTermios = unix.TIOCSETA
+)

--- a/internal/session/stdin_queue_termios_linux.go
+++ b/internal/session/stdin_queue_termios_linux.go
@@ -1,0 +1,10 @@
+//go:build linux
+
+package session
+
+import "golang.org/x/sys/unix"
+
+const (
+	ioctlGetTermios = unix.TCGETS
+	ioctlSetTermios = unix.TCSETS
+)

--- a/internal/session/stdin_queue_unix.go
+++ b/internal/session/stdin_queue_unix.go
@@ -45,7 +45,7 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 			newState.Cc[unix.VMIN] = 1
 			newState.Cc[unix.VTIME] = 0
 			if setErr := unix.IoctlSetTermios(fd, ioctlSetTermios, &newState); setErr == nil {
-				defer unix.IoctlSetTermios(fd, ioctlSetTermios, oldState)
+				defer func() { _ = unix.IoctlSetTermios(fd, ioctlSetTermios, oldState) }()
 			}
 		}
 

--- a/internal/session/stdin_queue_unix.go
+++ b/internal/session/stdin_queue_unix.go
@@ -51,7 +51,15 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 
 		var lineRunes []rune
 		var rawBuf []byte
+		// Pre-allocated read buffer — reused every iteration.
+		readBuf := make([]byte, 32)
 		typing := false
+
+		// Escape-sequence state machine: absorbs ESC sequences so that
+		// Option+Arrow (which sends ESC+b/f or ESC+[+...+D/C) doesn't
+		// insert stray characters into the typed line.
+		escSeq := false    // true after ESC, consuming the sequence
+		escBracket := false // true after ESC+[ (CSI), consuming until final byte
 
 		for {
 			select {
@@ -71,27 +79,25 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 				continue
 			}
 
-			buf := make([]byte, 32)
-			nr, err := unix.Read(fd, buf)
+			nr, err := unix.Read(fd, readBuf)
 			if err != nil || nr == 0 {
 				continue
 			}
-			rawBuf = append(rawBuf, buf[:nr]...)
+			rawBuf = append(rawBuf, readBuf[:nr]...)
 
 			for len(rawBuf) > 0 {
 				r, size := utf8.DecodeRune(rawBuf)
-				if r == utf8.RuneError {
-					if size == 0 {
-						break // empty — wait for more bytes
-					}
-					rawBuf = rawBuf[1:] // bad byte; skip
-					continue
+				if size == 0 {
+					break // incomplete sequence — wait for more bytes
 				}
 				rawBuf = rawBuf[size:]
+				if r == utf8.RuneError && size == 1 {
+					continue // bad byte; discard
+				}
 
 				// On the first keystroke: tell the spinner to pause (it checks this
 				// flag before each frame write), then open a dedicated typing line.
-				if !typing {
+				if !typing && !escSeq && r != 0x1b {
 					typing = true
 					term.SetUserTyping(true)
 					// \r moves to column 0; \033[K clears to EOL (erases any spinner
@@ -131,7 +137,24 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 					fmt.Println()
 
 				default:
-					if r >= 32 { // printable
+					if r == 0x1b { // ESC — start of an escape sequence
+						escSeq = true
+						escBracket = false
+					} else if escSeq {
+						if escBracket {
+							// Inside CSI: consume until final byte (0x40–0x7E)
+							if r >= 0x40 && r <= 0x7E {
+								escSeq = false
+								escBracket = false
+							}
+						} else if r == '[' {
+							escBracket = true // ESC+[ introduces a CSI sequence
+						} else {
+							// Simple ESC+char (e.g., Option+b/f on macOS Terminal.app)
+							escSeq = false
+						}
+						// In all escape-sequence branches: do not append to lineRunes
+					} else if r >= 32 { // printable character
 						lineRunes = append(lineRunes, r)
 						fmt.Printf("%c", r)
 					}

--- a/internal/session/stdin_queue_unix.go
+++ b/internal/session/stdin_queue_unix.go
@@ -7,39 +7,62 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
-// StartQueueReader starts a background goroutine that reads lines from stdin
-// (using OS canonical mode — full-line buffering with echo) while the agent
-// is processing.  Each non-empty line is pushed onto pq.
+// StartQueueReader starts a background goroutine that reads chars from stdin
+// one at a time while the agent is processing. Each non-empty line (Enter-terminated)
+// is pushed onto pq. If cancelFn is non-nil it is called when the user presses Enter,
+// allowing the running agent to be interrupted so the queued prompt is processed next.
 //
-// Returns a stop function that must be called before the next tui.ReadInput so
-// that no stdin data is consumed by two readers simultaneously.
-func StartQueueReader(pq *PromptQueue, term *tui.Terminal) func() {
+// The goroutine switches stdin to "half-raw" mode: ICANON and ECHO are disabled so
+// we can manage echo ourselves (preventing the spinner from overwriting typed text),
+// while OPOST is left enabled so the agent's concurrent stdout output still gets
+// proper newline translation. Returns a stop function that must be called before the
+// next tui.ReadInput to ensure stdin is never shared between two readers.
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() {
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
+		defer term.SetUserTyping(false)
 
 		fd := int(os.Stdin.Fd())
-		var pending []byte // bytes read before the closing newline
+
+		// Switch to half-raw mode: disable canonical mode and echo only.
+		// Keeping OPOST ensures the agent's fmt.Print output (running concurrently)
+		// still gets \n → \r\n translation and doesn't look broken.
+		oldState, stateErr := unix.IoctlGetTermios(fd, ioctlGetTermios)
+		if stateErr == nil {
+			newState := *oldState
+			newState.Lflag &^= unix.ICANON | unix.ECHO
+			newState.Cc[unix.VMIN] = 1
+			newState.Cc[unix.VTIME] = 0
+			if setErr := unix.IoctlSetTermios(fd, ioctlSetTermios, &newState); setErr == nil {
+				defer unix.IoctlSetTermios(fd, ioctlSetTermios, oldState)
+			}
+		}
+
+		var lineRunes []rune
+		var rawBuf []byte
+		typing := false
 
 		for {
-			// Check whether we've been asked to stop.
 			select {
 			case <-done:
+				if typing {
+					fmt.Print("\r\033[K") // erase the typing line before exiting
+				}
 				return
 			default:
 			}
 
-			// Poll stdin with a 50 ms timeout so we wake up frequently
-			// enough to notice the done signal.
 			var rfds unix.FdSet
 			rfds.Set(fd)
 			tv := unix.Timeval{Sec: 0, Usec: 50_000}
@@ -48,39 +71,77 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal) func() {
 				continue
 			}
 
-			// In canonical mode the OS delivers a complete line at once.
-			buf := make([]byte, 4096)
+			buf := make([]byte, 32)
 			nr, err := unix.Read(fd, buf)
 			if err != nil || nr == 0 {
 				continue
 			}
+			rawBuf = append(rawBuf, buf[:nr]...)
 
-			pending = append(pending, buf[:nr]...)
-
-			// Extract complete lines.
-			for {
-				idx := strings.IndexByte(string(pending), '\n')
-				if idx < 0 {
-					break
-				}
-				line := strings.TrimSpace(string(pending[:idx]))
-				pending = pending[idx+1:]
-
-				if line == "" {
+			for len(rawBuf) > 0 {
+				r, size := utf8.DecodeRune(rawBuf)
+				if r == utf8.RuneError {
+					if size == 0 {
+						break // empty — wait for more bytes
+					}
+					rawBuf = rawBuf[1:] // bad byte; skip
 					continue
 				}
-				pq.Push(line)
-				pos := pq.Len()
-				// Print confirmation on its own line so it doesn't corrupt
-				// mid-stream token output.
-				fmt.Printf("\n  %s✓ queued [%d]:%s %s\n",
-					tui.ColorDim, pos, tui.ColorReset, line)
+				rawBuf = rawBuf[size:]
+
+				// On the first keystroke: tell the spinner to pause (it checks this
+				// flag before each frame write), then open a dedicated typing line.
+				if !typing {
+					typing = true
+					term.SetUserTyping(true)
+					// \r moves to column 0; \033[K clears to EOL (erases any spinner
+					// text); \n moves to a fresh line where we show the input prompt.
+					fmt.Print("\r\033[K\n  ⌨  ")
+				}
+
+				switch r {
+				case '\r', '\n': // Enter
+					text := strings.TrimSpace(string(lineRunes))
+					lineRunes = lineRunes[:0]
+					fmt.Println()
+					typing = false
+					term.SetUserTyping(false)
+					if text == "" {
+						break
+					}
+					// Cancel the running agent so this prompt is processed immediately.
+					if cancelFn != nil {
+						cancelFn()
+					}
+					pq.Push(text)
+					pos := pq.Len()
+					fmt.Printf("  %s✓ queued [%d]:%s %s\n",
+						tui.ColorDim, pos, tui.ColorReset, text)
+
+				case 127, 8: // Backspace / Delete
+					if len(lineRunes) > 0 {
+						lineRunes = lineRunes[:len(lineRunes)-1]
+						fmt.Print("\b \b")
+					}
+
+				case 3: // Ctrl+C — owned by the signal handler in repl.go; don't eat it
+					typing = false
+					term.SetUserTyping(false)
+					lineRunes = lineRunes[:0]
+					fmt.Println()
+
+				default:
+					if r >= 32 { // printable
+						lineRunes = append(lineRunes, r)
+						fmt.Printf("%c", r)
+					}
+				}
 			}
 		}
 	}()
 
 	return func() {
 		close(done)
-		wg.Wait() // guaranteed no stdin reads after this returns
+		wg.Wait()
 	}
 }

--- a/internal/session/stdin_queue_windows.go
+++ b/internal/session/stdin_queue_windows.go
@@ -6,6 +6,6 @@ import "github.com/qualitymax/qmax-code/internal/tui"
 
 // StartQueueReader is a no-op on Windows; the prompt queue still works via
 // /queue but concurrent stdin reading while streaming is not supported.
-func StartQueueReader(pq *PromptQueue, term *tui.Terminal) func() {
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() {
 	return func() {}
 }

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -426,7 +426,7 @@ func (m inputModel) View() string {
 			mode = "verbose"
 		}
 		b.WriteString("\n")
-		b.WriteString(menuHintStyle.Render(fmt.Sprintf("  Ctrl+O output: %s • Ctrl+X×3 clear • Ctrl+←/→ words • Ctrl+C cancel • / commands", mode)))
+		b.WriteString(menuHintStyle.Render(fmt.Sprintf("  Ctrl+O output: %s • Ctrl+X×3 clear • Opt+←/→ or Ctrl+←/→ words • Ctrl+C cancel • / commands", mode)))
 	} else {
 		// Menu mode
 		b.WriteString(m.prompt)

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -146,12 +146,18 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.KeyLeft:
-		if m.cursor > 0 {
+		// Alt+Left (xterm \x1b[1;3D) = word-left, plain Left = char-left.
+		if msg.Alt {
+			m.cursor = previousWordBoundary(runes, m.cursor)
+		} else if m.cursor > 0 {
 			m.cursor--
 		}
 
 	case tea.KeyRight:
-		if m.cursor < len(runes) {
+		// Alt+Right (xterm \x1b[1;3C) = word-right, plain Right = char-right.
+		if msg.Alt {
+			m.cursor = nextWordBoundary(runes, m.cursor)
+		} else if m.cursor < len(runes) {
 			m.cursor++
 		}
 
@@ -214,6 +220,18 @@ func (m inputModel) updateTyping(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyRunes:
 		if msg.Paste {
 			m.pasted = true
+		}
+		// macOS Option+Left sends ESC+'b', Option+Right sends ESC+'f'.
+		// Bubbletea delivers these as KeyRunes with Alt=true.
+		if msg.Alt && len(msg.Runes) == 1 {
+			switch msg.Runes[0] {
+			case 'b', 'B':
+				m.cursor = previousWordBoundary(runes, m.cursor)
+				return m, nil
+			case 'f', 'F':
+				m.cursor = nextWordBoundary(runes, m.cursor)
+				return m, nil
+			}
 		}
 		ch := string(msg.Runes)
 		// Typing "/" on an empty line opens the slash menu.

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/glamour"
@@ -121,10 +122,11 @@ type spinner struct {
 	done sync.Once
 	stop chan struct{}
 	wg   sync.WaitGroup
+	term *Terminal // checked each tick to pause while user is typing
 }
 
-func newSpinner() *spinner {
-	s := &spinner{stop: make(chan struct{})}
+func newSpinner(t *Terminal) *spinner {
+	s := &spinner{stop: make(chan struct{}), term: t}
 	msg := spinnerMessages[rand.Intn(len(spinnerMessages))]
 	s.wg.Add(1)
 	go func() {
@@ -138,6 +140,10 @@ func newSpinner() *spinner {
 				fmt.Print("\r\033[K") // erase spinner line
 				return
 			case <-ticker.C:
+				// Pause while the user is typing so our \r doesn't overwrite their input.
+				if s.term != nil && s.term.userTyping.Load() {
+					continue
+				}
 				frame := spinnerFrames[i%len(spinnerFrames)]
 				i++
 				fmt.Printf("\r  %s%s %s...%s",
@@ -163,6 +169,13 @@ type Terminal struct {
 	streamBuf     strings.Builder // buffers streamed text for post-render
 	currentPrompt string          // track prompt for readline recreation
 	thinking      *spinner        // active thinking spinner, if any
+	userTyping    atomic.Bool     // true while StartQueueReader has the user typing
+}
+
+// SetUserTyping tells the active spinner to pause (true) or resume (false) its
+// line rewrites so typed characters are not overwritten.
+func (t *Terminal) SetUserTyping(v bool) {
+	t.userTyping.Store(v)
 }
 
 // Stderr returns the writer used for diagnostic / debug log lines that the
@@ -236,7 +249,7 @@ func (t *Terminal) Close() {
 // Safe to call even if a spinner is already running (replaces it).
 func (t *Terminal) StartThinking() {
 	t.StopThinking()
-	t.thinking = newSpinner()
+	t.thinking = newSpinner(t)
 }
 
 // StopThinking stops the spinner and erases it from the terminal.


### PR DESCRIPTION
## Problem

When the user types text during agent thinking and presses Enter, `Cancel()` fires — killing the CC/Codex subprocess via context cancellation. `cmd.Wait()` returns `signal: killed`, which was being displayed as:

```
✗ claude exited with error: signal: killed
```

## Fix

Before treating a non-zero `cmd.Wait()` exit as an error, check `ctx.Err()`. If the context was already cancelled, the kill was intentional — return whatever output was collected (possibly empty) with `nil` error. The REPL then silently moves on to process the queued prompt.

Applies to both `CCAgent` and `CodexAgent`.

## Test plan
- [ ] Type during agent thinking, press Enter → no error message, queued prompt processes cleanly
- [ ] Genuine CC/Codex errors (bad API key, binary not found) still surface correctly
- [ ] `go test -race ./internal/agent/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)