### PR TITLE
chore: bump version to 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.17.0] - 2026-06-04
+
+### Added
+- Eight pure-static-analysis review skills added to the orch catalog (#120): `diff-risk-review`, `secret-scan`, `dependency-audit`, `dead-code-scan`, `complexity-hotspots`, `error-handling-audit`, `test-quality-review`, `flaky-selector-scan`. Like `sast-presurgery`, they reason over the diff/source and declare no MCP dependency, so they work in both Claude Code and Codex sessions. The catalog now ships 12 skills, materialized into `~/.claude/skills` and `~/.codex/skills`.
+
 ## [1.16.18] - 2026-06-04
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.16.18"
+var Version = "1.17.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Minor bump covering #120 — 8 new pure-static-analysis review skills in the orch catalog (`diff-risk-review`, `secret-scan`, `dependency-audit`, `dead-code-scan`, `complexity-hotspots`, `error-handling-audit`, `test-quality-review`, `flaky-selector-scan`). Catalog now ships 12 skills, materialized into both Claude Code and Codex.

Tag `v1.17.0` after merge to release.

- `main.go`: `1.16.18` → `1.17.0`
- `CHANGELOG.md`: 1.17.0 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)