### PR TITLE
fix(api): retry on 429 rate-limit with exponential backoff (QUA-645)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -558,21 +558,22 @@ func (a *Agent) callStreamingAPI(term *tui.Terminal, model string) ([]api.Conten
 		cancel()
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, "POST", api.AnthropicMessagesURL, bytes.NewReader(data))
-	if err != nil {
-		return nil, "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", a.Cfg.AnthropicKey)
-	req.Header.Set("anthropic-version", api.AnthropicVersion)
-
 	a.Logger.Info("api", "request", map[string]interface{}{"model": model, "messages": len(a.History)})
 
 	if a.Cfg.Verbose {
 		fmt.Printf("[API] Streaming request: %d bytes, %d messages\n", len(data), len(a.History))
 	}
 
-	resp, err := a.client.Do(req)
+	resp, err := doWithRetry(ctx, a.client, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", api.AnthropicMessagesURL, bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", a.Cfg.AnthropicKey)
+		req.Header.Set("anthropic-version", api.AnthropicVersion)
+		return req, nil
+	}, term)
 	if err != nil {
 		if ctx.Err() != nil {
 			return nil, "interrupted", nil
@@ -763,19 +764,20 @@ func (a *Agent) callAPI() (*api.APIResponse, error) {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", api.AnthropicMessagesURL, bytes.NewReader(data))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", a.Cfg.AnthropicKey)
-	req.Header.Set("anthropic-version", api.AnthropicVersion)
-
 	if a.Cfg.Verbose {
 		fmt.Printf("[API] Request: %d bytes, %d messages\n", len(data), len(a.History))
 	}
 
-	resp, err := a.client.Do(req)
+	resp, err := doWithRetry(context.Background(), a.client, func() (*http.Request, error) {
+		req, err := http.NewRequest("POST", api.AnthropicMessagesURL, bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", a.Cfg.AnthropicKey)
+		req.Header.Set("anthropic-version", api.AnthropicVersion)
+		return req, nil
+	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("API request failed: %w", err)
 	}

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -1,0 +1,61 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/qualitymax/qmax-code/internal/tui"
+)
+
+const maxAPIRetries = 3
+
+// doWithRetry executes newReq() and retries up to maxAPIRetries times on HTTP 429
+// with exponential backoff starting at 1 s (doubling each attempt). Parses the
+// Retry-After response header when present to override the computed delay.
+// A status line is printed via term (or to stdout when term is nil) while waiting.
+// The context is respected during sleep so a cancellation (Ctrl+C) exits immediately.
+func doWithRetry(ctx context.Context, client *http.Client, newReq func() (*http.Request, error), term *tui.Terminal) (*http.Response, error) {
+	wait := time.Second
+
+	for attempt := 0; ; attempt++ {
+		req, err := newReq()
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests || attempt >= maxAPIRetries {
+			return resp, nil
+		}
+
+		// 429 — use Retry-After header when provided, otherwise exponential backoff.
+		delay := wait
+		if ra := resp.Header.Get("Retry-After"); ra != "" {
+			if secs, parseErr := strconv.Atoi(ra); parseErr == nil && secs > 0 {
+				delay = time.Duration(secs) * time.Second
+			}
+		}
+		_ = resp.Body.Close()
+
+		msg := fmt.Sprintf("rate limited — retrying in %.0fs (%d/%d)…", delay.Seconds(), attempt+1, maxAPIRetries)
+		if term != nil {
+			term.PrintSystem(msg)
+		} else {
+			fmt.Printf("  ⚠ %s\n", msg)
+		}
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		wait *= 2
+	}
+}


### PR DESCRIPTION
## Summary

Free-tier Anthropic keys hit per-minute token limits on the very first call because qmax-code's system prompt + tool catalog is large. The 429 was surfaced raw with no retry — blocking any trial user on a free key.

- Adds `doWithRetry()` in `internal/agent/retry.go`
- Retries up to 3 times on HTTP 429: 1 s → 2 s → 4 s backoff
- Parses `Retry-After` header to use the server-suggested delay when present
- Respects context cancellation during sleep (Ctrl+C exits immediately, doesn't hang for 4 s)
- Prints `  ● rate limited — retrying in 2s (1/3)…` via the terminal status line
- Wired into both `callStreamingAPI()` and `callAPI()`; request body is rebuilt from the already-marshaled `[]byte` slice each attempt (no double-read issue)

Closes QUA-645

## Test plan

- [ ] With a free-tier key, trigger a large-context call — should see the retry status line and succeed on retry rather than dying immediately
- [ ] Verify Ctrl+C during a retry sleep exits cleanly rather than waiting out the delay
- [ ] Verify a non-429 error (e.g. 401, 500) is still surfaced immediately without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)