### PR TITLE
fix(QUA-577): recover partial typed input when agent finishes mid-typing

### DIFF
--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -326,6 +326,15 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 			}
 			continue
 
+		case input == "/queue clear":
+			n := pq.Clear()
+			if n == 0 {
+				term.PrintSystem("Queue was already empty.")
+			} else {
+				term.PrintSystem(fmt.Sprintf("Cleared %d queued prompt(s).", n))
+			}
+			continue
+
 		case strings.HasPrefix(input, "/queue "):
 			queued := strings.TrimSpace(strings.TrimPrefix(input, "/queue "))
 			if queued != "" {
@@ -872,7 +881,17 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 
 		// Stop queue reader and wait for the goroutine to exit before we
 		// touch stdin again (either via the queue loop or tui.ReadInput).
-		stopQueueReader()
+		// If the user was mid-typing when the agent finished — i.e. typed a
+		// partial line but didn't press Enter before the response came back —
+		// the queue reader returns that text. Push it onto the queue so it
+		// isn't silently lost (QUA-577). The user can /queue clear if it was
+		// stray input.
+		partial := strings.TrimSpace(stopQueueReader())
+		if partial != "" {
+			pq.Push(partial)
+			fmt.Println()
+			term.PrintSystem(fmt.Sprintf("↩ partial input recovered → queued [%d]: %s  (type /queue clear to discard)", pq.Len(), partial))
+		}
 
 		// If prompts were queued during this run, surface them.
 		if n := pq.Len(); n > 0 {
@@ -1143,6 +1162,7 @@ api.Config examples:
 Queue:
   /queue                    Show pending queue
   /queue <prompt>           Add a prompt to the queue immediately
+  /queue clear              Discard all queued prompts
   (type while agent runs)   Prompts entered during processing are auto-queued
 
 Shortcuts:

--- a/internal/session/queue.go
+++ b/internal/session/queue.go
@@ -39,3 +39,12 @@ func (q *PromptQueue) Len() int {
 	defer q.mu.Unlock()
 	return len(q.items)
 }
+
+// Clear empties the queue and returns the number of items that were removed.
+func (q *PromptQueue) Clear() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	n := len(q.items)
+	q.items = nil
+	return n
+}

--- a/internal/session/queue_test.go
+++ b/internal/session/queue_test.go
@@ -128,6 +128,29 @@ func TestPromptQueue_ConcurrentPush(t *testing.T) {
 	}
 }
 
+func TestPromptQueue_ClearReturnsCount(t *testing.T) {
+	var q PromptQueue
+	q.Push("a")
+	q.Push("b")
+	q.Push("c")
+
+	n := q.Clear()
+	if n != 3 {
+		t.Errorf("clear returned %d, want 3", n)
+	}
+	if q.Len() != 0 {
+		t.Errorf("len after clear: got %d, want 0", q.Len())
+	}
+}
+
+func TestPromptQueue_ClearEmpty(t *testing.T) {
+	var q PromptQueue
+	n := q.Clear()
+	if n != 0 {
+		t.Errorf("clear on empty queue returned %d, want 0", n)
+	}
+}
+
 func TestPromptQueue_ConcurrentPushPop(t *testing.T) {
 	var q PromptQueue
 	const count = 200

--- a/internal/session/stdin_queue_unix.go
+++ b/internal/session/stdin_queue_unix.go
@@ -24,14 +24,29 @@ import (
 // while OPOST is left enabled so the agent's concurrent stdout output still gets
 // proper newline translation. Returns a stop function that must be called before the
 // next tui.ReadInput to ensure stdin is never shared between two readers.
-func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() {
+//
+// The stop function returns any partial line the user had typed but not yet
+// Enter-terminated when the agent finished. If the agent's response races the
+// user's typing (turn ends before Enter is pressed), the caller can recover the
+// partial text rather than silently dropping it (QUA-577).
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() string {
 	done := make(chan struct{})
+	partialCh := make(chan string, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
+
+	// lineRunes is only mutated inside the goroutine. The stop function
+	// reads its final value via partialCh after wg.Wait, so there is no
+	// concurrent access window.
+	var lineRunes []rune
 
 	go func() {
 		defer wg.Done()
 		defer term.SetUserTyping(false)
+		// Send whatever partial line was buffered when the goroutine exits.
+		// Runs before wg.Done (LIFO), so wg.Wait observes the send. Channel
+		// is buffered (cap 1), so this never blocks even if no one reads.
+		defer func() { partialCh <- string(lineRunes) }()
 
 		fd := int(os.Stdin.Fd())
 
@@ -49,7 +64,6 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 			}
 		}
 
-		var lineRunes []rune
 		var rawBuf []byte
 		// Pre-allocated read buffer — reused every iteration.
 		readBuf := make([]byte, 32)
@@ -163,8 +177,17 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 		}
 	}()
 
-	return func() {
+	return func() string {
 		close(done)
 		wg.Wait()
+		// Channel is buffered and always written in a defer before wg.Done,
+		// so by the time we read, the value is there. Use a non-blocking
+		// receive with a default as belt-and-suspenders.
+		select {
+		case s := <-partialCh:
+			return s
+		default:
+			return ""
+		}
 	}
 }

--- a/internal/session/stdin_queue_windows.go
+++ b/internal/session/stdin_queue_windows.go
@@ -6,6 +6,7 @@ import "github.com/qualitymax/qmax-code/internal/tui"
 
 // StartQueueReader is a no-op on Windows; the prompt queue still works via
 // /queue but concurrent stdin reading while streaming is not supported.
-func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() {
-	return func() {}
+// The returned stop function always reports no partial input.
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() string {
+	return func() string { return "" }
 }


### PR DESCRIPTION
## Summary
Fixes [QUA-577](https://linear.app/quality-max/issue/QUA-577/qmax-code-type-while-thinking-prompt-queue-drops-keystrokes-advertised). The v1.13 "type while agent runs, auto-queue" feature was silently dropping the user's typed-but-not-yet-Enter-terminated input when the agent's response came back before they could press Enter.

## Root cause (from e2e PTY probe)
- `StartQueueReader` accumulates each typed character in an in-goroutine `lineRunes` buffer. On Enter the buffer is pushed onto the queue.
- When `stopQueueReader()` fires (agent turn ended), the goroutine returns and `lineRunes` is garbage-collected — **even if it contained a partial line the user was mid-typing**.
- Additionally, bytes that arrive between `stopQueueReader()` and the next `tui.ReadInput()` end up split across two prompts.

Reproduction (real keyboard, confirmed by @strazhnyk): submit a slow prompt, start typing a second one, and let the agent finish before you press Enter. Your typed text vanishes; the next prompt opens empty.

## Fix
- `StartQueueReader` now returns `func() string`. The goroutine sends its final `lineRunes` value through a buffered channel before exiting; the stop function returns it after `wg.Wait`.
- `repl.go` reads the partial after the agent's turn finishes and, if non-empty after trim, pushes it onto the queue with a clear notice:
  ```
  ↩ partial input recovered → queued [N]: <text>  (type /queue clear to discard)
  ```
- New `/queue clear` slash command (`PromptQueue.Clear`) lets the user discard recovered text if it was stray input.
- Windows stub updated to match the new signature.

## Verification
- e2e PTY harness: pre-fix, the typed prefix was lost and never appeared in the queue. Post-fix, the partial is recovered, queued, and processed on the next iteration. Subsequent characters that arrived during the stopReader→ReadInput window are captured by the new queue reader and queued cleanly too.
- `go test ./... -short -count=1` is green.
- New unit tests: `TestPromptQueue_ClearReturnsCount`, `TestPromptQueue_ClearEmpty`.

## Test plan
- [ ] Real-keyboard regression: open `qmax-code`, submit a slow prompt, type a few chars during thinking but don't press Enter. Confirm the agent's response is followed by `↩ partial input recovered → queued [1]: <your text>`, then `processing queued prompt`.
- [ ] Same flow but press Enter mid-thinking: confirm the existing `✓ queued [N]:` path still works and Enter still cancels the running agent.
- [ ] `/queue clear` discards queued items as expected.
- [ ] No regression in `go test ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)