### PR TITLE
feat(fastapply): Fast Apply safety-guard harness (QUA-765)

### DIFF
--- a/internal/fastapply/fastapply.go
+++ b/internal/fastapply/fastapply.go
@@ -1,0 +1,221 @@
+// Package fastapply implements the safety guards around "Fast Apply" — applying
+// a targeted edit to a file by having a small/cheap model regenerate the ENTIRE
+// file in one shot (à la Cursor's apply model). Regenerating the whole file is
+// fast and forgiving of fuzzy edit instructions, but it has one dangerous
+// failure mode: the model can silently return a truncated or partially-dropped
+// file, and writing that result corrupts the file while reporting success.
+//
+// This package contains the defensive harness that makes that failure mode
+// impossible to commit silently. Every guard converts a suspect result into a
+// typed error instead of a corrupted write. It is intentionally backend-
+// agnostic: the actual model call is injected as a Generator, so Apply/CheckSize
+// are pure and fully unit-testable without a live model.
+//
+// Ported from the e2b coding agent's lib/fastApply.ts (QUA-765).
+package fastapply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Tunables. These mirror the e2b implementation and assume the underlying model
+// call is made with an output budget of ~MaxOutputTokens.
+const (
+	// MaxOutputTokens is the output-token budget Fast Apply assumes for the
+	// model call. The whole file is regenerated within this budget.
+	MaxOutputTokens = 12_000
+
+	// charsPerToken is a rough chars-per-token estimate for pre-flight sizing.
+	charsPerToken = 4
+
+	// MaxFileChars caps the original file size. Fast Apply regenerates the ENTIRE
+	// file in a single response, so the file must fit the OUTPUT budget — not just
+	// the input context window. Anything larger is guaranteed to truncate, so it is
+	// rejected before a model call is spent. ~20% headroom is left for lines the
+	// edit adds: 12_000 * 4 * 0.8 = 38_400.
+	MaxFileChars = MaxOutputTokens * charsPerToken * 8 / 10
+
+	// MaxInputChars is a secondary guard on total prompt size (file + edit) to
+	// avoid input-context errors.
+	MaxInputChars = 320_000
+
+	// minRetainedLineRatio / shrinkGuardMinLines drive the drastic-shrink guard.
+	// A single intended edit on a large file virtually never removes more than
+	// half of it; if the regenerated file shrinks past this ratio it is treated
+	// as a botched rewrite. The line floor is deliberately high: on small files a
+	// >50% drop is a normal edit, so the guard only fires where it is genuinely
+	// anomalous.
+	minRetainedLineRatio = 0.5
+	shrinkGuardMinLines  = 40
+)
+
+// Sentinel errors, one per refusal case. Callers can branch with errors.Is and
+// the wrapped messages carry the specifics. A non-nil error from this package
+// ALWAYS means "did not write" — never a silently corrupted file.
+var (
+	ErrFileTooLarge    = errors.New("file too large for fast apply")
+	ErrEditTooLarge    = errors.New("edit too large for fast apply")
+	ErrTruncated       = errors.New("fast apply output was truncated at the token limit")
+	ErrAbnormalFinish  = errors.New("fast apply did not complete cleanly")
+	ErrEmptyOutput     = errors.New("fast apply model returned an empty response")
+	ErrDrasticShrink   = errors.New("fast apply produced a suspiciously short result")
+	remedyUseWriteFile = "use an exact string-replace edit or write the complete updated file instead"
+)
+
+// Finish describes how the model's generation terminated. Backends map their own
+// stop reasons onto this (see FinishFromAnthropic).
+type Finish int
+
+const (
+	// FinishOK — the model decided it was done (a clean stop). Only this value
+	// allows the regenerated file to be written.
+	FinishOK Finish = iota
+	// FinishTruncated — generation hit the output-token cap; the file is cut off.
+	FinishTruncated
+	// FinishOther — any other abnormal termination (content filter, error, …);
+	// the output may be partial.
+	FinishOther
+)
+
+// FinishFromAnthropic maps an Anthropic stop_reason onto a Finish.
+//   - end_turn / stop_sequence → FinishOK (model stopped on its own)
+//   - max_tokens               → FinishTruncated
+//   - anything else            → FinishOther
+//
+// tool_use never occurs here because Fast Apply passes no tools.
+func FinishFromAnthropic(stopReason string) Finish {
+	switch stopReason {
+	case "end_turn", "stop_sequence":
+		return FinishOK
+	case "max_tokens":
+		return FinishTruncated
+	default:
+		return FinishOther
+	}
+}
+
+// SystemPrompt is the instruction given to the regeneration model. Exposed so a
+// caller's Generator can reuse the exact wording the harness was tuned against.
+const SystemPrompt = `You are a precise code editor. You will receive an original file and an edit to apply.
+
+Rules:
+- Return ONLY the complete updated file content — nothing else
+- No markdown fences, no explanations, no preamble, no trailing commentary
+- Preserve all formatting, indentation, and coding style of the original
+- Apply the minimum change needed to implement the edit
+- The edit may be a code snippet, a partial diff, or a natural-language instruction`
+
+// BuildPrompt assembles the user prompt from the original file and the edit.
+func BuildPrompt(original, edit string) string {
+	return fmt.Sprintf("<original_file>\n%s\n</original_file>\n\n<edit>\n%s\n</edit>", original, edit)
+}
+
+// Generator runs the underlying single-shot regeneration. It is expected to call
+// the model with SystemPrompt + BuildPrompt(original, edit) and an output budget
+// of ~MaxOutputTokens, returning the raw text and how generation finished.
+// Injecting it keeps the guards backend-agnostic and unit-testable.
+type Generator func(ctx context.Context, system, prompt string) (text string, finish Finish, err error)
+
+// CheckSize rejects inputs that cannot be fast-applied BEFORE a (billed) model
+// call is spent. Returns ErrFileTooLarge / ErrEditTooLarge on rejection.
+func CheckSize(original, edit string) error {
+	if len(original) > MaxFileChars {
+		return fmt.Errorf("%w (%dk chars; limit ~%dk) — %s",
+			ErrFileTooLarge, len(original)/1000, MaxFileChars/1000, remedyUseWriteFile)
+	}
+	// The prompt size is dominated by file + edit; the wrapper text is negligible.
+	if promptLen := len(BuildPrompt(original, edit)); promptLen > MaxInputChars {
+		return fmt.Errorf("%w (%dk chars) — %s",
+			ErrEditTooLarge, promptLen/1000, remedyUseWriteFile)
+	}
+	return nil
+}
+
+// Apply validates and finalizes a fast-apply result. Given the original file, the
+// model's raw regenerated output, and how generation finished, it returns the
+// content to write or a typed error. It NEVER returns corrupted content with a
+// nil error — every suspect result becomes an error.
+//
+// Use this directly when you already have the model output (e.g. in tests, or
+// when the model call lives elsewhere); use FastApply to run the whole flow.
+func Apply(original, modelOutput string, finish Finish) (string, error) {
+	// Fast Apply regenerates the ENTIRE file. A truncated or otherwise abnormal
+	// finish means `modelOutput` is a partial file — refuse it rather than write a
+	// cut-off result that would report bogus success.
+	switch finish {
+	case FinishTruncated:
+		return "", fmt.Errorf("%w (%d tokens) — the file is too large to regenerate safely; %s",
+			ErrTruncated, MaxOutputTokens, remedyUseWriteFile)
+	case FinishOther:
+		return "", fmt.Errorf("%w — refusing to write a possibly partial file; %s",
+			ErrAbnormalFinish, remedyUseWriteFile)
+	}
+
+	stripped := stripOuterFence(modelOutput)
+	if strings.TrimSpace(stripped) == "" {
+		return "", fmt.Errorf("%w — the edit was not applied", ErrEmptyOutput)
+	}
+
+	updated := preserveTrailingNewline(original, stripped)
+
+	// Defense-in-depth: even within the token budget a small model can silently
+	// drop large regions. Reject a drastic shrink rather than write a damaged file.
+	origLines := lineCount(original)
+	updLines := lineCount(updated)
+	if origLines >= shrinkGuardMinLines && float64(updLines) < float64(origLines)*minRetainedLineRatio {
+		return "", fmt.Errorf("%w (%d → %d lines) — %s",
+			ErrDrasticShrink, origLines, updLines, remedyUseWriteFile)
+	}
+
+	return updated, nil
+}
+
+// FastApply runs the full flow: pre-flight size check → model regeneration via
+// gen → result validation. Returns the content to write or a typed error.
+func FastApply(ctx context.Context, original, edit string, gen Generator) (string, error) {
+	if err := CheckSize(original, edit); err != nil {
+		return "", err
+	}
+	text, finish, err := gen(ctx, SystemPrompt, BuildPrompt(original, edit))
+	if err != nil {
+		return "", err
+	}
+	return Apply(original, text, finish)
+}
+
+// fenceRe matches a response wholly wrapped in a single markdown code fence.
+// (?s) makes . span newlines; the capture is the fenced body.
+var fenceRe = regexp.MustCompile("(?s)^```[^\n]*\n(.+)\n```$")
+
+// stripOuterFence removes a single outermost markdown fence iff the ENTIRE
+// (trimmed) response is wrapped in one. On the normal no-fence path it returns
+// the text verbatim — trimming there would strip the file's own leading/trailing
+// whitespace, including the conventional final newline. Files that merely contain
+// fenced blocks in their body are never touched (the fence must bookend the
+// whole response).
+func stripOuterFence(text string) string {
+	if m := fenceRe.FindStringSubmatch(strings.TrimSpace(text)); m != nil {
+		return m[1]
+	}
+	return text
+}
+
+// preserveTrailingNewline re-attaches the original file's final newline when the
+// model dropped it. This avoids a spurious "no newline at end of file" diff on
+// every edit and keeps a no-op edit (updated == original) detectable.
+func preserveTrailingNewline(original, stripped string) string {
+	if strings.HasSuffix(original, "\n") && !strings.HasSuffix(stripped, "\n") {
+		return stripped + "\n"
+	}
+	return stripped
+}
+
+// lineCount matches the JS `s.split("\n").length`: a non-empty string with no
+// newline is 1 line; n newlines yield n+1 lines.
+func lineCount(s string) int {
+	return strings.Count(s, "\n") + 1
+}

--- a/internal/fastapply/fastapply_test.go
+++ b/internal/fastapply/fastapply_test.go
@@ -1,0 +1,227 @@
+package fastapply
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestFinishFromAnthropic(t *testing.T) {
+	cases := map[string]Finish{
+		"end_turn":      FinishOK,
+		"stop_sequence": FinishOK,
+		"max_tokens":    FinishTruncated,
+		"tool_use":      FinishOther,
+		"":              FinishOther,
+		"weird":         FinishOther,
+	}
+	for in, want := range cases {
+		if got := FinishFromAnthropic(in); got != want {
+			t.Errorf("FinishFromAnthropic(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestCheckSize(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		if err := CheckSize("small file", "tiny edit"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("file too large", func(t *testing.T) {
+		err := CheckSize(strings.Repeat("a", MaxFileChars+1), "edit")
+		if !errors.Is(err, ErrFileTooLarge) {
+			t.Fatalf("got %v, want ErrFileTooLarge", err)
+		}
+	})
+	t.Run("edit too large", func(t *testing.T) {
+		// Small file (passes the file check) but an oversized edit pushes the
+		// combined prompt past MaxInputChars.
+		err := CheckSize("small", strings.Repeat("b", MaxInputChars))
+		if !errors.Is(err, ErrEditTooLarge) {
+			t.Fatalf("got %v, want ErrEditTooLarge", err)
+		}
+	})
+}
+
+func TestApply_Truncated(t *testing.T) {
+	_, err := Apply("original\nfile\n", "partial out", FinishTruncated)
+	if !errors.Is(err, ErrTruncated) {
+		t.Fatalf("got %v, want ErrTruncated", err)
+	}
+}
+
+func TestApply_AbnormalFinish(t *testing.T) {
+	_, err := Apply("original\nfile\n", "partial out", FinishOther)
+	if !errors.Is(err, ErrAbnormalFinish) {
+		t.Fatalf("got %v, want ErrAbnormalFinish", err)
+	}
+}
+
+func TestApply_EmptyOutput(t *testing.T) {
+	_, err := Apply("original", "   \n\t ", FinishOK)
+	if !errors.Is(err, ErrEmptyOutput) {
+		t.Fatalf("got %v, want ErrEmptyOutput", err)
+	}
+}
+
+func TestApply_HappyPath(t *testing.T) {
+	out, err := Apply("a = 1\n", "set a to 2\na = 2\n", FinishOK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "set a to 2\na = 2\n" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestApply_StripsOuterFence(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain fence", "```\ncode here\n```", "code here"},
+		{"language tag", "```go\npackage main\n```", "package main"},
+		{"surrounding whitespace", "\n  ```go\nx := 1\n```  \n", "x := 1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := Apply("orig\nfile\n", tc.in, FinishOK)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// Original ends in \n, fenced body doesn't → trailing newline re-added.
+			if out != tc.want+"\n" {
+				t.Errorf("got %q, want %q", out, tc.want+"\n")
+			}
+		})
+	}
+}
+
+func TestApply_DoesNotStripInternalFences(t *testing.T) {
+	// A file whose body contains fenced blocks but isn't wholly wrapped must be
+	// returned verbatim.
+	doc := "# Readme\n\n```\nexample\n```\n\nmore text\n"
+	out, err := Apply("# Readme\nold\n", doc, FinishOK)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != doc {
+		t.Errorf("internal fences were altered:\n got %q\nwant %q", out, doc)
+	}
+}
+
+func TestApply_PreservesTrailingNewline(t *testing.T) {
+	t.Run("re-adds when original had one", func(t *testing.T) {
+		out, err := Apply("a\nb\n", "a\nB", FinishOK)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "a\nB\n" {
+			t.Errorf("got %q, want %q", out, "a\nB\n")
+		}
+	})
+	t.Run("does not add when original lacked one", func(t *testing.T) {
+		out, err := Apply("a\nb", "a\nB", FinishOK)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "a\nB" {
+			t.Errorf("got %q, want %q", out, "a\nB")
+		}
+	})
+}
+
+func TestApply_DrasticShrinkGuard(t *testing.T) {
+	orig := strings.Repeat("line\n", 40) // 40 newlines → 41 lines
+
+	t.Run("fires on >50% drop of a large file", func(t *testing.T) {
+		small := strings.Repeat("line\n", 5) // 6 lines, well under half
+		_, err := Apply(orig, small, FinishOK)
+		if !errors.Is(err, ErrDrasticShrink) {
+			t.Fatalf("got %v, want ErrDrasticShrink", err)
+		}
+	})
+
+	t.Run("allows a modest shrink", func(t *testing.T) {
+		// 41 → 30 lines is well above the 50% floor; must pass.
+		modest := strings.Repeat("line\n", 29) // 30 lines
+		out, err := Apply(orig, modest, FinishOK)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != modest {
+			t.Errorf("content altered unexpectedly")
+		}
+	})
+
+	t.Run("ignored on small files (below line floor)", func(t *testing.T) {
+		// A 10-line file dropping to 1 line is a normal edit, not a botched
+		// rewrite — the guard must not fire below shrinkGuardMinLines.
+		smallOrig := strings.Repeat("x\n", 10) // 11 lines, < 40
+		_, err := Apply(smallOrig, "x\n", FinishOK)
+		if err != nil {
+			t.Fatalf("guard wrongly fired on a small file: %v", err)
+		}
+	})
+}
+
+func TestFastApply_FullFlowSuccess(t *testing.T) {
+	gen := func(ctx context.Context, system, prompt string) (string, Finish, error) {
+		if system != SystemPrompt {
+			t.Errorf("generator got unexpected system prompt")
+		}
+		if !strings.Contains(prompt, "<original_file>") || !strings.Contains(prompt, "<edit>") {
+			t.Errorf("prompt missing expected tags: %q", prompt)
+		}
+		return "updated = true\n", FinishOK, nil
+	}
+	out, err := FastApply(context.Background(), "updated = false\n", "flip it", gen)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "updated = true\n" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestFastApply_PropagatesGeneratorError(t *testing.T) {
+	boom := errors.New("model unavailable")
+	gen := func(ctx context.Context, system, prompt string) (string, Finish, error) {
+		return "", FinishOK, boom
+	}
+	_, err := FastApply(context.Background(), "x\n", "edit", gen)
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want propagated generator error", err)
+	}
+}
+
+func TestFastApply_SizeCheckShortCircuitsBeforeModelCall(t *testing.T) {
+	called := false
+	gen := func(ctx context.Context, system, prompt string) (string, Finish, error) {
+		called = true
+		return "x", FinishOK, nil
+	}
+	_, err := FastApply(context.Background(), strings.Repeat("a", MaxFileChars+1), "edit", gen)
+	if !errors.Is(err, ErrFileTooLarge) {
+		t.Fatalf("got %v, want ErrFileTooLarge", err)
+	}
+	if called {
+		t.Error("generator was called despite a failed pre-flight size check (wasted/billed call)")
+	}
+}
+
+func TestLineCount(t *testing.T) {
+	cases := map[string]int{
+		"":         1,
+		"one line": 1,
+		"a\nb":     2,
+		"a\nb\n":   3,
+		"\n":       2,
+	}
+	for in, want := range cases {
+		if got := lineCount(in); got != want {
+			t.Errorf("lineCount(%q) = %d, want %d", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Ports the defensive harness from the e2b coding agent's `lib/fastApply.ts` into a self-contained Go package `internal/fastapply`. Part of epic QUA-763.

**Fast Apply** = have a small/cheap model regenerate an *entire* file from an edit instruction (à la Cursor's apply model). It's fast and forgiving of fuzzy edits, but has one dangerous failure mode: the model can silently return a **truncated or partially-dropped** file, and writing that corrupts the file while reporting success. This harness makes that impossible to commit silently — every guard turns a suspect result into a **typed error** instead of a bad write.

## Guards

- **Pre-flight size rejection** (`CheckSize`) — the file must fit the *output* budget (not just context); rejected before any billed model call. (`ErrFileTooLarge` / `ErrEditTooLarge`)
- **Truncation detection** — `FinishTruncated` ⇒ refuse the cut-off file. (`ErrTruncated`)
- **Abnormal-finish guard** — any non-clean stop ⇒ refuse possibly-partial output. (`ErrAbnormalFinish`)
- **Drastic-shrink guard** — >50% line drop on files ≥40 lines = botched rewrite. (`ErrDrasticShrink`)
- **Outer-fence stripping** — only when the whole response is fenced; never touches files with internal fenced blocks.
- **Trailing-newline preservation** — re-adds the final newline the model dropped.

## Design

Backend-agnostic: the model call is injected as a `Generator` func, so `Apply`/`CheckSize` are **pure and fully unit-testable without a live model**. `FinishFromAnthropic` maps Anthropic `stop_reason` → `Finish`. `SystemPrompt`/`BuildPrompt` are exported so a caller's generator reuses the exact tuned wording.

## Scope / non-goals

**No consumer is wired up** (per the issue — this is preparatory). `write_file` / `update_script` in `internal/agent/tools.go` are the candidate consumers once a local model-assisted edit path exists.

## Tests

`fastapply_test.go` covers every guard: size checks (both), truncated/abnormal/empty finishes, fence stripping (plain/lang-tag/whitespace + internal-fence safety), trailing-newline both ways, drastic-shrink (fires / modest-shrink allowed / below-floor ignored), full-flow success, generator-error propagation, and that a failed size check short-circuits **before** the (billed) model call. `go build`, `go vet`, `gofmt` all clean.

Closes QUA-765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)