### PR TITLE
feat(skills): add 8 pure-static-analysis review skills to the catalog

### DIFF
--- a/internal/skills/catalog.go
+++ b/internal/skills/catalog.go
@@ -108,6 +108,57 @@ var Catalog = []Skill{
 		MCPDeps:          []MCPDep{qmaxDep},
 		bodyFile:         "qa-triage.md",
 	},
+	// The skills below are pure static-analysis / review passes: like
+	// sast-presurgery, they reason over the diff and source and do not drive the
+	// qmax test runner, so they declare no MCPDeps and work in either backend.
+	{
+		Name:             "diff-risk-review",
+		Description:      "Review the current git diff for correctness, security, and performance risk before it is committed, producing severity-ranked findings with file:line and a fix. Use before committing or opening a PR, or when the user asks what could be wrong with their changes.",
+		ShortDescription: "Risk-review the uncommitted diff",
+		bodyFile:         "diff-risk-review.md",
+	},
+	{
+		Name:             "secret-scan",
+		Description:      "Scan the working tree or git diff for hardcoded secrets: API keys, tokens, private keys, connection strings, and cloud credentials across common providers. Use before committing, or when the user worries a credential may have leaked into the code.",
+		ShortDescription: "Find hardcoded secrets before they're committed",
+		bodyFile:         "secret-scan.md",
+	},
+	{
+		Name:             "dependency-audit",
+		Description:      "Audit project dependencies for risk: known-vulnerable versions, unpinned ranges, abandoned packages, and badly outdated majors, across npm, pip, Go, Cargo, and Bundler. Use when the user asks about dependency risk, outdated packages, or supply-chain safety.",
+		ShortDescription: "Audit deps for vulns and rot",
+		bodyFile:         "dependency-audit.md",
+	},
+	{
+		Name:             "dead-code-scan",
+		Description:      "Find dead code in a repository: unused exports, unreferenced files, unreachable branches, and unused imports, each with a safe-to-remove confidence. Use when the user wants to clean up, asks what can be deleted, or is reducing maintenance surface.",
+		ShortDescription: "Find unused exports, files, and branches",
+		bodyFile:         "dead-code-scan.md",
+	},
+	{
+		Name:             "complexity-hotspots",
+		Description:      "Rank the most complex code in a repository: long functions, deep nesting, high cyclomatic complexity, and god-files, worst-first with a refactor for each. Use when the user wants to find refactor targets or asks which code is hardest to maintain.",
+		ShortDescription: "Rank refactor hotspots by complexity",
+		bodyFile:         "complexity-hotspots.md",
+	},
+	{
+		Name:             "error-handling-audit",
+		Description:      "Audit a repository or diff for weak error handling: swallowed exceptions, bare catches, floating promises, missing network timeouts/retries, and errors logged but not surfaced. Use when reviewing reliability, or when failures seem to disappear silently.",
+		ShortDescription: "Find swallowed errors and missing handling",
+		bodyFile:         "error-handling-audit.md",
+	},
+	{
+		Name:             "test-quality-review",
+		Description:      "Review an existing test suite for quality rather than coverage: assertion-free tests, weak assertions, skipped/only tests, over-mocking, and missing edge cases. Use when the user asks whether their tests actually test anything, or wants a test-suite quality audit.",
+		ShortDescription: "Audit whether tests actually assert anything",
+		bodyFile:         "test-quality-review.md",
+	},
+	{
+		Name:             "flaky-selector-scan",
+		Description:      "Scan a UI test suite (Playwright, Cypress, Selenium) for brittle locators such as nth-child, absolute XPath, and generated class hashes, and suggest stable role/data-test replacements. Use when UI tests keep breaking on redesigns or the user asks why their tests are flaky.",
+		ShortDescription: "Find brittle UI locators, suggest stable ones",
+		bodyFile:         "flaky-selector-scan.md",
+	},
 }
 
 // SortedCatalog returns the catalog ordered by name for deterministic output.

--- a/internal/skills/catalog/complexity-hotspots.md
+++ b/internal/skills/catalog/complexity-hotspots.md
@@ -1,0 +1,23 @@
+# Complexity Hotspots
+
+Rank the most complex code in a repository — long functions, deep nesting, high
+cyclomatic complexity, and god-files — worst-first, with a refactor for each.
+
+## Workflow
+
+1. **Use a metrics tool** if installed and parse it: `radon cc -s` (Python),
+   `lizard` (multi-language), `gocyclo` (Go), or the ESLint complexity rule.
+2. **Otherwise estimate** per function/method:
+   - **Length** (body lines), **nesting depth** (max control-flow indentation),
+   - **Cyclomatic complexity** (1 + count of `if/for/while/case/catch/&&/||/?:`),
+   - **Parameter count**. Also flag **god-files** doing many unrelated jobs.
+   Rough thresholds: length >50 warn / >100 bad · nesting >3 / >5 · cyclomatic
+   >10 / >20 · params >4 / >7 · file >400 / >800 lines.
+3. **Rank worst-first.** For each hotspot, name the dominant smell and a concrete
+   refactor (extract function, replace nested if-ladder with a dispatch table,
+   pass a params object, split the file).
+4. **Report** the top offenders with `file:line` and why each matters — these are
+   where defects cluster and change is hardest.
+
+Tie the recommendation to the metric. "Cyclomatic 31 → extract each branch"
+lands; "this looks complex" does not.

--- a/internal/skills/catalog/dead-code-scan.md
+++ b/internal/skills/catalog/dead-code-scan.md
@@ -1,0 +1,25 @@
+# Dead Code Scan
+
+Find dead code in a repository — unused exports, unreferenced files, unreachable
+branches, and unused imports — with a safe-to-remove confidence on each.
+
+## Workflow
+
+1. **Reach for a static analyzer** if present and parse it: `knip`/`ts-prune`
+   (JS/TS), `vulture` (Python), `deadcode`/`staticcheck` (Go).
+2. **Otherwise grep-and-reason**:
+   - Exported symbol with zero references outside its own file (and not a public
+     entry point) → candidate dead export.
+   - Imported name never used in the file → unused import.
+   - Module never imported anywhere and not a route/entry point → unreferenced
+     file.
+   - Statements after `return`/`throw`/`break`, or `if (false)` → unreachable.
+3. **Assign confidence, conservatively.** Anything reachable via dynamic import,
+   reflection, string-keyed dispatch, a public package export, or a framework
+   convention (routes, hooks, migrations, tasks) is **low confidence** — mark it
+   "verify before deleting", never "safe to remove".
+4. **Report** in two buckets: high-confidence removals (with `file:line`) and
+   verify-first items (with the reason each might still be live).
+
+When unsure, downgrade confidence. A false "safe to delete" costs far more than
+a missed dead function.

--- a/internal/skills/catalog/dependency-audit.md
+++ b/internal/skills/catalog/dependency-audit.md
@@ -1,0 +1,24 @@
+# Dependency Audit
+
+Audit project dependencies for risk — known-vulnerable versions, unpinned
+ranges, abandoned packages, and badly outdated majors.
+
+## Workflow
+
+1. **Detect the ecosystem** by manifest: `package.json`/lockfile (npm/pnpm/yarn),
+   `requirements.txt`/`pyproject.toml` (pip), `go.mod` (Go), `Cargo.toml` (Rust),
+   `Gemfile` (Ruby).
+2. **Run the native auditor** when the toolchain is present and parse it:
+   `npm audit --json`, `pip-audit -f json`, `go list -m -u all`, `cargo audit`.
+   Fall back to reasoning over the manifest if no auditor is available.
+3. **Classify** each dependency:
+   - **Vulnerable** — flagged by the auditor (CVE/advisory).
+   - **Unpinned** — `*`/`latest`/no lock entry; non-reproducible builds.
+   - **Wide range** — `^`/`~` on a 0.x package, where any minor can break.
+   - **Outdated** — several majors behind current.
+   - **Abandoned** — archived upstream / no release in a long time.
+4. **Report** worst-first (vulnerabilities lead), each with the concrete bump or
+   replacement command and a note on breaking-change risk.
+
+Distinguish "must fix now" (exploitable vulnerability) from "hygiene" (pin,
+upgrade) so the reader knows what blocks a release.

--- a/internal/skills/catalog/diff-risk-review.md
+++ b/internal/skills/catalog/diff-risk-review.md
@@ -1,0 +1,25 @@
+# Diff Risk Review
+
+Review the current git diff for correctness, security, and performance risk
+before it is committed — a focused second pass over only what changed.
+
+## Workflow
+
+1. **Get the change** — `git diff` and `git diff --staged` for uncommitted work,
+   or `git diff <base>...HEAD` for a branch. Review only the changed hunks.
+2. **Inspect each hunk** against three lenses:
+   - **Correctness** — off-by-one, inverted conditions, wrong operator, null
+     deref on newly accessed fields, a changed signature with un-updated callers,
+     missing `await` / unhandled rejection / race on shared state.
+   - **Security** — user input reaching SQL, shell, `eval`, file paths, or HTML
+     without sanitization; a new route/handler missing an ownership or permission
+     check (BOLA); logging that now emits tokens or PII.
+   - **Performance** — a new N+1 query, unbounded allocation on user-controlled
+     size, or work moved onto a hot path.
+3. **Rank** — BLOCKER (breaks or is exploitable) · WARNING (likely bug/risk) ·
+   NIT (clarity). Cite `file:line` for every finding.
+4. **Report** — findings worst-first, each with the concrete fix. If a hunk is
+   clean, say so rather than padding.
+
+Only report findings you can justify from the diff. A review that flags
+everything trains the reader to ignore it.

--- a/internal/skills/catalog/error-handling-audit.md
+++ b/internal/skills/catalog/error-handling-audit.md
@@ -1,0 +1,25 @@
+# Error Handling Audit
+
+Audit a repository or diff for weak error handling — places where failures
+disappear silently instead of being surfaced or recovered.
+
+## Workflow
+
+1. **Scope** — whole repo, a directory, or the pending `git diff` (default to the
+   diff when changes are staged).
+2. **Flag the anti-patterns**:
+   - **Swallowed** — `except: pass`, `except Exception: pass`, `catch (e) {}`,
+     empty/comment-only handlers with no log, rethrow, or recovery.
+   - **Over-broad** — `except Exception` / `catch (Throwable)` that hides bugs
+     which should crash, or returns a default that masks the failure.
+   - **Async** — a floating promise (not `await`ed, no `.catch`), `Promise.all`
+     dropping siblings on one rejection, no top-level rejection handler.
+   - **Network/IO** — HTTP call with no timeout, no retry/backoff on a flaky
+     dependency, a resource opened without `finally`/`with`/`defer` cleanup.
+   - **Observability** — error caught and logged but the caller still gets a
+     success; `logger.error(e)` with no stack/context.
+3. **Report** each with `file:line`, the risk (what failure becomes invisible),
+   and the fix.
+
+The question for every handler: if this fails in production, does anyone find
+out? If not, it's a finding.

--- a/internal/skills/catalog/flaky-selector-scan.md
+++ b/internal/skills/catalog/flaky-selector-scan.md
@@ -1,0 +1,23 @@
+# Flaky Selector Scan
+
+Scan a UI test suite (Playwright, Cypress, Selenium) for brittle locators that
+will break on the next redesign, and suggest stable replacements.
+
+## Workflow
+
+1. **Find UI tests** (`*.spec.ts`, `*.cy.js`, Selenium page objects) and extract
+   locators from `page.locator`, `getBy*`, `$(...)`, `find_element`, `cy.get`.
+2. **Classify each by fragility**:
+   - **Absolute XPath** — `/html/body/div[2]/…`, breaks on any DOM reshuffle.
+   - **Positional CSS** — `:nth-child(3)`, breaks when order/count changes.
+   - **Generated class** — `.css-1a2b3c`, `.MuiBox-root-42`, changes every build.
+   - **Deep descendant** — `div div span.label`, coupled to layout nesting.
+   - **Index-based** — `.locator('button').nth(4)`, breaks when buttons are added.
+   Stable (good): `getByRole(..., { name })`, `data-test`/`data-testid`,
+   `getByLabel`, stable `id`, ARIA roles.
+3. **For each brittle locator** give `file:line`, the fragility class, and a
+   concrete stable alternative (often: add a `data-test` attribute and target it).
+4. **Report** ranked by risk, plus a per-file count so the worst suites stand out.
+
+Prefer role- and test-id-based locators in every suggestion — they survive
+restyles and copy changes that positional selectors can't.

--- a/internal/skills/catalog/secret-scan.md
+++ b/internal/skills/catalog/secret-scan.md
@@ -1,0 +1,26 @@
+# Secret Scan
+
+Scan the working tree or git diff for hardcoded secrets — API keys, tokens,
+private keys, connection strings, cloud credentials — before they reach history.
+
+## Workflow
+
+1. **Scope** — default to `git diff` + `git diff --staged` (what's about to land);
+   on request, scan all tracked files (skip `.git`, `node_modules`, lockfiles,
+   build output, binaries).
+2. **Match** the high-signal signatures: AWS keys (`AKIA…`, 40-char secrets),
+   Google `AIza…`, GitHub `ghp_`/`gho_`/`github_pat_`, Slack `xox[baprs]-`,
+   Stripe `sk_live_`, OpenAI/Anthropic `sk-`/`sk-ant-`, `-----BEGIN … PRIVATE
+   KEY-----`, JWTs, `postgres|mysql|mongodb|redis://user:pass@…` URLs, and generic
+   `(password|secret|token|api_key) = "…"` assignments.
+3. **Triage** each hit:
+   - **Real secret** → BLOCKER. Recommend remove, **rotate** (it's compromised
+     once committed), and move to env / secret store.
+   - **Placeholder** (`your-key-here`, `xxxx`, `${…}`, obvious fixture) → note as
+     ignored.
+   - Already committed → flag that rotation is required regardless of removal.
+4. **Report** with `file:line` and the value **masked to the first 4 chars** —
+   never echo a full live secret.
+
+Precision matters more than recall here: mask aggressively and don't dump
+secrets into the report you're trying to protect.

--- a/internal/skills/catalog/test-quality-review.md
+++ b/internal/skills/catalog/test-quality-review.md
@@ -1,0 +1,26 @@
+# Test Quality Review
+
+Review an existing test suite for quality rather than coverage — tests that look
+green but assert little or nothing.
+
+## Workflow
+
+1. **Find the tests** (`*.test.*`, `*.spec.*`, `*_test.go`, `test_*.py`) and read
+   them.
+2. **Flag the quality smells**:
+   - **No real assertion** — exercises code but never asserts, `expect(true)`,
+     snapshot-only with no meaningful check, a test that can't fail.
+   - **Weak assertion** — `toBeTruthy()`/`assert result` where an exact value is
+     knowable; asserts status code but not body; asserts length but not contents.
+   - **Disabled/hidden** — `.skip`, `.only`, `xit`, `xdescribe`, `test.todo`,
+     `describe.skip`, commented-out tests (`.only` is the worst — it silently
+     drops the rest of the file from CI).
+   - **Over-mocking** — mocks the unit under test, or asserts a mock was called
+     but never that the result is correct.
+   - **Missing edge cases** — happy path only for logic with empty/null/error/
+     boundary cases; hardcoded `sleep`, real network/time/random without control.
+3. **Report** per finding with `file:line`, why it's weak, and the stronger
+   assertion to write.
+
+A passing test that asserts nothing is worse than no test — it buys false
+confidence. Call those out first.


### PR DESCRIPTION
## What

Grows the materialized skill catalog from **4 → 12** by porting the no-MCP code- and test-review skills from [`free-qa-skills`](https://github.com/Quality-Max/free-qa-skills) (PR #2 there) into the orch catalog, so they install into both Claude Code and Codex:

- `diff-risk-review` — risk-review the uncommitted diff (correctness / security / perf)
- `secret-scan` — hardcoded keys, tokens, private keys, connection strings
- `dependency-audit` — vulnerable / unpinned / abandoned / outdated packages
- `dead-code-scan` — unused exports, unreferenced files, unreachable branches
- `complexity-hotspots` — long functions, deep nesting, cyclomatic, god-files
- `error-handling-audit` — swallowed exceptions, floating promises, missing timeouts
- `test-quality-review` — assertion-free/weak tests, skip/only, over-mocking
- `flaky-selector-scan` — brittle UI locators → stable role/data-test suggestions

## Why these, this way

These are pure static-analysis / review passes. Like the existing `sast-presurgery`, they reason over the diff and source rather than driving the qmax test runner — so they declare **no `MCPDeps`** and materialize cleanly into either backend with no `dependencies.tools`. That's exactly why this subset was the natural first port: zero MCP surface to reconcile.

Adding a skill follows the documented pattern: drop a `catalog/<name>.md` body (no frontmatter — it's generated from the struct) and append a `Skill` entry to `Catalog`.

## Tests

- `gofmt -l` clean, `go vet ./internal/skills/` clean
- `go test ./internal/skills/` passes — the count assertion is `len(Catalog)`-relative, so it tracks the new entries automatically; embed-integrity, CC/Codex render, and YAML-quoting tests all still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)