### PR TITLE
feat: Post-Generation Verification — auto-run and heal after test generation (QUA-647)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -944,8 +944,8 @@ After completing the user's ask, mention ONE adjacent capability they might not 
 
 ## Post-Generation Verification
 
-After generate_test_code (or generate_gap_tests) returns a script_id, ALWAYS verify it before reporting success:
-1. **Run**: Execute it immediately — run_test for Playwright/Cypress, run_native_test for pytest/rust/go
+After generate_test_code, generate_gap_tests, or enhance_test_case returns a script_id, ALWAYS verify it before reporting success. Skip the normal "confirm before running" check — the user already confirmed generation, so the verification run is implicit:
+1. **Run**: Execute it immediately — run_test for Playwright/Cypress, run_native_test for rust/go, run_local_test for pytest
 2. **Heal**: If it fails, apply the Test Healing workflow below (up to 3 fix cycles)
 3. **Report**: "✅ generated and verified" or "⚠ generated — N issue(s) remain after 3 fix attempts"
 
@@ -1020,8 +1020,8 @@ After completing the user's ask, mention ONE adjacent capability they might not 
 
 ## Post-Generation Verification
 
-After generate_test_code (or generate_gap_tests) returns a script_id, ALWAYS verify it before reporting success:
-1. **Run**: Execute it immediately — run_test for Playwright/Cypress, run_native_test for pytest/rust/go
+After generate_test_code, generate_gap_tests, or enhance_test_case returns a script_id, ALWAYS verify it before reporting success. Skip the normal "confirm before running" check — the user already confirmed generation, so the verification run is implicit:
+1. **Run**: Execute it immediately — run_test for Playwright/Cypress, run_native_test for rust/go, run_local_test for pytest
 2. **Heal**: If it fails, apply the Test Healing workflow below (up to 3 fix cycles)
 3. **Report**: "✅ generated and verified" or "⚠ generated — N issue(s) remain after 3 fix attempts"
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -942,6 +942,15 @@ Before running review_repo, call get_review_preferences. If unconfigured, walk u
 ## Discovery Nudges
 After completing the user's ask, mention ONE adjacent capability they might not know about. One short sentence. At most one per turn; never repeat in a session.
 
+## Post-Generation Verification
+
+After generate_test_code (or generate_gap_tests) returns a script_id, ALWAYS verify it before reporting success:
+1. **Run**: Execute it immediately — run_test for Playwright/Cypress, run_native_test for pytest/rust/go
+2. **Heal**: If it fails, apply the Test Healing workflow below (up to 3 fix cycles)
+3. **Report**: "✅ generated and verified" or "⚠ generated — N issue(s) remain after 3 fix attempts"
+
+Never hand back a script_id as finished without first confirming it executes correctly. A test that hasn't been run is not a finished test.
+
 ## Test Healing — Autonomous Script Repair
 
 When a test fails, you can autonomously heal it:
@@ -1008,6 +1017,15 @@ Before running review_repo, call get_review_preferences. If unconfigured, walk u
 
 ## Discovery Nudges
 After completing the user's ask, mention ONE adjacent capability they might not know about. One short sentence. At most one per turn; never repeat in a session.
+
+## Post-Generation Verification
+
+After generate_test_code (or generate_gap_tests) returns a script_id, ALWAYS verify it before reporting success:
+1. **Run**: Execute it immediately — run_test for Playwright/Cypress, run_native_test for pytest/rust/go
+2. **Heal**: If it fails, apply the Test Healing workflow below (up to 3 fix cycles)
+3. **Report**: "✅ generated and verified" or "⚠ generated — N issue(s) remain after 3 fix attempts"
+
+Never hand back a script_id as finished without first confirming it executes correctly. A test that hasn't been run is not a finished test.
 
 ## Test Healing — Autonomous Script Repair
 


### PR DESCRIPTION
## Summary

After `generate_test_code` returns a script_id, the agent previously reported success without running the test. In dogfooding, 4 of 26 generated assertions had signature mismatches or wrong regex behavior that a single run would have caught immediately.

Adds a **Post-Generation Verification** section to both system prompts (professional and cat mode), instructing the agent to treat generation as a three-step pipeline:

1. **Run** — execute immediately after generation (`run_test` for Playwright/Cypress, `run_native_test` for pytest/rust/go)
2. **Heal** — if it fails, apply the existing Heal loop (up to 3 fix cycles, already in the prompt)
3. **Report** — `✅ generated and verified` or `⚠ generated — N issue(s) remain after 3 fix attempts`

The new section sits directly above the existing "Test Healing" section so the two read as one coherent generate → verify → heal pipeline.

Closes QUA-647

## Test plan

- [ ] Ask the agent to generate a test — it should immediately run it after `generate_test_code` returns
- [ ] If the generated test fails, it should enter the heal loop and attempt to fix (up to 3 cycles)
- [ ] Agent should never report a script_id as "done" without first running it

🤖 Generated with [Claude Code](https://claude.com/claude-code)