### PR TITLE
chore: bump version to 1.16.9

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.8"
+var Version = "1.16.9"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Bumps the CLI version to 1.16.9 for the PR #99 release.