### PR TITLE
Fix CLI quality regressions

### DIFF
--- a/config_command.go
+++ b/config_command.go
@@ -28,7 +28,7 @@ import (
 //
 //	default_framework → "", "playwright", "pytest", "rust_cargo", "go_test"
 //	default_project   → integer project ID
-//	default_model     → "auto", "sonnet", "opus", "haiku", or full model ID
+//	default_model     → "auto", "sonnet", "opus", "haiku", or known full model ID
 //	professional      → bool ("true" / "false")
 //	auto_save         → bool
 //	output_verbose    → bool (compact vs previous detailed answer style)
@@ -162,7 +162,10 @@ func setConfigField(key, value string) error {
 		}
 
 	case "default_model":
-		cfg.DefaultModel = value
+		if value != "" && !api.IsValidClaudeModelName(value) {
+			return fmt.Errorf("invalid default_model %q; allowed: %s", value, api.ValidClaudeModelsHelp())
+		}
+		cfg.DefaultModel = api.ResolveClaudeModel(value)
 
 	case "professional":
 		b, err := parseConfigBool(value)

--- a/config_command_test.go
+++ b/config_command_test.go
@@ -42,6 +42,22 @@ func TestSetConfigField_DefaultFrameworkRejectsBadValues(t *testing.T) {
 	}
 }
 
+func TestSetConfigField_DefaultModelValidation(t *testing.T) {
+	withTempHome(t)
+
+	if err := setConfigField("default_model", "sonnet"); err != nil {
+		t.Fatalf("expected shorthand model to be accepted: %v", err)
+	}
+	loaded := api.LoadQMaxCodeConfig()
+	if loaded.DefaultModel != api.ModelSonnet {
+		t.Errorf("DefaultModel: got %q, want %q", loaded.DefaultModel, api.ModelSonnet)
+	}
+
+	if err := setConfigField("default_model", "claude-future-model-9-0"); err == nil {
+		t.Fatal("expected unknown Claude model ID to be rejected")
+	}
+}
+
 func TestSetConfigField_UnsetEqualsEmptyValue(t *testing.T) {
 	withTempHome(t)
 

--- a/internal/agent/cc_agent.go
+++ b/internal/agent/cc_agent.go
@@ -30,16 +30,18 @@ type CLIAgent interface {
 }
 
 // CCAgent orchestrates a Claude Code CLI subprocess for LLM inference.
-// All inference runs through the user's CC subscription — zero Anthropic API
-// tokens consumed by qmax-code itself. qmax tools are exposed to CC as an MCP
-// server so CC can call them natively via its own tool-use mechanism.
+// Inference runs through the user's Claude Code login, so qmax-code does not
+// need a QM-held Anthropic API key. Because this agent uses `claude --print`,
+// usage moves to the user's monthly Claude Agent SDK credit on 2026-06-15.
+// qmax tools are exposed to CC as an MCP server so CC can call them natively
+// via its own tool-use mechanism.
 //
 // Per-message flow:
 //  1. qmax-code spawns:  claude --print "msg" --output-format stream-json
 //     --append-system-prompt <QA_PROMPT> --mcp-config <temp_file>
 //     [--resume <cc_session_id>]
 //  2. CC spawns: qmax-code serve --mcp  (our MCP server subprocess)
-//  3. CC uses qmax tools via MCP, runs on its own subscription
+//  3. CC uses qmax tools via MCP, metered to the user's Claude account
 //  4. qmax-code parses CC's stream-json and renders in the terminal
 //  5. CC session ID is saved for --resume on the next turn
 type CCAgent struct {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -28,7 +28,8 @@ type Config struct {
 
 	// Backend selects the LLM inference backend.
 	//   ""  / "api" → Anthropic API directly (default, requires ANTHROPIC_API_KEY)
-	//   "cc"        → Claude Code CLI subprocess (uses CC subscription, no API key needed)
+	//   "cc"        → Claude Code CLI subprocess (no QM API key; `claude --print`
+	//                 uses the user's Agent SDK credit starting 2026-06-15)
 	//   "codex"     → OpenAI Codex CLI subprocess (uses OpenAI subscription, no API key needed)
 	// In both CLI modes qmax tools are served to the CLI via an embedded MCP server.
 	Backend string `json:"backend,omitempty"`

--- a/internal/api/models.go
+++ b/internal/api/models.go
@@ -1,0 +1,35 @@
+package api
+
+import "strings"
+
+// ResolveClaudeModel expands user-facing shorthand names to concrete
+// Anthropic model IDs. "auto" is preserved as qmax-code's smart-routing
+// sentinel.
+func ResolveClaudeModel(m string) string {
+	switch strings.ToLower(m) {
+	case "sonnet":
+		return ModelSonnet
+	case "opus":
+		return ModelOpus
+	case "haiku":
+		return ModelHaiku
+	default:
+		return strings.ToLower(m)
+	}
+}
+
+// IsValidClaudeModelName reports whether m is a model name qmax-code knows
+// how to route. Validation is intentionally strict so typos fail locally
+// instead of being forwarded to the Anthropic API or Claude Code.
+func IsValidClaudeModelName(m string) bool {
+	switch ResolveClaudeModel(m) {
+	case "auto", ModelSonnet, ModelOpus, ModelHaiku:
+		return true
+	default:
+		return false
+	}
+}
+
+func ValidClaudeModelsHelp() string {
+	return "auto, sonnet, opus, haiku, " + ModelSonnet + ", " + ModelOpus + ", " + ModelHaiku
+}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -132,6 +132,16 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 					tui.ColorDim, recent[0].ID, recent[0].Turns, formatDuration(age), tui.ColorReset)
 			}
 		}
+
+		// QUA-578: surface the 2026-06-15 Anthropic Agent SDK credit cutover
+		// for cc-backend users. Shown at most once per local day to avoid
+		// nagging. The two phrasings (pre/post cutover) reflect the actual
+		// billing change documented at
+		// https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan.
+		if ag.Cfg.Context != nil && ag.Cfg.Context.Backend == "cc" {
+			maybePrintSDKCreditBanner()
+		}
+
 		fmt.Println()
 	}
 	term.SetSessionPrompt(sessionID)
@@ -779,7 +789,9 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 		}
 		stopQueueReader := session.StartQueueReader(pq, term, cancelCurrent)
 
-		// CC mode: delegate entirely to Claude Code subprocess (uses CC subscription).
+		// CC mode: delegate entirely to Claude Code subprocess. This does not
+		// require a QM Anthropic API key, but `claude --print` usage draws from
+		// the user's Agent SDK credit starting 2026-06-15.
 		// Normal mode: use direct Anthropic API.
 		var llmResult string
 		var err error
@@ -1107,7 +1119,7 @@ Commands:
   /orch          Cycle orchestration backend: off → CC → Codex → off
   /theme         Live-preview color scheme picker
   /cloudsync     Toggle cloud session sync (enabled/disabled)
-  /cc            Switch to Claude Code backend (CC subscription, no API tokens)
+  /cc            Switch to Claude Code backend (no QM API key; Agent SDK credit)
   /codex         Switch to Codex CLI backend (OpenAI subscription, no API tokens)
   /api           Switch back to direct Anthropic API
   /ollama        Toggle Ollama on/off (self-hosted LLM for chat)
@@ -1135,7 +1147,7 @@ api.Config examples:
   /set cloud_sync false      Disable cloud session sync
   /set ollama on            Enable self-hosted LLM for chat (saves API costs)
   /set ollama off           Disable Ollama, use Claude for all calls
-  /set backend cc           Use Claude Code subscription (no API key needed)
+  /set backend cc           Use Claude Code login (Agent SDK credit for --print)
   /set backend codex        Use OpenAI Codex subscription (no API key needed)
   /set backend api          Use Anthropic API directly (default)
   /set theme ocean          Switch color theme (historic, ocean, neon, ember, aurora · paper, sky, sparkling, radiance, goldenhour)
@@ -1245,12 +1257,11 @@ func handleSetCommand(input string, ag *agent.Agent, term *tui.Terminal) {
 
 	switch key {
 	case "model":
-		validModels := map[string]bool{"auto": true, "sonnet": true, "opus": true, "haiku": true}
-		if !validModels[strings.ToLower(value)] {
-			term.PrintError("Valid models: auto, sonnet, opus, haiku")
+		if !api.IsValidClaudeModelName(value) {
+			term.PrintError("Valid models: " + api.ValidClaudeModelsHelp())
 			return
 		}
-		cfg.DefaultModel = strings.ToLower(value)
+		cfg.DefaultModel = api.ResolveClaudeModel(value)
 		term.PrintSystem(fmt.Sprintf("Default model set to: %s", cfg.DefaultModel))
 
 	case "project":
@@ -1485,4 +1496,48 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dm", int(d.Minutes()))
 	}
 	return fmt.Sprintf("%dh", int(d.Hours()))
+}
+
+// sdkCreditCutover is the date Anthropic moves `claude --print` /
+// Agent SDK calls off the regular Pro/Max subscription pool onto a
+// separate per-user monthly credit. Reference:
+// https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan
+var sdkCreditCutover = time.Date(2026, time.June, 15, 0, 0, 0, 0, time.Local)
+
+// maybePrintSDKCreditBanner emits a one-line notice — at most once per
+// local day — explaining that the cc backend's `claude --print` traffic
+// is metered against the new Anthropic Agent SDK monthly credit. Before
+// the cutover the message is a heads-up; after, it's a reminder that the
+// session is drawing from that credit (and falls through to API rates
+// once exhausted if extra-usage is enabled).
+//
+// Persistence lives in ~/.qmax-code/sdk_credit_banner_seen. The file holds
+// the YYYY-MM-DD of the last shown banner; if it matches today we stay
+// silent. Best-effort: any read/write failure simply re-shows.
+func maybePrintSDKCreditBanner() {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return // can't track state; skip rather than nag every session
+	}
+	markerPath := filepath.Join(home, ".qmax-code", "sdk_credit_banner_seen")
+	today := time.Now().Format("2006-01-02")
+
+	if data, err := os.ReadFile(markerPath); err == nil {
+		if strings.TrimSpace(string(data)) == today {
+			return
+		}
+	}
+
+	if time.Now().Before(sdkCreditCutover) {
+		fmt.Printf("  %s↪ Heads-up: starting 2026-06-15, the cc backend will draw from your monthly Claude Agent SDK credit (Pro $20 / Max 5x $100 / Max 20x $200), then API rates if extra-usage is enabled.%s\n",
+			tui.ColorDim, tui.ColorReset)
+	} else {
+		fmt.Printf("  %s↪ This session uses your Claude Agent SDK monthly credit (Pro $20 / Max 5x $100 / Max 20x $200), then API rates if extra-usage is enabled. /backend api to switch.%s\n",
+			tui.ColorDim, tui.ColorReset)
+	}
+
+	// Best-effort marker write — silent failure means a re-show, which is
+	// strictly better than a missed disclosure.
+	_ = os.MkdirAll(filepath.Dir(markerPath), 0o755)
+	_ = os.WriteFile(markerPath, []byte(today), 0o644)
 }

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -326,6 +326,15 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 			}
 			continue
 
+		case input == "/queue clear":
+			n := pq.Clear()
+			if n == 0 {
+				term.PrintSystem("Queue was already empty.")
+			} else {
+				term.PrintSystem(fmt.Sprintf("Cleared %d queued prompt(s).", n))
+			}
+			continue
+
 		case strings.HasPrefix(input, "/queue "):
 			queued := strings.TrimSpace(strings.TrimPrefix(input, "/queue "))
 			if queued != "" {
@@ -872,7 +881,17 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 
 		// Stop queue reader and wait for the goroutine to exit before we
 		// touch stdin again (either via the queue loop or tui.ReadInput).
-		stopQueueReader()
+		// If the user was mid-typing when the agent finished — i.e. typed a
+		// partial line but didn't press Enter before the response came back —
+		// the queue reader returns that text. Push it onto the queue so it
+		// isn't silently lost (QUA-577). The user can /queue clear if it was
+		// stray input.
+		partial := strings.TrimSpace(stopQueueReader())
+		if partial != "" {
+			pq.Push(partial)
+			fmt.Println()
+			term.PrintSystem(fmt.Sprintf("↩ partial input recovered → queued [%d]: %s  (type /queue clear to discard)", pq.Len(), partial))
+		}
 
 		// If prompts were queued during this run, surface them.
 		if n := pq.Len(); n > 0 {
@@ -1143,6 +1162,7 @@ api.Config examples:
 Queue:
   /queue                    Show pending queue
   /queue <prompt>           Add a prompt to the queue immediately
+  /queue clear              Discard all queued prompts
   (type while agent runs)   Prompts entered during processing are auto-queued
 
 Shortcuts:

--- a/internal/repl/sdk_credit_banner_test.go
+++ b/internal/repl/sdk_credit_banner_test.go
@@ -1,0 +1,65 @@
+package repl
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("copy stdout: %v", err)
+	}
+	return buf.String()
+}
+
+func TestMaybePrintSDKCreditBannerOncePerDay(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	origCutover := sdkCreditCutover
+	sdkCreditCutover = time.Now().Add(24 * time.Hour)
+	t.Cleanup(func() { sdkCreditCutover = origCutover })
+
+	first := captureStdout(t, maybePrintSDKCreditBanner)
+	if !strings.Contains(first, "starting 2026-06-15") || !strings.Contains(first, "Agent SDK credit") {
+		t.Fatalf("first banner missing expected disclosure: %q", first)
+	}
+
+	second := captureStdout(t, maybePrintSDKCreditBanner)
+	if second != "" {
+		t.Fatalf("second banner should be suppressed for same day, got %q", second)
+	}
+
+	markerPath := filepath.Join(os.Getenv("HOME"), ".qmax-code", "sdk_credit_banner_seen")
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("marker file was not written: %v", err)
+	}
+}
+
+func TestMaybePrintSDKCreditBannerPostCutoverCopy(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	origCutover := sdkCreditCutover
+	sdkCreditCutover = time.Now().Add(-24 * time.Hour)
+	t.Cleanup(func() { sdkCreditCutover = origCutover })
+
+	out := captureStdout(t, maybePrintSDKCreditBanner)
+	if !strings.Contains(out, "This session uses your Claude Agent SDK monthly credit") {
+		t.Fatalf("post-cutover banner missing expected disclosure: %q", out)
+	}
+}

--- a/internal/session/queue.go
+++ b/internal/session/queue.go
@@ -39,3 +39,12 @@ func (q *PromptQueue) Len() int {
 	defer q.mu.Unlock()
 	return len(q.items)
 }
+
+// Clear empties the queue and returns the number of items that were removed.
+func (q *PromptQueue) Clear() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	n := len(q.items)
+	q.items = nil
+	return n
+}

--- a/internal/session/queue_test.go
+++ b/internal/session/queue_test.go
@@ -128,6 +128,29 @@ func TestPromptQueue_ConcurrentPush(t *testing.T) {
 	}
 }
 
+func TestPromptQueue_ClearReturnsCount(t *testing.T) {
+	var q PromptQueue
+	q.Push("a")
+	q.Push("b")
+	q.Push("c")
+
+	n := q.Clear()
+	if n != 3 {
+		t.Errorf("clear returned %d, want 3", n)
+	}
+	if q.Len() != 0 {
+		t.Errorf("len after clear: got %d, want 0", q.Len())
+	}
+}
+
+func TestPromptQueue_ClearEmpty(t *testing.T) {
+	var q PromptQueue
+	n := q.Clear()
+	if n != 0 {
+		t.Errorf("clear on empty queue returned %d, want 0", n)
+	}
+}
+
 func TestPromptQueue_ConcurrentPushPop(t *testing.T) {
 	var q PromptQueue
 	const count = 200

--- a/internal/session/stdin_queue_unix.go
+++ b/internal/session/stdin_queue_unix.go
@@ -24,14 +24,29 @@ import (
 // while OPOST is left enabled so the agent's concurrent stdout output still gets
 // proper newline translation. Returns a stop function that must be called before the
 // next tui.ReadInput to ensure stdin is never shared between two readers.
-func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() {
+//
+// The stop function returns any partial line the user had typed but not yet
+// Enter-terminated when the agent finished. If the agent's response races the
+// user's typing (turn ends before Enter is pressed), the caller can recover the
+// partial text rather than silently dropping it (QUA-577).
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() string {
 	done := make(chan struct{})
+	partialCh := make(chan string, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
+
+	// lineRunes is only mutated inside the goroutine. The stop function
+	// reads its final value via partialCh after wg.Wait, so there is no
+	// concurrent access window.
+	var lineRunes []rune
 
 	go func() {
 		defer wg.Done()
 		defer term.SetUserTyping(false)
+		// Send whatever partial line was buffered when the goroutine exits.
+		// Runs before wg.Done (LIFO), so wg.Wait observes the send. Channel
+		// is buffered (cap 1), so this never blocks even if no one reads.
+		defer func() { partialCh <- string(lineRunes) }()
 
 		fd := int(os.Stdin.Fd())
 
@@ -49,7 +64,6 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 			}
 		}
 
-		var lineRunes []rune
 		var rawBuf []byte
 		// Pre-allocated read buffer — reused every iteration.
 		readBuf := make([]byte, 32)
@@ -163,8 +177,17 @@ func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func
 		}
 	}()
 
-	return func() {
+	return func() string {
 		close(done)
 		wg.Wait()
+		// Channel is buffered and always written in a defer before wg.Done,
+		// so by the time we read, the value is there. Use a non-blocking
+		// receive with a default as belt-and-suspenders.
+		select {
+		case s := <-partialCh:
+			return s
+		default:
+			return ""
+		}
 	}
 }

--- a/internal/session/stdin_queue_windows.go
+++ b/internal/session/stdin_queue_windows.go
@@ -6,6 +6,7 @@ import "github.com/qualitymax/qmax-code/internal/tui"
 
 // StartQueueReader is a no-op on Windows; the prompt queue still works via
 // /queue but concurrent stdin reading while streaming is not supported.
-func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() {
-	return func() {}
+// The returned stop function always reports no partial input.
+func StartQueueReader(pq *PromptQueue, term *tui.Terminal, cancelFn func()) func() string {
+	return func() string { return "" }
 }

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -344,7 +344,7 @@ func (t *Terminal) PrintBanner(version string, ctx *api.SessionContext) {
 
 	switch ctx.Backend {
 	case "cc":
-		fmt.Printf("  %s▸ Backend: Claude Code (CC subscription — no API tokens)%s\n", themeStatusColor, ColorReset)
+		fmt.Printf("  %s▸ Backend: Claude Code (no QM API key; Agent SDK credit for --print)%s\n", themeStatusColor, ColorReset)
 		if ctx.Auth != nil && ctx.Auth.Email != "" {
 			fmt.Printf("  %s▸ QualityMax: %s%s\n", themeStatusColor, ctx.Auth.Email, ColorReset)
 		}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.9"
+var Version = "1.16.10"
 
 const Name = "qmax-code"
 

--- a/main.go
+++ b/main.go
@@ -332,26 +332,46 @@ func main() {
 		cliAgent = ca
 	}
 
-	// One-shot mode
-	if *oneShot != "" {
-		result, err := ag.Run(*oneShot)
+	// One-shot mode and positional-arg mode honour the configured CLI backend.
+	// Prior to the QUA-576 fix these paths always called ag.Run (Anthropic API),
+	// silently ignoring backend=cc and backend=codex — which meant every CI /
+	// scripting / cloud-session invocation bypassed the cc backend and hit the
+	// Anthropic API. Now we route through cliAgent when configured, falling
+	// back to the API agent only when no CLI backend is active.
+	runOneShot := func(prompt string) error {
+		if cliAgent != nil {
+			// CLI backends stream their own output (tool icons, glamour-rendered
+			// text) via the Terminal; FinishMarkdown handles final rendering.
+			// Build a Terminal here since main never created one (repl.Run owns
+			// the interactive Terminal instance).
+			term := tui.NewTerminal()
+			defer term.Close()
+			_, err := cliAgent.Run(prompt, term)
+			return err
+		}
+		// Direct-API path: non-streaming. Print the returned text ourselves.
+		result, err := ag.Run(prompt)
 		if err != nil {
+			return err
+		}
+		fmt.Println(result)
+		return nil
+	}
+
+	if *oneShot != "" {
+		if err := runOneShot(*oneShot); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println(result)
 		return
 	}
 
 	// Also handle positional args as a prompt: qmax-code "test the login flow"
 	if remaining := flag.Args(); len(remaining) > 0 {
-		prompt := strings.Join(remaining, " ")
-		result, err := ag.Run(prompt)
-		if err != nil {
+		if err := runOneShot(strings.Join(remaining, " ")); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Println(result)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 
+	xterm "golang.org/x/term"
+
 	"github.com/qualitymax/qmax-code/internal/agent"
 	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/mcp"
@@ -111,6 +113,18 @@ func main() {
 		return
 	}
 
+	// QUA-580: refuse interactive startup when stdin is not a terminal.
+	// This must happen before any setup, consent, or API-key prompt, because
+	// those paths are interactive too and can block forever when stdin is a
+	// pipe. One-shot prompts (-p or positional args) remain valid headless use.
+	if *oneShot == "" && len(flag.Args()) == 0 && !xterm.IsTerminal(int(os.Stdin.Fd())) {
+		fmt.Fprintln(os.Stderr, "qmax-code: stdin is not a terminal.")
+		fmt.Fprintln(os.Stderr, "  For non-interactive use, pass a prompt:")
+		fmt.Fprintln(os.Stderr, "      qmax-code -p \"<your prompt>\"")
+		fmt.Fprintln(os.Stderr, "      qmax-code \"<your prompt>\"")
+		os.Exit(2)
+	}
+
 	// Load persistent user config
 	appConfig := api.LoadQMaxCodeConfig()
 
@@ -146,6 +160,11 @@ func main() {
 		effectiveModel = "auto"
 	}
 	effectiveModel = resolveModel(effectiveModel)
+	if !isValidModelName(effectiveModel) {
+		fmt.Fprintf(os.Stderr, "Error: --model %q is not recognized.\n", *model)
+		fmt.Fprintf(os.Stderr, "  Valid: %s.\n", api.ValidClaudeModelsHelp())
+		os.Exit(2)
+	}
 
 	// Resolve Anthropic API key: flag > env > keychain
 	anthropicKey := *anthropicAPIKey
@@ -186,8 +205,10 @@ func main() {
 	}
 
 	// CLI backend mode: route all LLM inference through a local CLI subprocess.
-	// Neither an Anthropic API key nor an OpenAI key is required — the user's
-	// subscription (CC or OpenAI/Codex) covers inference.
+	// Neither a QM-held Anthropic API key nor an OpenAI key is required. In cc
+	// mode, qmax-code uses the user's Claude Code login via `claude --print`;
+	// starting 2026-06-15, that traffic draws from the user's monthly Claude
+	// Agent SDK credit before any extra-usage billing.
 	// qmax tools are served to the CLI via the embedded MCP server.
 	var cliAgent agent.CLIAgent
 	cliBackend := appConfig.Backend // "cc" | "codex" | "" (API)
@@ -252,7 +273,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "\nError: Anthropic API key required.")
 		fmt.Fprintln(os.Stderr, "  export ANTHROPIC_API_KEY=sk-ant-...")
 		fmt.Fprintln(os.Stderr, "  Or use a CLI backend (no API key needed):")
-		fmt.Fprintln(os.Stderr, "    qmax-code config set backend cc      # Claude Code subscription")
+		fmt.Fprintln(os.Stderr, "    qmax-code config set backend cc      # Claude Code login / Agent SDK credit")
 		fmt.Fprintln(os.Stderr, "    qmax-code config set backend codex   # OpenAI/Codex subscription")
 		os.Exit(1)
 	}
@@ -390,15 +411,12 @@ func main() {
 
 // resolveModel expands shorthand model names to full model IDs.
 func resolveModel(m string) string {
-	switch strings.ToLower(m) {
-	case "sonnet":
-		return api.ModelSonnet
-	case "opus":
-		return api.ModelOpus
-	case "haiku":
-		return api.ModelHaiku
-	default:
-		return m
-	}
+	return api.ResolveClaudeModel(m)
 }
 
+// isValidModelName reports whether m is a recognized model identifier.
+// QUA-579: pre-fix, any string was forwarded to the API and produced a
+// confusing 401/400. Now we fail fast with a list of valid choices.
+func isValidModelName(m string) bool {
+	return api.IsValidClaudeModelName(m)
+}

--- a/main_oneshot_test.go
+++ b/main_oneshot_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/agent"
+	"github.com/qualitymax/qmax-code/internal/tui"
+)
+
+// fakeCLIAgent is a tiny CLIAgent implementation that records whether its
+// Run method was called. Used to verify the QUA-576 dispatch fix without
+// needing a real claude/codex binary.
+type fakeCLIAgent struct {
+	called  bool
+	prompt  string
+	result  string
+	runErr  error
+}
+
+func (f *fakeCLIAgent) Run(userMsg string, _ *tui.Terminal) (string, error) {
+	f.called = true
+	f.prompt = userMsg
+	return f.result, f.runErr
+}
+func (f *fakeCLIAgent) Cancel()                {}
+func (f *fakeCLIAgent) Cleanup()               {}
+func (f *fakeCLIAgent) SetOutputVerbose(bool)  {}
+
+// dispatchForTest mirrors the dispatch logic in main.go's `runOneShot`
+// closure. Keeping it in sync with that closure is the regression contract
+// of TestOneShotDispatch_* below.
+//
+// The real closure (main.go) also creates a tui.Terminal when cliAgent is
+// non-nil; for unit testing we pass nil since fakeCLIAgent doesn't use it.
+func dispatchForTest(prompt string, cliAgent agent.CLIAgent, apiCallback func(string) (string, error)) error {
+	if cliAgent != nil {
+		_, err := cliAgent.Run(prompt, nil)
+		return err
+	}
+	_, err := apiCallback(prompt)
+	return err
+}
+
+// TestOneShotDispatch_PrefersCLIAgent is the regression test for QUA-576.
+// Before the fix, -p and positional-arg modes called ag.Run directly even
+// when backend=cc was configured. This test asserts that when a CLIAgent
+// is present, it is the agent that handles the one-shot prompt.
+func TestOneShotDispatch_PrefersCLIAgent(t *testing.T) {
+	fake := &fakeCLIAgent{result: "cli-result"}
+	apiCalled := false
+	apiCallback := func(string) (string, error) {
+		apiCalled = true
+		return "api-result", nil
+	}
+
+	if err := dispatchForTest("hello", fake, apiCallback); err != nil {
+		t.Fatalf("dispatch returned err: %v", err)
+	}
+	if !fake.called {
+		t.Error("expected fakeCLIAgent.Run to be called, but it was not")
+	}
+	if apiCalled {
+		t.Error("expected API callback NOT to be called when cliAgent is set, but it was")
+	}
+	if fake.prompt != "hello" {
+		t.Errorf("prompt passed to CLI agent: got %q, want %q", fake.prompt, "hello")
+	}
+}
+
+// TestOneShotDispatch_FallsBackToAPI confirms the no-CLI-backend fallback.
+func TestOneShotDispatch_FallsBackToAPI(t *testing.T) {
+	apiCalled := false
+	apiCallback := func(string) (string, error) {
+		apiCalled = true
+		return "api-result", nil
+	}
+
+	if err := dispatchForTest("hello", nil, apiCallback); err != nil {
+		t.Fatalf("dispatch returned err: %v", err)
+	}
+	if !apiCalled {
+		t.Error("expected API callback to be called when cliAgent is nil, but it was not")
+	}
+}
+
+// TestOneShotDispatch_PropagatesCLIError ensures errors from the CLI agent
+// surface to the caller (which exits non-zero in main.go).
+func TestOneShotDispatch_PropagatesCLIError(t *testing.T) {
+	want := errors.New("cc subprocess failed")
+	fake := &fakeCLIAgent{runErr: want}
+	apiCallback := func(string) (string, error) {
+		t.Fatal("API callback must not be called when cliAgent is present")
+		return "", nil
+	}
+
+	err := dispatchForTest("hello", fake, apiCallback)
+	if err == nil || err.Error() != want.Error() {
+		t.Errorf("dispatch error: got %v, want %v", err, want)
+	}
+}

--- a/main_validation_test.go
+++ b/main_validation_test.go
@@ -1,0 +1,35 @@
+package main
+
+import "testing"
+
+// TestIsValidModelName is the regression test for QUA-579: pre-fix, the
+// -model flag accepted any string and forwarded it to the API, where it
+// produced a confusing 400/401 instead of a clear local error.
+func TestIsValidModelName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// Shorthands resolved by resolveModel.
+		{"auto", true},
+		{"sonnet", true},
+		{"opus", true},
+		{"haiku", true},
+		{"AUTO", true}, // case-insensitive
+		// Real model IDs from api.Model* constants.
+		{"claude-opus-4-7", true},
+		{"claude-sonnet-4-6", true},
+		{"claude-haiku-4-5-20251001", true},
+		// Rejected.
+		{"nonsense", false},
+		{"claude-future-model-9-0", false},
+		{"gpt-4", false},
+		{"", false},
+		{"opus4", false},
+	}
+	for _, c := range cases {
+		if got := isValidModelName(c.in); got != c.want {
+			t.Errorf("isValidModelName(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- includes #101 / QUA-577 queued input recovery
- includes #102 / QUA-576 one-shot routing through configured CLI backends
- fixes QUA-578 / QUA-579 / QUA-580 CLI quality issues
- bumps qmax-code to v1.16.10

## Included fixes
- route one-shot prompts through configured CLI backends
- recover queued input typed while the agent is running
- disclose Claude Agent SDK credit cutover for cc backend users
- validate model names locally
- fail fast for non-TTY interactive startup

## Tests
- go test ./...