### PR TITLE
Enable GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,4 @@
+github:
+- Quality-Max
 custom:
-  - https://buymeacoffee.com/qualitymax
+- https://buymeacoffee.com/qualitymax


### PR DESCRIPTION
## Summary
- add the Quality-Max GitHub Sponsors profile
- preserve the existing Buy Me a Coffee funding link

This repository has a local funding file, so it must be updated directly instead of inheriting the organization default.