### PR TITLE
fix: correct Claude Code keychain service name and dot-prefixed credentials file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [1.18.3] - 2026-06-22
+
+### Fixed
+- Fixed Claude Code credential lookup on macOS by checking the correct Keychain service name `"Claude Code-credentials"` and added support for `.credentials.json` (leading dot) fallbacks.
+
 ## [1.18.2] - 2026-06-22
 
 ### Added

--- a/claude_code_command.go
+++ b/claude_code_command.go
@@ -36,12 +36,19 @@ func handleCCCommand(args []string) error {
 
 func loadClaudeCodeFromKeychain() (string, error) {
 	if runtime.GOOS == "darwin" {
-		cmd := exec.Command("security", "find-generic-password", "-s", "claude-code", "-w")
+		// Try "Claude Code-credentials" first
+		cmd := exec.Command("security", "find-generic-password", "-s", "Claude Code-credentials", "-w")
 		out, err := cmd.Output()
-		if err != nil {
-			return "", fmt.Errorf("not found in macOS keychain")
+		if err == nil {
+			return strings.TrimSpace(string(out)), nil
 		}
-		return strings.TrimSpace(string(out)), nil
+		// Fallback to "claude-code"
+		cmd = exec.Command("security", "find-generic-password", "-s", "claude-code", "-w")
+		out, err = cmd.Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+		return "", fmt.Errorf("not found in macOS keychain")
 	}
 	return "", fmt.Errorf("keychain not supported on %s", runtime.GOOS)
 }
@@ -61,9 +68,15 @@ func readClaudeCodeAuth() (string, error) {
 	}
 
 	paths := []string{
-		filepath.Join(home, ".config", "claude", "credentials.json"),
+		filepath.Join(home, ".claude", ".credentials.json"),
 		filepath.Join(home, ".claude", "credentials.json"),
+		filepath.Join(home, ".config", "claude", ".credentials.json"),
+		filepath.Join(home, ".config", "claude", "credentials.json"),
+		filepath.Join(home, ".config", "claude-code", ".credentials.json"),
 		filepath.Join(home, ".config", "claude-code", "credentials.json"),
+		filepath.Join(home, "Library", "Application Support", "Claude", "claude-code", ".credentials.json"),
+		filepath.Join(home, "Library", "Application Support", "Claude", "claude-code", "credentials.json"),
+		filepath.Join(home, "Library", "Application Support", "claude", "claude-code", ".credentials.json"),
 		filepath.Join(home, "Library", "Application Support", "claude", "claude-code", "credentials.json"),
 	}
 

--- a/claude_code_command_test.go
+++ b/claude_code_command_test.go
@@ -33,6 +33,29 @@ func TestReadClaudeCodeAuthFile(t *testing.T) {
 	}
 }
 
+func TestReadClaudeCodeAuthFileDot(t *testing.T) {
+	home := withTempHome(t)
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, ".credentials.json"),
+		[]byte(`{"tokens":{"access_token":"access-dot"}}`),
+		0600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readClaudeCodeAuth()
+	if err != nil {
+		t.Fatalf("readClaudeCodeAuth: %v", err)
+	}
+	if got != `{"tokens":{"access_token":"access-dot"}}` {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
 func TestConnectClaudeCodeRunsAndUsesAuthenticatedUpload(t *testing.T) {
 	oldLoad := loadQualityMaxAuthForCC
 	oldLogin := loginQualityMaxForCC

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.18.2"
+var Version = "1.18.3"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Fixes Claude Code connection by checking the correct Keychain service name 'Claude Code-credentials' and adds support for '.credentials.json' (leading dot) fallback paths.