### PR TITLE
feat(orch): materialize qmax QA skills into Claude Code and Codex

### DIFF
--- a/internal/setup/orch.go
+++ b/internal/setup/orch.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/qualitymax/qmax-code/internal/agent"
+	"github.com/qualitymax/qmax-code/internal/skills"
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
@@ -132,6 +133,7 @@ func RunOrch(backend string, term *tui.Terminal) {
 		}
 		term.PrintSystem("Claude Code now has qmax tools in EVERY session (not just when spawned by qmax-code).")
 		term.PrintSystem("Run `claude` directly and qmax QA tools will be available automatically.")
+		materializeSkills(skills.BackendCC, term)
 
 	case "codex":
 		term.PrintSystem("Setting up Codex integration…")
@@ -146,7 +148,26 @@ func RunOrch(backend string, term *tui.Terminal) {
 			term.PrintSystem(fmt.Sprintf("qmax MCP entry added to %s", res.MCPPath))
 		}
 		term.PrintSystem("Codex now has qmax tools in every session.")
+		materializeSkills(skills.BackendCodex, term)
 	}
+}
+
+// materializeSkills writes the qmax skill catalog into the backend's native
+// skills directory so the QA skills auto-load in every CLI session, the same
+// way the MCP tools do. Failures are non-fatal — the MCP integration is the
+// hard requirement; skills are an additive convenience.
+func materializeSkills(backend skills.Backend, term *tui.Terminal) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		term.PrintError(fmt.Sprintf("Could not locate home dir for skill install: %v", err))
+		return
+	}
+	res, err := skills.Materialize(backend, home)
+	if err != nil {
+		term.PrintError(fmt.Sprintf("Skill install failed: %v", err))
+		return
+	}
+	term.PrintSystem(fmt.Sprintf("Installed %d qmax QA skills into %s", len(res.Written), res.Dir))
 }
 
 // IsOrchSetupDone returns true if the qmax MCP entry already exists in the

--- a/internal/skills/catalog.go
+++ b/internal/skills/catalog.go
@@ -1,0 +1,117 @@
+// Package skills defines the backend-neutral catalog of qmax QA skills and
+// materializes them into the native skill directories of each supported CLI
+// backend (Claude Code and Codex).
+//
+// Both Claude Code and Codex load "agent skills" from a folder containing a
+// SKILL.md file with YAML frontmatter (name + description), auto-invoked when a
+// user request matches the description. The two CLIs share that core format but
+// diverge on the optional enrichment they understand:
+//
+//   - Claude Code reads an `allowed-tools:` frontmatter key to gate which tools
+//     the skill may call.
+//   - Codex ignores `allowed-tools`; it reads an optional sibling
+//     `agents/openai.yaml` for UI metadata, MCP dependencies, and invocation
+//     policy.
+//
+// A single Skill in this catalog is the source of truth. Render() emits the
+// right SKILL.md (and, for Codex, openai.yaml) for whichever backend is being
+// installed, so one definition stays in sync across both CLIs.
+package skills
+
+import (
+	"embed"
+	"fmt"
+	"sort"
+)
+
+//go:embed catalog/*.md
+var catalogFS embed.FS
+
+// MCPDep declares an MCP server a skill depends on. It is surfaced to Codex via
+// agents/openai.yaml so the harness can warn when the dependency is missing.
+// Claude Code does not consume this directly (the qmax MCP is already wired in
+// via the global install), but it documents intent in either backend.
+type MCPDep struct {
+	// Value is the MCP server identifier as registered in the CLI config,
+	// e.g. "qmax".
+	Value string
+	// Description is a human-readable explanation of why the skill needs it.
+	Description string
+}
+
+// Skill is one backend-neutral QA skill. The same definition renders to a
+// Claude Code skill folder and a Codex skill folder.
+type Skill struct {
+	// Name is the skill slug: lowercase, hyphenated, unique. It is the folder
+	// name and the token used to invoke the skill (`$name` in Codex).
+	Name string
+	// Description is the single most important field: both CLIs use it to decide
+	// when to auto-invoke the skill, so it must describe what the skill does and
+	// when to use it.
+	Description string
+	// ShortDescription is an optional <=64-char blurb for UI lists. Falls back to
+	// Description when empty.
+	ShortDescription string
+	// AllowedTools gates tool access in Claude Code. Empty means "inherit all".
+	AllowedTools []string
+	// MCPDeps are the MCP servers the skill relies on, surfaced to Codex.
+	MCPDeps []MCPDep
+	// bodyFile is the embedded markdown body under catalog/.
+	bodyFile string
+}
+
+// Body returns the markdown instructions for the skill (everything after the
+// frontmatter). It panics on a missing embed because the catalog is compiled
+// into the binary — a missing file is a build-time programming error, not a
+// runtime condition.
+func (s Skill) Body() string {
+	data, err := catalogFS.ReadFile("catalog/" + s.bodyFile)
+	if err != nil {
+		panic(fmt.Sprintf("skills: embedded body %q missing: %v", s.bodyFile, err))
+	}
+	return string(data)
+}
+
+// qmaxDep is the dependency every catalog skill shares: the qmax MCP server
+// that orch installs into both CLIs.
+var qmaxDep = MCPDep{Value: "qmax", Description: "qmax QA tools (list, run, generate, review)"}
+
+// Catalog is the full set of qmax QA skills shipped with qmax-code. Adding a
+// skill is: drop a catalog/<name>.md body and append an entry here.
+var Catalog = []Skill{
+	{
+		Name:             "migrate-to-playwright",
+		Description:      "Migrate a test-automation framework from Cypress or Selenium to Playwright. Use when the user wants to port, convert, or migrate an existing E2E/UI test suite to Playwright, or modernize a legacy Cypress/Selenium project.",
+		ShortDescription: "Port a Cypress/Selenium suite to Playwright",
+		MCPDeps:          []MCPDep{qmaxDep},
+		bodyFile:         "migrate-to-playwright.md",
+	},
+	{
+		Name:             "qa-quality-gate",
+		Description:      "Enforce a release quality gate on a code change: generate tests for the diff, run them, review results, and emit a pass/fail verdict with blocking findings. Use before merging or shipping, or when the user asks whether a change is safe to release.",
+		ShortDescription: "Pass/fail release gate for a diff",
+		MCPDeps:          []MCPDep{qmaxDep},
+		bodyFile:         "qa-quality-gate.md",
+	},
+	{
+		Name:             "sast-presurgery",
+		Description:      "Run a focused static-analysis security pass on the code about to be changed, before the edit lands. Use when planning a change to security-sensitive code, or when the user wants vulnerabilities found pre-emptively rather than in post-merge review.",
+		ShortDescription: "Pre-change SAST on the surgical site",
+		bodyFile:         "sast-presurgery.md",
+	},
+	{
+		Name:             "qa-triage",
+		Description:      "Triage a failing test run or bug report into a diagnosis: real defect vs. flaky test vs. environment issue, with the next concrete action. Use when a test fails, a suite is red, a bug comes in, or the user asks why something is failing.",
+		ShortDescription: "Diagnose a failure: defect vs flake vs env",
+		MCPDeps:          []MCPDep{qmaxDep},
+		bodyFile:         "qa-triage.md",
+	},
+}
+
+// SortedCatalog returns the catalog ordered by name for deterministic output.
+func SortedCatalog() []Skill {
+	out := make([]Skill, len(Catalog))
+	copy(out, Catalog)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/internal/skills/catalog.go
+++ b/internal/skills/catalog.go
@@ -13,9 +13,9 @@
 //     `agents/openai.yaml` for UI metadata, MCP dependencies, and invocation
 //     policy.
 //
-// A single Skill in this catalog is the source of truth. Render() emits the
-// right SKILL.md (and, for Codex, openai.yaml) for whichever backend is being
-// installed, so one definition stays in sync across both CLIs.
+// A single Skill in this catalog is the source of truth. Materialize() emits
+// the right SKILL.md (and, for Codex, openai.yaml) for whichever backend is
+// being installed, so one definition stays in sync across both CLIs.
 package skills
 
 import (
@@ -97,7 +97,9 @@ var Catalog = []Skill{
 		Name:             "sast-presurgery",
 		Description:      "Run a focused static-analysis security pass on the code about to be changed, before the edit lands. Use when planning a change to security-sensitive code, or when the user wants vulnerabilities found pre-emptively rather than in post-merge review.",
 		ShortDescription: "Pre-change SAST on the surgical site",
-		bodyFile:         "sast-presurgery.md",
+		// No MCPDeps: this is a pure static-analysis skill that reasons over the
+		// diff and source; it does not drive the qmax test runner like the others.
+		bodyFile: "sast-presurgery.md",
 	},
 	{
 		Name:             "qa-triage",

--- a/internal/skills/catalog/migrate-to-playwright.md
+++ b/internal/skills/catalog/migrate-to-playwright.md
@@ -1,0 +1,26 @@
+# Migrate to Playwright
+
+Migrate an existing test-automation framework from Cypress or Selenium to
+Playwright. Analyze the existing suite, map patterns, convert tests one-by-one
+with AI-powered code generation and validation.
+
+## Workflow
+
+1. **Inventory** — list every spec file, page object, fixture, and custom
+   command in the source framework. Record the runner config (timeouts,
+   retries, base URL, env handling).
+2. **Map idioms** — translate source constructs to Playwright equivalents:
+   - Cypress `cy.get().click()` → `await page.locator(...).click()`
+   - Selenium `WebDriverWait` → Playwright auto-waiting / `expect().toBeVisible()`
+   - custom commands → fixtures or helper functions
+3. **Convert** — port one spec at a time. Prefer role/text locators over CSS
+   where the source allowed it. Replace implicit sleeps with web-first
+   assertions.
+4. **Validate** — run each converted spec with the qmax test tools and confirm
+   parity against the original before deleting the source spec.
+5. **Report** — summarize coverage delta, flaky-risk reductions, and any tests
+   that could not be mechanically converted.
+
+Use the qmax QA tools (list, run, generate, review) to execute and verify each
+converted spec as you go — do not consume model tokens re-running suites you can
+run through qmax.

--- a/internal/skills/catalog/qa-quality-gate.md
+++ b/internal/skills/catalog/qa-quality-gate.md
@@ -1,0 +1,23 @@
+# QA Quality Gate
+
+Enforce a release quality gate before code merges or ships. Generates tests for
+changed code, runs them, reviews the results, and produces a pass/fail verdict
+with quality findings.
+
+## Workflow
+
+1. **Scope the diff** — determine the changed files and the surface area they
+   affect (API, UI, data, infra).
+2. **Generate coverage** — for each changed unit, generate or extend tests via
+   the qmax generate tool. Cover happy path, boundaries, and the regression the
+   change is most likely to introduce.
+3. **Run** — execute the generated and existing relevant suites through qmax.
+4. **Review** — evaluate failures, flake, and coverage gaps. Classify each
+   finding by severity.
+5. **Gate** — emit a verdict:
+   - **PASS** — all required checks green, coverage threshold met.
+   - **FAIL** — list blocking findings with the exact file:line and the failing
+     assertion, plus the smallest fix that would unblock.
+
+Always cite the concrete failing test and the changed line that caused it. Never
+pass a gate on unverified assumptions — run the suite.

--- a/internal/skills/catalog/qa-triage.md
+++ b/internal/skills/catalog/qa-triage.md
@@ -1,0 +1,24 @@
+# QA Triage
+
+Triage a failing test run or an incoming bug report into an actionable
+diagnosis: real defect vs. flaky test vs. environment issue, with the next
+concrete step.
+
+## Workflow
+
+1. **Reproduce** — re-run the failing test(s) through qmax. A failure that does
+   not reproduce on a clean run is a flake candidate, not a defect.
+2. **Localize** — bisect to the smallest failing assertion. Capture the actual
+   vs. expected and the stack/trace.
+3. **Classify**:
+   - **Defect** — deterministic failure tied to a code path. Point at the
+     file:line and the regression that introduced it.
+   - **Flake** — passes on retry / depends on timing, order, or shared state.
+     Identify the source of nondeterminism.
+   - **Environment** — fails due to config, data, or infra, not the code under
+     test.
+4. **Recommend** — the single highest-value next action (fix, quarantine,
+   stabilize, or escalate) with the rationale.
+
+Do not guess the category — gather the evidence (a rerun, a diff, a log) that
+distinguishes flake from defect before labeling.

--- a/internal/skills/catalog/sast-presurgery.md
+++ b/internal/skills/catalog/sast-presurgery.md
@@ -1,0 +1,21 @@
+# SAST Pre-Surgery
+
+Run a focused static-analysis security pass on the code about to be changed
+("pre-surgery") so vulnerabilities are found before the edit lands, not after.
+
+## Workflow
+
+1. **Define the surgical site** — the files and functions the upcoming change
+   will touch, plus their immediate callers and callees.
+2. **Scan** — look for the high-signal SAST categories on that surface:
+   injection (SQL/command/template), SSRF, path traversal, deserialization,
+   auth/authorization gaps, secret handling, and unsafe crypto.
+3. **Triage** — for each finding record severity, exploitability, and whether
+   the planned change makes it better or worse.
+4. **Pre-empt** — propose the secure pattern to use during the edit so the new
+   code does not reintroduce the class of bug.
+5. **Report** — a short list of must-fix items with file:line and a one-line
+   remediation each. No false-positive padding.
+
+Prefer precision over recall: a security report that cries wolf gets ignored.
+Flag only findings you can justify with a concrete data-flow path.

--- a/internal/skills/materialize.go
+++ b/internal/skills/materialize.go
@@ -1,0 +1,163 @@
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Backend identifies which CLI's native skill format to render.
+type Backend string
+
+const (
+	BackendCC    Backend = "cc"
+	BackendCodex Backend = "codex"
+)
+
+// MaterializeResult reports what Materialize wrote, for display to the user.
+type MaterializeResult struct {
+	Backend Backend
+	Dir     string   // root skills directory written into
+	Written []string // skill names written or updated
+}
+
+// SkillsDir returns the user-level skills directory for a backend under home,
+// e.g. ~/.claude/skills or ~/.codex/skills. home is taken as a parameter so the
+// caller (and tests) control it.
+func SkillsDir(backend Backend, home string) (string, error) {
+	switch backend {
+	case BackendCC:
+		return filepath.Join(home, ".claude", "skills"), nil
+	case BackendCodex:
+		return filepath.Join(home, ".codex", "skills"), nil
+	default:
+		return "", fmt.Errorf("skills: unknown backend %q", backend)
+	}
+}
+
+// Materialize writes every catalog skill into the backend's user-level skills
+// directory under home, rendering the SKILL.md (and, for Codex, the
+// agents/openai.yaml) appropriate to that backend. Existing qmax skill folders
+// are overwritten so the catalog stays authoritative; unrelated skills the user
+// installed themselves are left untouched.
+func Materialize(backend Backend, home string) (*MaterializeResult, error) {
+	root, err := SkillsDir(backend, home)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(root, 0700); err != nil {
+		return nil, err
+	}
+
+	res := &MaterializeResult{Backend: backend, Dir: root}
+	for _, sk := range SortedCatalog() {
+		if err := writeSkill(backend, root, sk); err != nil {
+			return nil, fmt.Errorf("write skill %q: %w", sk.Name, err)
+		}
+		res.Written = append(res.Written, sk.Name)
+	}
+	return res, nil
+}
+
+// writeSkill renders one skill folder for the given backend.
+func writeSkill(backend Backend, root string, sk Skill) error {
+	dir := filepath.Join(root, sk.Name)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(renderSkillMD(backend, sk)), 0600); err != nil {
+		return err
+	}
+
+	// Codex consumes optional per-skill config from agents/openai.yaml: UI
+	// metadata and MCP dependencies. Only emit it when there is something to say.
+	if backend == BackendCodex && (len(sk.MCPDeps) > 0 || sk.ShortDescription != "") {
+		agentsDir := filepath.Join(dir, "agents")
+		if err := os.MkdirAll(agentsDir, 0700); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(agentsDir, "openai.yaml"), []byte(renderOpenAIYAML(sk)), 0600); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// renderSkillMD builds the SKILL.md contents for a backend. The frontmatter core
+// (name, description) is identical across both; only the optional enrichment
+// differs.
+func renderSkillMD(backend Backend, sk Skill) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("name: " + yamlScalar(sk.Name) + "\n")
+	b.WriteString("description: " + yamlScalar(sk.Description) + "\n")
+
+	switch backend {
+	case BackendCC:
+		// Claude Code: gate tools via allowed-tools when the skill declares them.
+		if len(sk.AllowedTools) > 0 {
+			b.WriteString("allowed-tools:\n")
+			for _, t := range sk.AllowedTools {
+				b.WriteString("  - " + yamlScalar(t) + "\n")
+			}
+		}
+	case BackendCodex:
+		// Codex: surface a short description via metadata; richer config lives in
+		// agents/openai.yaml.
+		if sk.ShortDescription != "" {
+			b.WriteString("metadata:\n")
+			b.WriteString("  short-description: " + yamlScalar(sk.ShortDescription) + "\n")
+		}
+	}
+
+	b.WriteString("---\n\n")
+	b.WriteString(sk.Body())
+	if !strings.HasSuffix(sk.Body(), "\n") {
+		b.WriteString("\n")
+	}
+	// Provenance footer so a reader (or a future orch run) can tell these folders
+	// are catalog-managed and will be overwritten.
+	b.WriteString("\n<!-- Managed by qmax-code orch. Edit the catalog, not this file. -->\n")
+	return b.String()
+}
+
+// renderOpenAIYAML builds the Codex agents/openai.yaml for a skill from its
+// short description and MCP dependencies.
+func renderOpenAIYAML(sk Skill) string {
+	var b strings.Builder
+	b.WriteString("# Managed by qmax-code orch. Edit the catalog, not this file.\n")
+	if sk.ShortDescription != "" {
+		b.WriteString("interface:\n")
+		b.WriteString("  short_description: " + yamlQuoted(sk.ShortDescription) + "\n")
+	}
+	if len(sk.MCPDeps) > 0 {
+		b.WriteString("dependencies:\n")
+		b.WriteString("  tools:\n")
+		for _, d := range sk.MCPDeps {
+			b.WriteString("    - type: \"mcp\"\n")
+			b.WriteString("      value: " + yamlQuoted(d.Value) + "\n")
+			b.WriteString("      description: " + yamlQuoted(d.Description) + "\n")
+		}
+	}
+	b.WriteString("policy:\n")
+	b.WriteString("  allow_implicit_invocation: true\n")
+	return b.String()
+}
+
+// yamlScalar renders a string as a YAML scalar, quoting only when needed so the
+// common case stays readable. Used for unquoted-by-default frontmatter keys.
+func yamlScalar(s string) string {
+	if s == "" || strings.ContainsAny(s, ":#\"'\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") {
+		return yamlQuoted(s)
+	}
+	return s
+}
+
+// yamlQuoted renders a double-quoted YAML string with the minimal escaping YAML
+// requires inside double quotes.
+func yamlQuoted(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
+	return `"` + r.Replace(s) + `"`
+}

--- a/internal/skills/materialize.go
+++ b/internal/skills/materialize.go
@@ -53,7 +53,13 @@ func Materialize(backend Backend, home string) (*MaterializeResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(root, 0700); err != nil {
+	if err := mkdirStrict(root); err != nil {
+		return nil, err
+	}
+	// Guard against a pre-planted symlink at ~/.claude or ~/.codex redirecting
+	// writes outside the user's home. Done after MkdirAll so the path exists to
+	// resolve, but before any skill files are written.
+	if err := ensureWithinHome(root, home); err != nil {
 		return nil, err
 	}
 
@@ -73,11 +79,11 @@ func Materialize(backend Backend, home string) (*MaterializeResult, error) {
 // writeSkill renders one skill folder for the given backend.
 func writeSkill(backend Backend, root string, sk Skill) error {
 	dir := filepath.Join(root, sk.Name)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := mkdirStrict(dir); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(renderSkillMD(backend, sk)), 0600); err != nil {
+	if err := writeFileStrict(filepath.Join(dir, "SKILL.md"), []byte(renderSkillMD(backend, sk))); err != nil {
 		return err
 	}
 
@@ -85,12 +91,55 @@ func writeSkill(backend Backend, root string, sk Skill) error {
 	// metadata and MCP dependencies. Only emit it when there is something to say.
 	if backend == BackendCodex && (len(sk.MCPDeps) > 0 || sk.ShortDescription != "") {
 		agentsDir := filepath.Join(dir, "agents")
-		if err := os.MkdirAll(agentsDir, 0700); err != nil {
+		if err := mkdirStrict(agentsDir); err != nil {
 			return err
 		}
-		if err := os.WriteFile(filepath.Join(agentsDir, "openai.yaml"), []byte(renderOpenAIYAML(sk)), 0600); err != nil {
+		if err := writeFileStrict(filepath.Join(agentsDir, "openai.yaml"), []byte(renderOpenAIYAML(sk))); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// Skill files hold no secrets, but they live among the user's CLI config, so we
+// keep them owner-only and deterministic regardless of the ambient umask.
+const (
+	dirPerm  os.FileMode = 0700
+	filePerm os.FileMode = 0600
+)
+
+// mkdirStrict creates dir (and parents) then chmods the leaf so umask can't
+// leave it more permissive than dirPerm.
+func mkdirStrict(dir string) error {
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return err
+	}
+	return os.Chmod(dir, dirPerm)
+}
+
+// writeFileStrict writes data then chmods the file to filePerm, so the result
+// is the same whatever the umask was.
+func writeFileStrict(path string, data []byte) error {
+	if err := os.WriteFile(path, data, filePerm); err != nil {
+		return err
+	}
+	return os.Chmod(path, filePerm)
+}
+
+// ensureWithinHome resolves symlinks on root and home and verifies root is
+// contained in home, so a redirected ~/.claude or ~/.codex can't escape.
+func ensureWithinHome(root, home string) error {
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	realHome, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(realHome, realRoot)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("skills: resolved dir %q escapes home %q", realRoot, realHome)
 	}
 	return nil
 }

--- a/internal/skills/materialize.go
+++ b/internal/skills/materialize.go
@@ -4,8 +4,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
+
+// skillNameRe constrains a skill slug to a single path segment of lowercase
+// alphanumerics, hyphens, and underscores. Since Name becomes a directory path
+// under the user's home, this guards against traversal ("../") or hidden-dir
+// ("." prefix) names — defense for the day the catalog is sourced externally.
+var skillNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 
 // Backend identifies which CLI's native skill format to render.
 type Backend string
@@ -52,6 +59,9 @@ func Materialize(backend Backend, home string) (*MaterializeResult, error) {
 
 	res := &MaterializeResult{Backend: backend, Dir: root}
 	for _, sk := range SortedCatalog() {
+		if !skillNameRe.MatchString(sk.Name) {
+			return nil, fmt.Errorf("skills: invalid skill name %q (must match %s)", sk.Name, skillNameRe)
+		}
 		if err := writeSkill(backend, root, sk); err != nil {
 			return nil, fmt.Errorf("write skill %q: %w", sk.Name, err)
 		}
@@ -110,6 +120,10 @@ func renderSkillMD(backend Backend, sk Skill) string {
 			b.WriteString("metadata:\n")
 			b.WriteString("  short-description: " + yamlScalar(sk.ShortDescription) + "\n")
 		}
+	default:
+		// Materialize validates the backend via SkillsDir before reaching here,
+		// so an unknown value is a programming error, not a runtime condition.
+		panic(fmt.Sprintf("skills: unknown backend %q", backend))
 	}
 
 	b.WriteString("---\n\n")
@@ -148,16 +162,53 @@ func renderOpenAIYAML(sk Skill) string {
 
 // yamlScalar renders a string as a YAML scalar, quoting only when needed so the
 // common case stays readable. Used for unquoted-by-default frontmatter keys.
+//
+// A backslash in a plain scalar is a literal (YAML only escapes inside double
+// quotes), so it does not force quoting — but control characters do, since they
+// can corrupt the frontmatter. This hardening matters most when the catalog is
+// ever fed from an external source rather than the in-repo definitions.
 func yamlScalar(s string) string {
-	if s == "" || strings.ContainsAny(s, ":#\"'\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") {
+	if s == "" || strings.ContainsAny(s, ":#\"'\n") || strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ") || hasControlChar(s) {
 		return yamlQuoted(s)
 	}
 	return s
 }
 
-// yamlQuoted renders a double-quoted YAML string with the minimal escaping YAML
-// requires inside double quotes.
+// hasControlChar reports whether s contains any C0 control character or DEL.
+func hasControlChar(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// yamlQuoted renders a double-quoted YAML string, escaping the metacharacters
+// and control characters that are illegal or ambiguous inside double quotes.
 func yamlQuoted(s string) string {
-	r := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`)
-	return `"` + r.Replace(s) + `"`
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\x%02x`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }

--- a/internal/skills/materialize_test.go
+++ b/internal/skills/materialize_test.go
@@ -111,10 +111,52 @@ func TestYAMLScalarQuoting(t *testing.T) {
 		"simple":          "simple",
 		"has: colon":      `"has: colon"`,
 		"trailing space ": `"trailing space "`,
+		// A backslash is literal in a plain scalar → stays unquoted.
+		`a\b`: `a\b`,
+		// Control characters force quoting and get escaped.
+		"tab\there":  `"tab\there"`,
+		"cr\rhere":   `"cr\rhere"`,
+		"nul\x00bye": `"nul\x00bye"`,
+		"esc\x1bseq": `"esc\x1bseq"`,
 	}
 	for in, want := range cases {
 		if got := yamlScalar(in); got != want {
 			t.Errorf("yamlScalar(%q) = %q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestYAMLQuotedEscapesBackslash(t *testing.T) {
+	if got := yamlQuoted(`a"b\c`); got != `"a\"b\\c"` {
+		t.Errorf("yamlQuoted = %q", got)
+	}
+}
+
+func TestCatalogNamesAreValid(t *testing.T) {
+	for _, sk := range Catalog {
+		if !skillNameRe.MatchString(sk.Name) {
+			t.Errorf("catalog skill name %q does not satisfy %s", sk.Name, skillNameRe)
+		}
+	}
+}
+
+// sast-presurgery has a ShortDescription but no MCPDeps: Codex should still get
+// an openai.yaml (for the UI blurb) but without a dependencies section.
+func TestMaterializeCodexShortDescWithoutMCPDeps(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Materialize(BackendCodex, home); err != nil {
+		t.Fatal(err)
+	}
+	yaml := filepath.Join(home, ".codex", "skills", "sast-presurgery", "agents", "openai.yaml")
+	data, err := os.ReadFile(yaml)
+	if err != nil {
+		t.Fatalf("expected openai.yaml for short-desc-only skill: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "short_description:") {
+		t.Errorf("missing short_description:\n%s", text)
+	}
+	if strings.Contains(text, "dependencies:") {
+		t.Errorf("should not emit dependencies section when MCPDeps empty:\n%s", text)
 	}
 }

--- a/internal/skills/materialize_test.go
+++ b/internal/skills/materialize_test.go
@@ -1,0 +1,120 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCatalogBodiesEmbed(t *testing.T) {
+	for _, sk := range Catalog {
+		if strings.TrimSpace(sk.Body()) == "" {
+			t.Errorf("skill %q has empty body", sk.Name)
+		}
+		if sk.Name == "" || sk.Description == "" {
+			t.Errorf("skill %q missing name or description", sk.Name)
+		}
+	}
+}
+
+func TestMaterializeCC(t *testing.T) {
+	home := t.TempDir()
+	res, err := Materialize(BackendCC, home)
+	if err != nil {
+		t.Fatalf("Materialize(cc): %v", err)
+	}
+	if len(res.Written) != len(Catalog) {
+		t.Fatalf("wrote %d skills, want %d", len(res.Written), len(Catalog))
+	}
+
+	for _, sk := range Catalog {
+		md := filepath.Join(home, ".claude", "skills", sk.Name, "SKILL.md")
+		data, err := os.ReadFile(md)
+		if err != nil {
+			t.Fatalf("read %s: %v", md, err)
+		}
+		text := string(data)
+		if !strings.HasPrefix(text, "---\n") {
+			t.Errorf("%s: missing frontmatter open", sk.Name)
+		}
+		if !strings.Contains(text, "name: "+sk.Name) {
+			t.Errorf("%s: frontmatter missing name", sk.Name)
+		}
+		if !strings.Contains(text, "description:") {
+			t.Errorf("%s: frontmatter missing description", sk.Name)
+		}
+		// Claude backend must NOT emit Codex's openai.yaml.
+		if _, err := os.Stat(filepath.Join(home, ".claude", "skills", sk.Name, "agents", "openai.yaml")); err == nil {
+			t.Errorf("%s: cc backend should not write agents/openai.yaml", sk.Name)
+		}
+	}
+}
+
+func TestMaterializeCodexEmitsOpenAIYAML(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Materialize(BackendCodex, home); err != nil {
+		t.Fatalf("Materialize(codex): %v", err)
+	}
+
+	// migrate-to-playwright declares the qmax MCP dep → expect openai.yaml.
+	yaml := filepath.Join(home, ".codex", "skills", "migrate-to-playwright", "agents", "openai.yaml")
+	data, err := os.ReadFile(yaml)
+	if err != nil {
+		t.Fatalf("read %s: %v", yaml, err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `value: "qmax"`) {
+		t.Errorf("openai.yaml missing qmax MCP dependency:\n%s", text)
+	}
+	if !strings.Contains(text, "allow_implicit_invocation: true") {
+		t.Errorf("openai.yaml missing invocation policy:\n%s", text)
+	}
+
+	// Codex SKILL.md should carry the short-description metadata, not allowed-tools.
+	md, err := os.ReadFile(filepath.Join(home, ".codex", "skills", "migrate-to-playwright", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(md), "short-description:") {
+		t.Errorf("codex SKILL.md missing short-description metadata")
+	}
+	if strings.Contains(string(md), "allowed-tools:") {
+		t.Errorf("codex SKILL.md should not carry allowed-tools")
+	}
+}
+
+func TestMaterializeIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Materialize(BackendCodex, home); err != nil {
+		t.Fatal(err)
+	}
+	md := filepath.Join(home, ".codex", "skills", "qa-triage", "SKILL.md")
+	first, err := os.ReadFile(md)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Materialize(BackendCodex, home); err != nil {
+		t.Fatal(err)
+	}
+	second, err := os.ReadFile(md)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(first) != string(second) {
+		t.Error("re-materializing changed the SKILL.md output")
+	}
+}
+
+func TestYAMLScalarQuoting(t *testing.T) {
+	cases := map[string]string{
+		"simple":          "simple",
+		"has: colon":      `"has: colon"`,
+		"trailing space ": `"trailing space "`,
+	}
+	for in, want := range cases {
+		if got := yamlScalar(in); got != want {
+			t.Errorf("yamlScalar(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/skills/materialize_test.go
+++ b/internal/skills/materialize_test.go
@@ -106,6 +106,47 @@ func TestMaterializeIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestMaterializeSetsDeterministicPerms(t *testing.T) {
+	home := t.TempDir()
+	if _, err := Materialize(BackendCodex, home); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(home, ".codex", "skills", "migrate-to-playwright")
+	di, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if di.Mode().Perm() != dirPerm {
+		t.Errorf("dir perms = %o, want %o", di.Mode().Perm(), dirPerm)
+	}
+	fi, err := os.Stat(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != filePerm {
+		t.Errorf("file perms = %o, want %o", fi.Mode().Perm(), filePerm)
+	}
+}
+
+func TestMaterializeRejectsSymlinkEscape(t *testing.T) {
+	home := t.TempDir()
+	evil := t.TempDir()
+	// Plant ~/.codex/skills as a symlink pointing outside home.
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(evil, filepath.Join(home, ".codex", "skills")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := Materialize(BackendCodex, home); err == nil {
+		t.Fatal("expected error materializing into a symlink that escapes home")
+	}
+	// And it must not have written any skill files into the escape target.
+	if _, err := os.Stat(filepath.Join(evil, "migrate-to-playwright", "SKILL.md")); err == nil {
+		t.Error("skill files were written outside home via symlink")
+	}
+}
+
 func TestYAMLScalarQuoting(t *testing.T) {
 	cases := map[string]string{
 		"simple":          "simple",


### PR DESCRIPTION
## What

Makes the qmax QA skills (`migrate-to-playwright`, `qa-quality-gate`, `sast-presurgery`, `qa-triage`, …) **convertable into both Claude Code and Codex sessions via orch** — the same setup path that already shares the qmax MCP tools.

## Why this approach (research-backed)

Both Claude Code and Codex (≥0.128) load **agent skills** from a `SKILL.md` folder with near-identical YAML frontmatter (`name` + `description`, auto-invoked by description match). That shared format is the universal substrate.

The earlier idea of exposing skills as **MCP prompts** was rejected: Codex does **not** yet surface MCP prompts as slash commands ([openai/codex#8342](https://github.com/openai/codex/issues/8342)). `SKILL.md` is consumed natively by both, so it's the right bridge. The qmax MCP **tools** the skills call are already shared via the existing global install.

## How

- **`internal/skills`** — one backend-neutral `Catalog` (embedded markdown bodies + per-backend enrichment) and a `Materialize(backend, home)` renderer:
  - Claude Code → `~/.claude/skills/<name>/SKILL.md` (with `allowed-tools` when declared)
  - Codex → `~/.codex/skills/<name>/SKILL.md` + `agents/openai.yaml` (MCP deps + `policy.allow_implicit_invocation`)
- **`RunOrch`** materializes the catalog right after the MCP install for the chosen backend. Non-fatal on error — MCP is the hard requirement, skills are additive.
- Adding a skill = drop a `catalog/<name>.md` body + append a `Skill` entry.

## Backend divergence handled from one definition

| | Claude Code | Codex |
|---|---|---|
| Tool gating | `allowed-tools:` frontmatter | `agents/openai.yaml` `dependencies.tools` |
| UI blurb | — | `metadata.short-description` + `openai.yaml` |
| Both | `name` + `description` core, auto-invoke | same |

## Tests

`internal/skills/materialize_test.go` — embed integrity, CC render (no stray `openai.yaml`), Codex render (`openai.yaml` carries the qmax MCP dep + policy; SKILL.md uses `short-description`, not `allowed-tools`), idempotency, YAML quoting. Full suite green; `go vet` + `gofmt` clean.

## Notes / follow-ups

- User-level install is the reliable target. Codex project-level skill loading has had regressions ([openai/codex#9752](https://github.com/openai/codex/issues/9752)); project-scope can be layered on later.
- Catalog currently embeds 4 representative skills to keep the diff reviewable; the rest from the skills menu drop in trivially. A future option is fetching the catalog per-project from the qmax API instead of embedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)