### PR TITLE
feat(agent): native update_plan planning tool (QUA-764)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -833,6 +833,23 @@ func (a *Agent) executeToolCallsWithUI(toolCalls []api.ContentBlock, term *tui.T
 	for _, block := range toolCalls {
 		a.Logger.Info("tool", block.Name, map[string]interface{}{"cost": ToolCost(block.Name)})
 		output := ExecuteTool(block.Name, block.Input, a.Cfg.Context, ctx)
+
+		// update_plan renders a dedicated checklist from its input rather than
+		// the generic tool-result line (which would just echo {total,done}).
+		if block.Name == "update_plan" {
+			if steps, err := parsePlanSteps(block.Input); err == nil {
+				term.PrintPlan(toTUIPlanSteps(steps))
+			} else {
+				term.PrintToolResult(block.Name, output) // surface the validation error
+			}
+			results = append(results, api.ContentBlock{
+				Type:      "tool_result",
+				ToolUseID: block.ID,
+				Content:   output,
+			})
+			continue
+		}
+
 		summarized := SummarizeToolResult(block.Name, output)
 		term.PrintToolResult(block.Name, summarized)
 
@@ -1066,6 +1083,12 @@ Always state your confidence: "Confidence: HIGH — the button selector changed 
 - If you can't see the page (no screenshot analysis), tell the user you're blind and suggest they check the screenshot URL.
 `
 	}
+
+	// Planning (shared by both personas). update_plan is native-agent only.
+	prompt += `
+## Planning
+For any multi-step task (e.g. generate→run→heal, gap analysis across cases, CI/CD setup), call update_plan FIRST to lay out your steps, then update it as you go — mark a step "in_progress" when you start it and "done" when you finish, always passing the COMPLETE ordered list. Skip it for single-step questions; don't narrate the plan in prose when the tool already shows it.
+`
 
 	// Dashboard URLs
 	cloudURL := a.Cfg.Context.QMaxCfg.CloudURL

--- a/internal/agent/plan.go
+++ b/internal/agent/plan.go
@@ -43,15 +43,27 @@ func parsePlanSteps(rawInput interface{}) ([]PlanStep, error) {
 		if !ok {
 			return nil, fmt.Errorf("step %d must be an object", i+1)
 		}
-		title := strings.TrimSpace(fmt.Sprintf("%v", m["title"]))
-		if m["title"] == nil || title == "" {
+		// Require a real string (nil/number/bool/object all fail) rather than
+		// stringifying whatever the model sent — a non-string title is a schema
+		// violation, not a label to coerce into "42" or "map[...]".
+		title, ok := m["title"].(string)
+		if !ok {
+			return nil, fmt.Errorf("step %d: title is required and must be a string", i+1)
+		}
+		if title = strings.TrimSpace(title); title == "" {
 			return nil, fmt.Errorf("step %d: title is required", i+1)
 		}
 		// Default an omitted/empty status to "pending" — a model often sends new
-		// steps without one. Any other non-empty value is a real error.
-		status := strings.TrimSpace(fmt.Sprintf("%v", m["status"]))
-		if m["status"] == nil || status == "" {
-			status = "pending"
+		// steps without one. A non-string or unknown value is a real error.
+		status := "pending"
+		if raw, present := m["status"]; present && raw != nil {
+			s, ok := raw.(string)
+			if !ok {
+				return nil, fmt.Errorf("step %d: status must be a string", i+1)
+			}
+			if trimmed := strings.TrimSpace(s); trimmed != "" {
+				status = trimmed
+			}
 		}
 		if !validPlanStatus[status] {
 			return nil, fmt.Errorf("step %d: invalid status %q (want pending|in_progress|done)", i+1, status)

--- a/internal/agent/plan.go
+++ b/internal/agent/plan.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/qualitymax/qmax-code/internal/tui"
+)
+
+// PlanStep is a single entry in the agent's task plan, surfaced via update_plan.
+type PlanStep struct {
+	Title  string
+	Status string // pending | in_progress | done
+}
+
+var validPlanStatus = map[string]bool{"pending": true, "in_progress": true, "done": true}
+
+// maxPlanSteps mirrors the maxItems cap in the update_plan input schema. Enforced
+// here too because a model can ignore the schema and the API doesn't reject it.
+const maxPlanSteps = 20
+
+// parsePlanSteps extracts and validates the steps array from update_plan input.
+func parsePlanSteps(rawInput interface{}) ([]PlanStep, error) {
+	input := parseInput(rawInput)
+	raw, ok := input["steps"]
+	if !ok || raw == nil {
+		return nil, fmt.Errorf("steps is required")
+	}
+	list, ok := raw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("steps must be an array")
+	}
+	if len(list) == 0 {
+		return nil, fmt.Errorf("steps must contain at least one step")
+	}
+	if len(list) > maxPlanSteps {
+		return nil, fmt.Errorf("too many steps (%d); max %d", len(list), maxPlanSteps)
+	}
+	steps := make([]PlanStep, 0, len(list))
+	for i, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("step %d must be an object", i+1)
+		}
+		title := strings.TrimSpace(fmt.Sprintf("%v", m["title"]))
+		if m["title"] == nil || title == "" {
+			return nil, fmt.Errorf("step %d: title is required", i+1)
+		}
+		// Default an omitted/empty status to "pending" — a model often sends new
+		// steps without one. Any other non-empty value is a real error.
+		status := strings.TrimSpace(fmt.Sprintf("%v", m["status"]))
+		if m["status"] == nil || status == "" {
+			status = "pending"
+		}
+		if !validPlanStatus[status] {
+			return nil, fmt.Errorf("step %d: invalid status %q (want pending|in_progress|done)", i+1, status)
+		}
+		steps = append(steps, PlanStep{Title: title, Status: status})
+	}
+	return steps, nil
+}
+
+// executeUpdatePlan validates the plan and returns a compact JSON summary for the
+// model. The human-facing checklist is rendered separately by the UI layer, so
+// the model-facing result stays small (it can re-derive the plan from its own
+// prior tool call).
+func executeUpdatePlan(rawInput interface{}) string {
+	steps, err := parsePlanSteps(rawInput)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	done := 0
+	for _, s := range steps {
+		if s.Status == "done" {
+			done++
+		}
+	}
+	out, _ := json.Marshal(map[string]interface{}{
+		"ok":    true,
+		"total": len(steps),
+		"done":  done,
+	})
+	return string(out)
+}
+
+// toTUIPlanSteps converts agent plan steps into the tui package's render shape.
+// (tui can't import agent — agent imports tui — so the types stay separate.)
+func toTUIPlanSteps(steps []PlanStep) []tui.PlanStep {
+	out := make([]tui.PlanStep, len(steps))
+	for i, s := range steps {
+		out[i] = tui.PlanStep{Title: s.Title, Status: s.Status}
+	}
+	return out
+}

--- a/internal/agent/plan_test.go
+++ b/internal/agent/plan_test.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
+)
+
+func TestParsePlanSteps_Valid(t *testing.T) {
+	in := map[string]interface{}{
+		"steps": []interface{}{
+			map[string]interface{}{"title": "Generate test", "status": "done"},
+			map[string]interface{}{"title": "Run it", "status": "in_progress"},
+			map[string]interface{}{"title": "Heal failures", "status": "pending"},
+		},
+	}
+	steps, err := parsePlanSteps(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(steps) != 3 {
+		t.Fatalf("got %d steps, want 3", len(steps))
+	}
+	if steps[1].Title != "Run it" || steps[1].Status != "in_progress" {
+		t.Errorf("step[1] = %+v, want {Run it in_progress}", steps[1])
+	}
+}
+
+func TestParsePlanSteps_DefaultsStatusToPending(t *testing.T) {
+	in := map[string]interface{}{
+		"steps": []interface{}{
+			map[string]interface{}{"title": "No status field"},
+			map[string]interface{}{"title": "Empty status", "status": ""},
+		},
+	}
+	steps, err := parsePlanSteps(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, s := range steps {
+		if s.Status != "pending" {
+			t.Errorf("step[%d].Status = %q, want pending", i, s.Status)
+		}
+	}
+}
+
+func TestParsePlanSteps_Errors(t *testing.T) {
+	tooMany := make([]interface{}, maxPlanSteps+1)
+	for i := range tooMany {
+		tooMany[i] = map[string]interface{}{"title": "x", "status": "pending"}
+	}
+	cases := []struct {
+		name string
+		in   map[string]interface{}
+		want string
+	}{
+		{"missing steps", map[string]interface{}{}, "required"},
+		{"steps not array", map[string]interface{}{"steps": "nope"}, "must be an array"},
+		{"empty steps", map[string]interface{}{"steps": []interface{}{}}, "at least one"},
+		{"too many", map[string]interface{}{"steps": tooMany}, "too many"},
+		{"step not object", map[string]interface{}{"steps": []interface{}{"x"}}, "must be an object"},
+		{"missing title", map[string]interface{}{"steps": []interface{}{map[string]interface{}{"status": "pending"}}}, "title is required"},
+		{"bad status", map[string]interface{}{"steps": []interface{}{map[string]interface{}{"title": "t", "status": "doing"}}}, "invalid status"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parsePlanSteps(tc.in)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteUpdatePlan_Summary(t *testing.T) {
+	in := map[string]interface{}{
+		"steps": []interface{}{
+			map[string]interface{}{"title": "a", "status": "done"},
+			map[string]interface{}{"title": "b", "status": "done"},
+			map[string]interface{}{"title": "c", "status": "pending"},
+		},
+	}
+	out := executeUpdatePlan(in)
+	var got struct {
+		OK    bool `json:"ok"`
+		Total int  `json:"total"`
+		Done  int  `json:"done"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%s)", err, out)
+	}
+	if !got.OK || got.Total != 3 || got.Done != 2 {
+		t.Errorf("got %+v, want {ok:true total:3 done:2}", got)
+	}
+}
+
+func TestExecuteUpdatePlan_InvalidReturnsError(t *testing.T) {
+	out := executeUpdatePlan(map[string]interface{}{})
+	if !strings.Contains(out, `"error"`) {
+		t.Errorf("expected JSON error, got %s", out)
+	}
+}
+
+func TestUpdatePlan_ExposedToNativeAgentButNotMCP(t *testing.T) {
+	if !hasTool(BuildToolDefs(), "update_plan") {
+		t.Error("update_plan missing from BuildToolDefs (native agent)")
+	}
+	if hasTool(BuildMCPToolDefs(), "update_plan") {
+		t.Error("update_plan must NOT be exposed via BuildMCPToolDefs (collides with Claude Code's TodoWrite)")
+	}
+}
+
+func hasTool(defs []api.ToolDef, name string) bool {
+	for _, d := range defs {
+		if d.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/plan_test.go
+++ b/internal/agent/plan_test.go
@@ -62,6 +62,8 @@ func TestParsePlanSteps_Errors(t *testing.T) {
 		{"too many", map[string]interface{}{"steps": tooMany}, "too many"},
 		{"step not object", map[string]interface{}{"steps": []interface{}{"x"}}, "must be an object"},
 		{"missing title", map[string]interface{}{"steps": []interface{}{map[string]interface{}{"status": "pending"}}}, "title is required"},
+		{"non-string title", map[string]interface{}{"steps": []interface{}{map[string]interface{}{"title": 42, "status": "pending"}}}, "must be a string"},
+		{"non-string status", map[string]interface{}{"steps": []interface{}{map[string]interface{}{"title": "t", "status": true}}}, "status must be a string"},
 		{"bad status", map[string]interface{}{"steps": []interface{}{map[string]interface{}{"title": "t", "status": "doing"}}}, "invalid status"},
 	}
 	for _, tc := range cases {

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -152,11 +152,65 @@ func BuildToolDefs() []api.ToolDef {
 	return out
 }
 
+// nativeOnlyToolNames lists tools exposed only to the native Anthropic agent
+// loop, never via the MCP server. update_plan is a UX/observability surface for
+// the native REPL; Claude Code (the MCP server's consumer) already has its own
+// TodoWrite, so exposing ours would be redundant and could collide.
+var nativeOnlyToolNames = map[string]bool{
+	"update_plan": true,
+}
+
+// BuildMCPToolDefs returns the tool definitions exposed via the MCP server —
+// the public set minus native-only tools (see nativeOnlyToolNames).
+func BuildMCPToolDefs() []api.ToolDef {
+	defs := BuildToolDefs()
+	out := make([]api.ToolDef, 0, len(defs))
+	for _, d := range defs {
+		if !nativeOnlyToolNames[d.Name] {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
 // buildAllToolDefs returns every tool definition, including experimental ones.
 // Used internally; public callers go through BuildToolDefs which applies the
 // QMAX_EXPERIMENTAL gate.
 func buildAllToolDefs() []api.ToolDef {
 	return []api.ToolDef{
+		// --- Planning ---
+		{
+			Name:        "update_plan",
+			Description: "Record or update your step-by-step plan for the current task. Call this FIRST — before running commands, generating code, or editing files — to lay out how you'll approach the work. Call it again whenever the plan changes: mark a step \"in_progress\" when you start it and \"done\" when you finish, adding or revising steps as you learn more. Always pass the COMPLETE ordered list of steps; it fully replaces the previous plan. Use it for multi-step work (generate→run→heal, gap analysis across cases, CI/CD setup); skip it for single-step questions.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"steps": map[string]interface{}{
+						"type":        "array",
+						"description": "The full ordered list of plan steps (1–20). Fully replaces any previous plan.",
+						"minItems":    1,
+						"maxItems":    20,
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"title": map[string]interface{}{
+									"type":        "string",
+									"description": "Short, concrete description of the step",
+								},
+								"status": map[string]interface{}{
+									"type":        "string",
+									"enum":        []string{"pending", "in_progress", "done"},
+									"description": "Current status of this step",
+								},
+							},
+							"required": []string{"title", "status"},
+						},
+					},
+				},
+				"required": []string{"steps"},
+			},
+		},
+
 		// --- Project operations ---
 		{
 			Name:        "list_projects",
@@ -656,6 +710,14 @@ func buildAllToolDefs() []api.ToolDef {
 // Uses the API client for QualityMax operations (no qmax CLI needed).
 // Falls back to qmax CLI if API client is not available.
 func ExecuteTool(name string, rawInput interface{}, sctx *api.SessionContext, ctx context.Context) string {
+	// update_plan is a local, side-effect-free planning surface — handle it
+	// before any API/CLI dispatch. The rich terminal checklist is rendered by
+	// the UI layer (executeToolCallsWithUI); here we just validate the steps and
+	// return a compact summary for the model.
+	if name == "update_plan" {
+		return executeUpdatePlan(rawInput)
+	}
+
 	// Use API client if available (standalone mode)
 	if sctx.API != nil {
 		result := executeToolViaAPI(name, rawInput, sctx, ctx)
@@ -1563,7 +1625,7 @@ func ToolCost(name string) string {
 	case "list_projects", "list_test_cases", "list_scripts", "check_test_status",
 		"crawl_status", "crawl_results", "list_crawl_jobs", "list_repos",
 		"repo_coverage", "repo_quality", "read_file", "run_command", "write_file",
-		"get_script":
+		"get_script", "update_plan":
 		return "free" // read-only or local, no cost
 	case "generate_test_code":
 		return "low" // AI generation, small cost

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -169,7 +169,7 @@ func errResp(id interface{}, code int, msg string) response {
 // buildToolList converts qmax ToolDefs to MCP format.
 // The only structural difference is camelCase inputSchema vs Anthropic's input_schema.
 func buildToolList() []toolDef {
-	defs := agent.BuildToolDefs()
+	defs := agent.BuildMCPToolDefs()
 	out := make([]toolDef, len(defs))
 	for i, d := range defs {
 		out[i] = toolDef(d)

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -84,6 +84,7 @@ var toolIcons = map[string]string{
 	"get_script":         "📖",
 	"update_script":      "🔧",
 	"rollback_script":    "⏪",
+	"update_plan":        "📋",
 }
 
 // spinnerFrames is the braille animation cycle.
@@ -539,6 +540,57 @@ func (t *Terminal) PrintToolResult(name string, output string) {
 		}
 	} else {
 		fmt.Printf("  %s\n", styleSuccess.Render(fmt.Sprintf("✓ %d lines of output", lineCount)))
+	}
+}
+
+// PlanStep is one entry of an agent task plan, in the shape PrintPlan renders.
+// Kept here (not imported from agent) because agent imports tui, not vice versa.
+type PlanStep struct {
+	Title  string
+	Status string // pending | in_progress | done
+}
+
+// PrintPlan renders the agent's task plan (from update_plan) as a checklist with
+// a done/total progress line. Marks: ✓ done, ▸ in_progress, ◦ pending.
+// Restarts the thinking spinner on exit, mirroring PrintToolResult.
+func (t *Terminal) PrintPlan(steps []PlanStep) {
+	t.StopThinking() // erase spinner before plan display
+	if t.streaming {
+		t.streaming = false
+		fmt.Println()
+	}
+	defer t.StartThinking()
+
+	done := 0
+	for _, s := range steps {
+		if s.Status == "done" {
+			done++
+		}
+	}
+
+	icon := toolIcons["update_plan"]
+	if icon == "" {
+		icon = "📋"
+	}
+	fmt.Printf("\n  %s %s %s\n",
+		icon,
+		styleTool.Render("plan"),
+		styleDim.Render(fmt.Sprintf("(%d/%d done)", done, len(steps))))
+
+	for _, s := range steps {
+		var mark, title string
+		switch s.Status {
+		case "done":
+			mark = styleSuccess.Render("✓")
+			title = styleDim.Render(s.Title)
+		case "in_progress":
+			mark = styleSystem.Render("▸")
+			title = styleTool.Render(s.Title)
+		default:
+			mark = styleDim.Render("◦")
+			title = s.Title
+		}
+		fmt.Printf("    %s %s\n", mark, title)
 	}
 }
 


### PR DESCRIPTION
## What

Adds a native `update_plan` planning tool to the Anthropic agent loop — qmax-code previously had **no** plan/todo tracking. Multi-step flows (Post-Generation Verification / Heal pass, `generate_gap_tests`, `setup_cicd`, batch runs) now surface a visible, status-tracked checklist in the terminal.

Borrowed from the standalone e2b coding agent's plan tool (see epic QUA-763). Same minimal design: **full-replace semantics**, **3-state status enum** (`pending`/`in_progress`/`done`), ~20-step cap, workflow guidance carried in the tool description.

## How

- **Tool def** (`internal/agent/tools.go`) — nested `steps[]` schema with enum + maxItems.
- **Execution** (`internal/agent/plan.go`) — side-effect-free; validates steps and returns a compact `{ok,total,done}` JSON to the model. The rich checklist (`✓`/`▸`/`◦` + `done/total` progress) is rendered by the TUI from the tool *input* (`Terminal.PrintPlan`), so the model-facing result stays small.
- **Native-agent only** — excluded from the MCP server export via new `BuildMCPToolDefs()`, so it doesn't collide with Claude Code's own TodoWrite (`internal/mcp/server.go`).
- **System prompt** — "plan first / update as you go" instruction added to the shared suffix (both professional + cat personas).

## Scope / non-goals

UX/observability only — no behavior change to existing tools. CC/Codex backends are untouched (they don't use the native tool set or system prompt).

## Tests

`internal/agent/plan_test.go` — parser (valid, status defaulting, all error cases), executor summary, and an assertion that `update_plan` is in `BuildToolDefs` but **not** in `BuildMCPToolDefs`. Full suite + `go vet` green.

Closes QUA-764. Part of epic QUA-763.

🤖 Generated with [Claude Code](https://claude.com/claude-code)