### PR TITLE
fix(orch): decouple skill install from one-time MCP guard (1.16.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.16.18] - 2026-06-04
+
+### Fixed
+- Skill materialization (1.16.17) never ran for users who already had the qmax MCP installed: it was nested inside `RunOrch`, which the REPL and startup gate behind `!IsOrchInstalled(backend)`. Since the guard short-circuits once the MCP entry exists, every existing orch user was locked out of the QA skills. Decoupled skill install from the one-time MCP guard — it now runs on every backend activation and every launch (idempotent), so the catalog reaches existing users and refreshes on upgrade. New `setup.InstallSkills` / `setup.InstallSkillsReport`.
+
 ## [1.16.17] - 2026-06-04
 
 ### Added

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -432,8 +432,11 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				}
 				cfg.OrchPermissionMode = consent.PermissionMode
 				cfg.OrchGlobalInstall = consent.GlobalInstall
-				if consent.GlobalInstall && !setup.IsOrchInstalled(result.Backend) {
-					setup.RunOrch(result.Backend, term)
+				if consent.GlobalInstall {
+					if !setup.IsOrchInstalled(result.Backend) {
+						setup.RunOrch(result.Backend, term)
+					}
+					setup.InstallSkillsReport(result.Backend, term)
 				}
 			}
 
@@ -554,8 +557,11 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				}
 				cfg.OrchPermissionMode = consent.PermissionMode
 				cfg.OrchGlobalInstall = consent.GlobalInstall
-				if consent.GlobalInstall && !setup.IsOrchInstalled("cc") {
-					setup.RunOrch("cc", term)
+				if consent.GlobalInstall {
+					if !setup.IsOrchInstalled("cc") {
+						setup.RunOrch("cc", term)
+					}
+					setup.InstallSkillsReport("cc", term)
 				}
 				cliAgent = agent.NewCCAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, ag.Cfg.Context)
 				cfg.Backend = "cc"
@@ -576,8 +582,11 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				}
 				cfg.OrchPermissionMode = consent.PermissionMode
 				cfg.OrchGlobalInstall = consent.GlobalInstall
-				if consent.GlobalInstall && !setup.IsOrchInstalled("codex") {
-					setup.RunOrch("codex", term)
+				if consent.GlobalInstall {
+					if !setup.IsOrchInstalled("codex") {
+						setup.RunOrch("codex", term)
+					}
+					setup.InstallSkillsReport("codex", term)
 				}
 				ca := agent.NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, ag.Cfg.Context)
 				if err := ca.WriteMCPConfig(); err != nil {

--- a/internal/setup/orch.go
+++ b/internal/setup/orch.go
@@ -133,7 +133,6 @@ func RunOrch(backend string, term *tui.Terminal) {
 		}
 		term.PrintSystem("Claude Code now has qmax tools in EVERY session (not just when spawned by qmax-code).")
 		term.PrintSystem("Run `claude` directly and qmax QA tools will be available automatically.")
-		materializeSkills(skills.BackendCC, term)
 
 	case "codex":
 		term.PrintSystem("Setting up Codex integration…")
@@ -148,21 +147,31 @@ func RunOrch(backend string, term *tui.Terminal) {
 			term.PrintSystem(fmt.Sprintf("qmax MCP entry added to %s", res.MCPPath))
 		}
 		term.PrintSystem("Codex now has qmax tools in every session.")
-		materializeSkills(skills.BackendCodex, term)
 	}
 }
 
-// materializeSkills writes the qmax skill catalog into the backend's native
-// skills directory so the QA skills auto-load in every CLI session, the same
-// way the MCP tools do. Failures are non-fatal — the MCP integration is the
-// hard requirement; skills are an additive convenience.
-func materializeSkills(backend skills.Backend, term *tui.Terminal) {
+// InstallSkills materializes the qmax QA skill catalog into the backend's
+// native skills directory (~/.claude/skills or ~/.codex/skills). It is
+// idempotent and refreshes the catalog on every call, so existing users pick up
+// new or updated skills on upgrade.
+//
+// It is deliberately decoupled from RunOrch's one-time MCP install: the MCP
+// entry is written once (guarded by IsOrchInstalled), but skills must keep
+// syncing on every activation/upgrade — otherwise anyone who already had the
+// MCP installed would never receive the skill catalog.
+func InstallSkills(backend string) (*skills.MaterializeResult, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		term.PrintError(fmt.Sprintf("Could not locate home dir for skill install: %v", err))
-		return
+		return nil, err
 	}
-	res, err := skills.Materialize(backend, home)
+	return skills.Materialize(skills.Backend(backend), home)
+}
+
+// InstallSkillsReport runs InstallSkills and reports the outcome to the
+// terminal. Non-fatal: skills are additive, so a failure is surfaced but does
+// not block backend activation.
+func InstallSkillsReport(backend string, term *tui.Terminal) {
+	res, err := InstallSkills(backend)
 	if err != nil {
 		term.PrintError(fmt.Sprintf("Skill install failed: %v", err))
 		return

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.17"
+var Version = "1.16.18"
 
 const Name = "qmax-code"
 
@@ -339,12 +339,21 @@ func main() {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
 			}
 		}
+		// Skills sync every launch (idempotent) so an upgraded catalog reaches
+		// users who already have the MCP installed. Independent of IsOrchInstalled.
+		if appConfig.OrchGlobalInstall {
+			_, _ = setup.InstallSkills("cc")
+		}
 		cliAgent = agent.NewCCAgent(agent.FindClaudeCode(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, appConfig.OutputVerbose, ctx)
 	case "codex":
 		if appConfig.OrchGlobalInstall && !setup.IsOrchInstalled("codex") {
 			if res, err := setup.InstallCodex(); err == nil && !res.AlreadyHadMCP {
 				fmt.Printf("  qmax MCP entry added to %s\n", res.MCPPath)
 			}
+		}
+		// Skills sync every launch (idempotent), independent of IsOrchInstalled.
+		if appConfig.OrchGlobalInstall {
+			_, _ = setup.InstallSkills("codex")
 		}
 		ca := agent.NewCodexAgent(agent.FindCodex(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, appConfig.OutputVerbose, ctx)
 		if err := ca.WriteMCPConfig(); err != nil {


### PR DESCRIPTION
## Bug

Skill materialization shipped in 1.16.17 (#117) **never ran for existing users**. The materialize call lived inside `RunOrch`, and every call site gates `RunOrch` behind `!setup.IsOrchInstalled(backend)`:

```go
if consent.GlobalInstall && !setup.IsOrchInstalled(backend) {
    setup.RunOrch(backend, term)   // skills were in here
}
```

Anyone who already had the qmax MCP entry in `~/.claude/settings.json` / `~/.codex/config.toml` (i.e. every prior orch user) hit the short-circuit → skills never materialized. Reproduced locally: `orch_global_install: true`, MCP present in both configs, `~/.claude/skills` and `~/.codex/skills` had none of the catalog.

## Fix

Decouple skills from the one-time MCP guard:

- **`setup.InstallSkills(backend)`** / **`setup.InstallSkillsReport(backend, term)`** — materialize the catalog independently. Idempotent (overwrites), so it also refreshes on catalog updates at upgrade time.
- **`repl.go`** (3 activation sites) — install skills whenever `GlobalInstall` is consented, regardless of `IsOrchInstalled`. MCP install stays guarded.
- **`main.go`** (cc/codex startup) — silent idempotent skill sync every launch.
- **`RunOrch`** is MCP-only again.

Verified: materializing into a real home now writes all 4 skills into both `~/.claude/skills` and `~/.codex/skills`, and a live Claude Code session picked them up.

Note: this is a backend-side install — skills surface **inside Claude Code / Codex sessions** (auto-invoked by description, or `$name` in Codex), not in qmax-code's own slash menu.

Bumps version to 1.16.18 + CHANGELOG. Tag `v1.16.18` after merge to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)