### PR TITLE
chore: bump version to 1.16.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.16.15] - 2026-06-02
+
+### Added
+- `internal/security.IsSafePublicURL`: an SSRF host-validator for user-supplied outbound URLs (QUA-766, #113). Rejects non-http(s) schemes, `localhost`/`*.localhost`/`*.local`, every IPv6 literal, and every IPv4 literal in any resolver notation — closing the octal/hex/decimal/short-form/bare-32-bit bypasses (`0177.0.0.1`, `0x7f.0.0.1`, `2130706433`, `[::1]`, …) in one rule, which inherently covers loopback, cloud-metadata, and RFC-1918 ranges. Preparatory: no call site yet — wire it in when an outbound-URL surface (MCP client, "fetch this URL") lands.
+
+### Changed
+- Stop tracking `.claude/` session state in git (added to `.gitignore`).
+
 ## [1.16.14] - 2026-06-02
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.14"
+var Version = "1.16.15"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Version bump for release **v1.16.15**, covering:

- `internal/security.IsSafePublicURL` SSRF host-validator (QUA-766, #113)
- `.gitignore`: stop tracking `.claude/` session state

Bumps `main.Version` and adds a CHANGELOG entry. Tag `v1.16.15` will be pushed after merge to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)