### PR TITLE
chore: bump version to 1.16.8

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.7"
+var Version = "1.16.8"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Bumps version string to 1.16.8 ahead of the v1.16.8 release tag.

## What's in this release

- fix: interrupting the agent with Enter no longer shows `✗ claude exited with error: signal: killed` — context-cancelled subprocess exits are now treated as graceful stops and the queued prompt processes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)