### PR TITLE
chore: bump version to 1.16.12

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.11"
+var Version = "1.16.12"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Bumps version to 1.16.12 following #106 (429 retry with exponential backoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)