### PR TITLE
feat(security): SSRF host-validator for outbound URLs (QUA-766)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"54a29312-1ae1-49c5-afb3-194c04fbb0ed","pid":36928,"procStart":"Tue Jun  2 10:41:31 2026","acquiredAt":1780398393050}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"54a29312-1ae1-49c5-afb3-194c04fbb0ed","pid":36928,"procStart":"Tue Jun  2 10:41:31 2026","acquiredAt":1780398393050}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 .DS_Store
 dist/
 security-roast-report.md
+.claude/

--- a/internal/security/ssrf.go
+++ b/internal/security/ssrf.go
@@ -1,0 +1,92 @@
+package security
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// SSRF host validation for user-supplied OUTBOUND URLs (e.g. an MCP server URL,
+// or any "fetch this URL" surface). Ported from the e2b coding agent's
+// lib/mcp.ts (isSafeSSEUrl) and lib/preview.ts (isDisallowedHost / isIpv4Literal)
+// (QUA-766).
+//
+// NOTE: this is preparatory — qmax-code is currently only an MCP *server* and has
+// no outbound user-URL surface, so there is no call site yet. Wire IsSafePublicURL
+// in at the point any user-supplied outbound URL is first accepted.
+//
+// The rule deliberately rejects EVERY IP literal (in every notation) rather than
+// computing per-range membership. Refusing raw IPs outright closes private-range
+// access together with the octal/hex/decimal/IPv6 notation bypasses
+// (0177.0.0.1, 0x7f.0.0.1, 2130706433, [::1], …) in one rule. DNS rebinding is out
+// of scope: we validate the literal host, we don't resolve names.
+
+var (
+	// ipv4HexPart matches a hex octet such as 0x7f (host is lower-cased first).
+	ipv4HexPart = regexp.MustCompile(`^0x[0-9a-f]+$`)
+	// ipv4OctalPart matches an octal octet such as 0177, and bare 0.
+	ipv4OctalPart = regexp.MustCompile(`^0[0-7]*$`)
+	// ipv4DecimalPart matches a decimal octet such as 127 (no leading zero).
+	ipv4DecimalPart = regexp.MustCompile(`^[1-9][0-9]*$`)
+)
+
+// IsSafePublicURL reports whether raw is an http(s) URL pointing at a public
+// hostname. It rejects:
+//   - non-http(s) schemes (file:, javascript:, data:, gopher:, …)
+//   - localhost, *.localhost, *.local, and the empty host
+//   - every IPv6 literal ([::1], fd00::, …)
+//   - every IPv4 literal in any resolver-accepted notation (dotted decimal/octal/
+//     hex and the short a / a.b / a.b.c forms, plus a bare 32-bit integer)
+//
+// A non-IP public hostname (example.com, mcp.linear.app, …) is allowed.
+func IsSafePublicURL(raw string) bool {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	host := u.Hostname() // strips port and IPv6 brackets
+	if host == "" {
+		return false
+	}
+	return !isDisallowedHost(host)
+}
+
+// isDisallowedHost reports whether hostname must be blocked as an SSRF target.
+func isDisallowedHost(hostname string) bool {
+	// Strip a trailing FQDN-root dot so "localhost." / "app.local." can't slip
+	// past the name checks.
+	host := strings.ToLower(strings.TrimRight(hostname, "."))
+	if host == "" {
+		return true
+	}
+	if host == "localhost" || strings.HasSuffix(host, ".localhost") || strings.HasSuffix(host, ".local") {
+		return true
+	}
+	// url.Hostname() already removes IPv6 brackets, but strip defensively in case
+	// a raw host is passed in. Any colon means an IPv6 literal.
+	h := strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	if strings.Contains(h, ":") {
+		return true // any IPv6 literal
+	}
+	return isIPv4Literal(h) // any IPv4 notation
+}
+
+// isIPv4Literal reports whether host is an IPv4 address in any notation a resolver
+// would accept — dotted decimal/octal/hex (a.b.c.d and the short a, a.b, a.b.c
+// forms) or a bare 32-bit number. Real hostnames have at least one non-numeric
+// label, so they never match.
+func isIPv4Literal(host string) bool {
+	parts := strings.Split(host, ".")
+	if len(parts) < 1 || len(parts) > 4 {
+		return false
+	}
+	for _, p := range parts {
+		if !ipv4HexPart.MatchString(p) && !ipv4OctalPart.MatchString(p) && !ipv4DecimalPart.MatchString(p) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/security/ssrf_test.go
+++ b/internal/security/ssrf_test.go
@@ -1,0 +1,135 @@
+package security
+
+import "testing"
+
+func TestIsSafePublicURL_Allows(t *testing.T) {
+	safe := []string{
+		"https://mcp.linear.app/sse",
+		"https://example.com",
+		"http://example.com:8080/path?q=1",
+		"https://sub.domain.co.uk/",
+		"https://api.github.com/repos/x/y",
+		"https://1example.com",    // starts with a digit but not numeric
+		"https://0x1.example.com", // hex-looking label but has a non-IP label
+		"https://example.com.",    // trailing root dot on a real host is fine
+	}
+	for _, u := range safe {
+		if !IsSafePublicURL(u) {
+			t.Errorf("IsSafePublicURL(%q) = false, want true (should be allowed)", u)
+		}
+	}
+}
+
+func TestIsSafePublicURL_BlocksSchemes(t *testing.T) {
+	bad := []string{
+		"file:///etc/passwd",
+		"javascript:alert(1)",
+		"data:text/html,<script>",
+		"gopher://example.com",
+		"ftp://example.com/x",
+		"ws://example.com/socket",
+		"example.com",   // no scheme
+		"//example.com", // scheme-relative
+		"",              // empty
+		"   ",           // whitespace only
+	}
+	for _, u := range bad {
+		if IsSafePublicURL(u) {
+			t.Errorf("IsSafePublicURL(%q) = true, want false (bad/missing scheme)", u)
+		}
+	}
+}
+
+func TestIsSafePublicURL_BlocksLocalAndPrivateNames(t *testing.T) {
+	bad := []string{
+		"http://localhost",
+		"http://localhost:3000/x",
+		"http://LOCALHOST/x",     // case-insensitive
+		"http://localhost./x",    // trailing root dot
+		"http://api.localhost/x", // *.localhost
+		"http://printer.local/x", // *.local (mDNS)
+		"http://service.LOCAL/x",
+	}
+	for _, u := range bad {
+		if IsSafePublicURL(u) {
+			t.Errorf("IsSafePublicURL(%q) = true, want false (local/private name)", u)
+		}
+	}
+}
+
+func TestIsSafePublicURL_BlocksLoopbackAndMetadataAndRFC1918(t *testing.T) {
+	bad := []string{
+		"http://127.0.0.1/x",
+		"http://127.1/x", // short-form loopback
+		"http://0.0.0.0/x",
+		"http://169.254.169.254/latest/meta-data/", // AWS/Azure metadata
+		"http://100.100.100.200/x",                 // Alibaba Cloud metadata
+		"http://10.0.0.5/x",                        // RFC-1918 class A
+		"http://172.16.0.1/x",                      // RFC-1918 class B
+		"http://172.31.255.255/x",
+		"http://192.168.1.1/x", // RFC-1918 class C
+	}
+	for _, u := range bad {
+		if IsSafePublicURL(u) {
+			t.Errorf("IsSafePublicURL(%q) = true, want false (loopback/metadata/private IP)", u)
+		}
+	}
+}
+
+// The headline of QUA-766: alternative IPv4 notations that bypass naive
+// substring/dotted-decimal checks.
+func TestIsSafePublicURL_BlocksIPv4NotationBypasses(t *testing.T) {
+	bad := []string{
+		"http://0177.0.0.1/x",   // octal
+		"http://0x7f.0.0.1/x",   // hex octet
+		"http://0x7f000001/x",   // single hex 32-bit
+		"http://2130706433/x",   // bare decimal 32-bit (== 127.0.0.1)
+		"http://0/x",            // bare octal zero
+		"http://017700000001/x", // octal 32-bit
+		"http://192.0x00.0.1/x", // mixed notation
+	}
+	for _, u := range bad {
+		if IsSafePublicURL(u) {
+			t.Errorf("IsSafePublicURL(%q) = true, want false (IPv4 notation bypass)", u)
+		}
+	}
+}
+
+func TestIsSafePublicURL_BlocksIPv6Literals(t *testing.T) {
+	bad := []string{
+		"http://[::1]/x", // IPv6 loopback
+		"http://[::1]:8080/x",
+		"http://[fd00::1]/x",     // unique local address
+		"http://[fe80::1]/x",     // link-local
+		"http://[2001:db8::1]/x", // even a "public" v6 literal — we reject all literals
+	}
+	for _, u := range bad {
+		if IsSafePublicURL(u) {
+			t.Errorf("IsSafePublicURL(%q) = true, want false (IPv6 literal)", u)
+		}
+	}
+}
+
+func TestIsIPv4Literal(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1":   true,
+		"127.1":       true,
+		"10":          true, // single decimal
+		"2130706433":  true, // bare 32-bit
+		"0x7f":        true, // hex
+		"0177":        true, // octal
+		"0":           true, // octal zero
+		"1.2.3.4":     true,
+		"example":     false, // plain label
+		"example.com": false,
+		"1example":    false, // digit-led but not numeric
+		"0xZZ":        false, // not valid hex
+		"1.2.3.4.5":   false, // too many parts
+		"":            false, // empty -> single empty part, not numeric
+	}
+	for in, want := range cases {
+		if got := isIPv4Literal(in); got != want {
+			t.Errorf("isIPv4Literal(%q) = %v, want %v", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Ports the SSRF host-validation from the e2b coding agent (`lib/mcp.ts` `isSafeSSEUrl` + `lib/preview.ts` `isIpv4Literal`/`isDisallowedHost`) into `internal/security` as **`IsSafePublicURL(raw string) bool`**. Final item of epic QUA-763.

## Why it's stronger than what we had

`internal/security/security.go` only did **substring** `localhost`/`127.0.0.1` checks, and only on *generated test code* — not on outbound request targets. `IsSafePublicURL` is a real host validator that rejects, in one rule:

- non-http(s) schemes (`file:`, `javascript:`, `data:`, `gopher:`, …)
- `localhost`, `*.localhost`, `*.local`, empty host (with trailing-root-dot stripping, e.g. `localhost.`)
- **every IPv6 literal** (`[::1]`, `fd00::`, …)
- **every IPv4 literal in any resolver-accepted notation** — dotted decimal/octal/hex and the short `a` / `a.b` / `a.b.c` forms, plus a bare 32-bit integer

Rejecting all IP literals outright closes private-range access **and** the notation bypasses (`0177.0.0.1`, `0x7f.0.0.1`, `2130706433`, `[::1]`, `192.0x00.0.1`, …) together, and inherently covers loopback, cloud-metadata (`169.254.x`, `100.100.100.x`), and RFC-1918 ranges. A non-IP public hostname (`mcp.linear.app`, `example.com`) is allowed.

## Scope / non-goals

**Preparatory — no call site yet.** qmax-code is currently only an MCP *server* (no outbound user URLs). Wire `IsSafePublicURL` in when a user-supplied outbound URL surface lands (MCP-client support, or any "fetch this URL" feature). DNS rebinding is explicitly out of scope (literal-host validation, no name resolution).

## Tests

`ssrf_test.go` is table-driven and covers: allowed public hosts, blocked schemes, local/`.local` names, loopback + metadata + RFC-1918, the **IPv4 notation bypass vectors** (octal/hex/decimal/mixed/bare-32-bit), IPv6 literals, and the `isIPv4Literal` helper directly. `go build`, `go vet`, `gofmt`, full `security` package tests all pass.

Closes QUA-766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)