### PR TITLE
feat: Cerebras inference backend (native function calling, /orch selectable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Cerebras inference backend.** Select `backend=cerebras` to drive the native
+  qmax agent loop through Cerebras's OpenAI-compatible API using native function
+  calling against the full qmax tool set — fast and low-cost, no Anthropic key or
+  external CLI required. Configure with `CEREBRAS_API_KEY` (stored in the OS
+  keychain) plus optional `cerebras_model` (default `gpt-oss-120b`) and
+  `cerebras_base_url` (default `https://api.cerebras.ai/v1`). Activate via
+  `qmax-code config set backend cerebras`, `--backend cerebras`, or the
+  `CEREBRAS_API_BASE` / `CEREBRAS_MODEL` env vars. Works in both interactive and
+  one-shot modes.
+- Cerebras is selectable in the `/orch` model picker (its own section with
+  `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b` (vision, preview), plus a
+  key-status indicator). Choosing it prompts
+  for the API key inline when one isn't configured yet (blank cancels), saving it
+  to the OS keychain.
+
 ## [1.18.3] - 2026-06-22
 
 ### Fixed

--- a/config_command.go
+++ b/config_command.go
@@ -99,6 +99,21 @@ func printConfig() {
 	} else {
 		fmt.Println("    ollama_url        = (not set)")
 	}
+	if cfg.CerebrasKey != "" {
+		fmt.Println("    cerebras_key      = (set; stored in OS keychain)")
+	} else {
+		fmt.Println("    cerebras_key      = (not set)")
+	}
+	cerebrasModel := cfg.CerebrasModel
+	if cerebrasModel == "" {
+		cerebrasModel = api.CerebrasDefaultModel + " (default)"
+	}
+	fmt.Printf("    cerebras_model    = %q\n", cerebrasModel)
+	cerebrasBase := cfg.CerebrasBaseURL
+	if cerebrasBase == "" {
+		cerebrasBase = api.CerebrasAPIBase + " (default)"
+	}
+	fmt.Printf("    cerebras_base_url = %q\n", cerebrasBase)
 	backend := cfg.Backend
 	if backend == "" {
 		backend = "api"
@@ -131,6 +146,12 @@ func printConfig() {
 			fmt.Printf("  (codex found: %s)", bin)
 		} else {
 			fmt.Print("  (WARNING: codex binary not found in PATH)")
+		}
+	case "cerebras":
+		if cfg.CerebrasKey != "" {
+			fmt.Printf("  (cerebras key set; model: %s)", cerebrasModel)
+		} else {
+			fmt.Print("  (WARNING: CEREBRAS_API_KEY not set)")
 		}
 	}
 	fmt.Println()
@@ -210,11 +231,30 @@ func setConfigField(key, value string) error {
 
 	case "backend":
 		switch value {
-		case "", "api", "cc", "codex":
+		case "", "api", "cc", "codex", "cerebras":
 			cfg.Backend = value
 		default:
-			return fmt.Errorf("invalid backend %q; allowed: api, cc, codex", value)
+			return fmt.Errorf("invalid backend %q; allowed: api, cc, codex, cerebras", value)
 		}
+
+	case "cerebras_key":
+		// Stored in the OS keychain, never in config.json. Empty clears it.
+		if value != "" {
+			looks, verr := api.ValidateCerebrasKey(value)
+			if verr != nil {
+				return fmt.Errorf("invalid cerebras_key: %w", verr)
+			}
+			if !looks {
+				fmt.Fprintln(os.Stderr, "  Note: key doesn't start with \"csk-\" — double-check it's a Cerebras key.")
+			}
+		}
+		return api.SaveCerebrasKey(value)
+
+	case "cerebras_model":
+		cfg.CerebrasModel = value
+
+	case "cerebras_base_url":
+		cfg.CerebrasBaseURL = value
 
 	case "theme":
 		return tui.SaveTheme(cfg, value)

--- a/config_command.go
+++ b/config_command.go
@@ -49,7 +49,7 @@ func handleConfigCommand(args []string) {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("  Set %s = %s\n", args[1], args[2])
+		fmt.Printf("  Set %s = %s\n", args[1], configSetDisplayValue(args[1], args[2]))
 
 	case "unset":
 		if len(args) < 2 {
@@ -292,4 +292,16 @@ func parseConfigBool(s string) (bool, error) {
 		return true, nil
 	}
 	return false, fmt.Errorf("expected true/false, got %q", s)
+}
+
+func configSetDisplayValue(key, value string) string {
+	switch key {
+	case "cerebras_key":
+		if value == "" {
+			return "(cleared)"
+		}
+		return "(set; stored in OS keychain)"
+	default:
+		return value
+	}
 }

--- a/config_command_test.go
+++ b/config_command_test.go
@@ -80,6 +80,23 @@ func TestSetConfigField_CerebrasModelAndBaseURL(t *testing.T) {
 	}
 }
 
+func TestConfigSetDisplayValueRedactsCerebrasKey(t *testing.T) {
+	secret := "csk-vv52c6kwywjmejmnp8xd8c2p4"
+	got := configSetDisplayValue("cerebras_key", secret)
+	if got == secret || got == "" {
+		t.Fatalf("cerebras_key display was not redacted: %q", got)
+	}
+	if got != "(set; stored in OS keychain)" {
+		t.Fatalf("cerebras_key display = %q", got)
+	}
+	if got := configSetDisplayValue("cerebras_key", ""); got != "(cleared)" {
+		t.Fatalf("cleared cerebras_key display = %q", got)
+	}
+	if got := configSetDisplayValue("cerebras_model", "gemma-4-31b"); got != "gemma-4-31b" {
+		t.Fatalf("non-secret display changed: %q", got)
+	}
+}
+
 func TestSetConfigField_DefaultModelValidation(t *testing.T) {
 	withTempHome(t)
 

--- a/config_command_test.go
+++ b/config_command_test.go
@@ -42,6 +42,44 @@ func TestSetConfigField_DefaultFrameworkRejectsBadValues(t *testing.T) {
 	}
 }
 
+func TestSetConfigField_BackendValidation(t *testing.T) {
+	withTempHome(t)
+
+	for _, b := range []string{"api", "cc", "codex", "cerebras", ""} {
+		if err := setConfigField("backend", b); err != nil {
+			t.Errorf("backend %q should be accepted: %v", b, err)
+		}
+	}
+	if err := setConfigField("backend", "gpt"); err == nil {
+		t.Error("expected error for unknown backend")
+	}
+
+	if err := setConfigField("backend", "cerebras"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded := api.LoadQMaxCodeConfig(); loaded.Backend != "cerebras" {
+		t.Errorf("Backend: got %q, want cerebras", loaded.Backend)
+	}
+}
+
+func TestSetConfigField_CerebrasModelAndBaseURL(t *testing.T) {
+	withTempHome(t)
+
+	if err := setConfigField("cerebras_model", "zai-glm-4.7"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := setConfigField("cerebras_base_url", "https://proxy.internal/v1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	loaded := api.LoadQMaxCodeConfig()
+	if loaded.CerebrasModel != "zai-glm-4.7" {
+		t.Errorf("CerebrasModel: got %q, want zai-glm-4.7", loaded.CerebrasModel)
+	}
+	if loaded.CerebrasBaseURL != "https://proxy.internal/v1" {
+		t.Errorf("CerebrasBaseURL: got %q", loaded.CerebrasBaseURL)
+	}
+}
+
 func TestSetConfigField_DefaultModelValidation(t *testing.T) {
 	withTempHome(t)
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,8 +63,9 @@ type Agent struct {
 	History   []api.Message
 	Usage     api.TokenUsage
 	Logger    *sysutil.Logger
-	Ollama    *OllamaClient // optional self-hosted LLM
-	Mode      OllamaMode    // off, chat, or full
+	Ollama    *OllamaClient   // optional self-hosted LLM
+	Mode      OllamaMode      // off, chat, or full
+	Cerebras  *CerebrasClient // optional Cerebras backend; when set, owns the whole turn
 
 	tools           []api.ToolDef
 	client          *http.Client
@@ -325,6 +326,15 @@ func (a *Agent) RunStreaming(prompt string, term *tui.Terminal) (string, error) 
 }
 
 func (a *Agent) runStreamingLoop(term *tui.Terminal) (string, error) {
+	// Cerebras backend owns the entire turn via its own native function-calling
+	// loop (full tool set). No Claude fallback — the user has no Anthropic key.
+	if a.Cerebras != nil {
+		if out, ok := a.RunCerebrasAgent(term); ok {
+			return out, nil
+		}
+		return "", fmt.Errorf("cerebras backend request failed")
+	}
+
 	for iterations := 0; iterations < maxIterations; iterations++ {
 		// Sanitize + compress history before each API call
 		session.SanitizeSessionMessages(a.History)

--- a/internal/agent/cerebras.go
+++ b/internal/agent/cerebras.go
@@ -1,0 +1,280 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/qualitymax/qmax-code/internal/api"
+)
+
+// Cerebras integration — drive the full native agent loop through Cerebras's
+// OpenAI-compatible /v1/chat/completions endpoint using native function
+// calling. Unlike the Ollama path (prompt-based dispatch over ~10 actions),
+// this exposes the complete qmax tool set, so Cerebras can handle all coding
+// tasks directly.
+
+// CerebrasClient wraps HTTP calls to a Cerebras (OpenAI-compatible) endpoint.
+type CerebrasClient struct {
+	BaseURL string // e.g. "https://api.cerebras.ai/v1"
+	Model   string // e.g. "gpt-oss-120b"
+	APIKey  string
+	HTTP    *http.Client
+}
+
+// NewCerebrasClient builds a client from config, or returns nil if no API key
+// is configured. Base URL and model fall back to the package defaults.
+func NewCerebrasClient(cfg *api.Config) *CerebrasClient {
+	if cfg == nil || cfg.CerebrasKey == "" {
+		return nil
+	}
+	base := cfg.CerebrasBaseURL
+	if base == "" {
+		base = api.CerebrasAPIBase
+	}
+	model := cfg.CerebrasModel
+	if model == "" {
+		model = api.CerebrasDefaultModel
+	}
+	return &CerebrasClient{
+		BaseURL: strings.TrimRight(base, "/"),
+		Model:   model,
+		APIKey:  cfg.CerebrasKey,
+		HTTP:    &http.Client{Timeout: 300 * time.Second},
+	}
+}
+
+// ── OpenAI-compatible wire types ──────────────────────────────────────────
+
+type oaiTool struct {
+	Type     string      `json:"type"` // always "function"
+	Function oaiFunction `json:"function"`
+}
+
+type oaiFunction struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+type oaiToolCallFn struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON-encoded string
+}
+
+type oaiToolCall struct {
+	ID       string        `json:"id"`
+	Type     string        `json:"type"` // "function"
+	Function oaiToolCallFn `json:"function"`
+}
+
+type oaiMessage struct {
+	Role       string        `json:"role"` // system | user | assistant | tool
+	Content    string        `json:"content"`
+	ToolCalls  []oaiToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string        `json:"tool_call_id,omitempty"` // for role="tool"
+}
+
+type oaiChatRequest struct {
+	Model       string       `json:"model"`
+	Messages    []oaiMessage `json:"messages"`
+	Tools       []oaiTool    `json:"tools,omitempty"`
+	MaxTokens   int          `json:"max_tokens,omitempty"`
+	Temperature float64      `json:"temperature"`
+	Stream      bool         `json:"stream"`
+}
+
+type oaiChatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content   string        `json:"content"`
+			ToolCalls []oaiToolCall `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+// Chat performs a single non-streaming chat completion. Cerebras is fast
+// enough (~1000+ tok/s) that non-streaming keeps the tool loop simple and the
+// tool-call parsing reliable.
+func (c *CerebrasClient) Chat(ctx context.Context, msgs []oaiMessage, tools []oaiTool) (*oaiChatResponse, error) {
+	reqBody := oaiChatRequest{
+		Model:       c.Model,
+		Messages:    msgs,
+		Tools:       tools,
+		MaxTokens:   8192,
+		Temperature: 0,
+		Stream:      false,
+	}
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.BaseURL+"/chat/completions", bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cerebras request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cerebras error %d: %s", resp.StatusCode, string(body))
+	}
+
+	var out oaiChatResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	return &out, nil
+}
+
+// toolDefsToOpenAI converts qmax tool definitions (Anthropic-shaped:
+// name/description/input_schema) into OpenAI function-calling tools.
+func toolDefsToOpenAI(defs []api.ToolDef) []oaiTool {
+	out := make([]oaiTool, 0, len(defs))
+	for _, d := range defs {
+		params := d.InputSchema
+		if params == nil {
+			params = map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			}
+		}
+		out = append(out, oaiTool{
+			Type: "function",
+			Function: oaiFunction{
+				Name:        d.Name,
+				Description: d.Description,
+				Parameters:  params,
+			},
+		})
+	}
+	return out
+}
+
+// normalizeContent flattens a message Content (string, []api.ContentBlock, or
+// []interface{} after a JSON round-trip) into typed blocks. The bool return is
+// true when the content was a plain string (text returned in the string).
+func normalizeContent(content interface{}) ([]api.ContentBlock, string, bool) {
+	switch v := content.(type) {
+	case string:
+		return nil, v, true
+	case []api.ContentBlock:
+		return v, "", false
+	case []interface{}:
+		blocks := make([]api.ContentBlock, 0, len(v))
+		for _, raw := range v {
+			m, ok := raw.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			b := api.ContentBlock{}
+			b.Type, _ = m["type"].(string)
+			b.Text, _ = m["text"].(string)
+			b.ID, _ = m["id"].(string)
+			b.Name, _ = m["name"].(string)
+			b.ToolUseID, _ = m["tool_use_id"].(string)
+			b.Content, _ = m["content"].(string)
+			if in, ok := m["input"]; ok {
+				b.Input = in
+			}
+			blocks = append(blocks, b)
+		}
+		return blocks, "", false
+	case nil:
+		return nil, "", true
+	}
+	return nil, "", true
+}
+
+// historyToOpenAI converts qmax conversation history (Anthropic Messages
+// shape) into OpenAI chat messages, mapping tool_use → assistant tool_calls
+// and tool_result → role:"tool" messages. Images are dropped (text-only
+// models); callers that need vision should select a multimodal Cerebras model
+// and a future content-array path.
+func historyToOpenAI(system string, history []api.Message) []oaiMessage {
+	msgs := make([]oaiMessage, 0, len(history)+1)
+	if system != "" {
+		msgs = append(msgs, oaiMessage{Role: "system", Content: system})
+	}
+
+	for _, m := range history {
+		blocks, plain, isString := normalizeContent(m.Content)
+		if isString {
+			msgs = append(msgs, oaiMessage{Role: m.Role, Content: plain})
+			continue
+		}
+
+		switch m.Role {
+		case "assistant":
+			var text strings.Builder
+			var toolCalls []oaiToolCall
+			for _, b := range blocks {
+				switch b.Type {
+				case "text":
+					text.WriteString(b.Text)
+				case "tool_use":
+					args := "{}"
+					if b.Input != nil {
+						if raw, err := json.Marshal(b.Input); err == nil {
+							args = string(raw)
+						}
+					}
+					toolCalls = append(toolCalls, oaiToolCall{
+						ID:       b.ID,
+						Type:     "function",
+						Function: oaiToolCallFn{Name: b.Name, Arguments: args},
+					})
+				}
+			}
+			msgs = append(msgs, oaiMessage{
+				Role:      "assistant",
+				Content:   text.String(),
+				ToolCalls: toolCalls,
+			})
+
+		default: // user (and any other role with block content)
+			var hasToolResult bool
+			for _, b := range blocks {
+				if b.Type == "tool_result" {
+					hasToolResult = true
+					msgs = append(msgs, oaiMessage{
+						Role:       "tool",
+						ToolCallID: b.ToolUseID,
+						Content:    b.Content,
+					})
+				}
+			}
+			if !hasToolResult {
+				var text strings.Builder
+				for _, b := range blocks {
+					if b.Type == "text" {
+						text.WriteString(b.Text)
+					}
+				}
+				msgs = append(msgs, oaiMessage{Role: m.Role, Content: text.String()})
+			}
+		}
+	}
+	return msgs
+}

--- a/internal/agent/cerebras.go
+++ b/internal/agent/cerebras.go
@@ -75,9 +75,19 @@ type oaiToolCall struct {
 
 type oaiMessage struct {
 	Role       string        `json:"role"` // system | user | assistant | tool
-	Content    string        `json:"content"`
+	Content    interface{}   `json:"content"`
 	ToolCalls  []oaiToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string        `json:"tool_call_id,omitempty"` // for role="tool"
+}
+
+type oaiContentPart struct {
+	Type     string       `json:"type"`
+	Text     string       `json:"text,omitempty"`
+	ImageURL *oaiImageURL `json:"image_url,omitempty"`
+}
+
+type oaiImageURL struct {
+	URL string `json:"url"`
 }
 
 type oaiChatRequest struct {
@@ -198,6 +208,15 @@ func normalizeContent(content interface{}) ([]api.ContentBlock, string, bool) {
 			if in, ok := m["input"]; ok {
 				b.Input = in
 			}
+			if source, ok := m["source"].(map[string]interface{}); ok {
+				img := &api.ImageSource{}
+				img.Type, _ = source["type"].(string)
+				img.MediaType, _ = source["media_type"].(string)
+				img.Data, _ = source["data"].(string)
+				if img.MediaType != "" && img.Data != "" {
+					b.Source = img
+				}
+			}
 			blocks = append(blocks, b)
 		}
 		return blocks, "", false
@@ -209,9 +228,9 @@ func normalizeContent(content interface{}) ([]api.ContentBlock, string, bool) {
 
 // historyToOpenAI converts qmax conversation history (Anthropic Messages
 // shape) into OpenAI chat messages, mapping tool_use → assistant tool_calls
-// and tool_result → role:"tool" messages. Images are dropped (text-only
-// models); callers that need vision should select a multimodal Cerebras model
-// and a future content-array path.
+// and tool_result → role:"tool" messages. User image blocks are converted to
+// OpenAI content parts so multimodal Cerebras models can inspect screenshots
+// and pasted images.
 func historyToOpenAI(system string, history []api.Message) []oaiMessage {
 	msgs := make([]oaiMessage, 0, len(history)+1)
 	if system != "" {
@@ -266,15 +285,45 @@ func historyToOpenAI(system string, history []api.Message) []oaiMessage {
 				}
 			}
 			if !hasToolResult {
-				var text strings.Builder
-				for _, b := range blocks {
-					if b.Type == "text" {
-						text.WriteString(b.Text)
-					}
-				}
-				msgs = append(msgs, oaiMessage{Role: m.Role, Content: text.String()})
+				msgs = append(msgs, oaiMessage{Role: m.Role, Content: contentBlocksToOpenAI(blocks)})
 			}
 		}
 	}
 	return msgs
+}
+
+func contentBlocksToOpenAI(blocks []api.ContentBlock) interface{} {
+	var text strings.Builder
+	var parts []oaiContentPart
+	hasImage := false
+
+	for _, b := range blocks {
+		switch b.Type {
+		case "text":
+			if b.Text == "" {
+				continue
+			}
+			text.WriteString(b.Text)
+			parts = append(parts, oaiContentPart{Type: "text", Text: b.Text})
+		case "image":
+			if b.Source == nil || b.Source.MediaType == "" || b.Source.Data == "" {
+				continue
+			}
+			hasImage = true
+			parts = append(parts, oaiContentPart{
+				Type: "image_url",
+				ImageURL: &oaiImageURL{
+					URL: "data:" + b.Source.MediaType + ";base64," + b.Source.Data,
+				},
+			})
+		}
+	}
+
+	if hasImage {
+		if len(parts) == 0 {
+			return []oaiContentPart{{Type: "text", Text: ""}}
+		}
+		return parts
+	}
+	return text.String()
 }

--- a/internal/agent/cerebras_agent.go
+++ b/internal/agent/cerebras_agent.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/qualitymax/qmax-code/internal/api"
+	"github.com/qualitymax/qmax-code/internal/session"
+	"github.com/qualitymax/qmax-code/internal/tui"
+)
+
+// RunCerebrasAgent runs a complete conversation turn through Cerebras using
+// native OpenAI function-calling against the full qmax tool set. It owns the
+// whole multi-round tool loop (call → execute tools → feed results → repeat)
+// and returns the final assistant text plus whether it succeeded.
+//
+// On any hard failure it returns ok=false. There is no Claude fallback here:
+// when backend=cerebras the user has no Anthropic key, so we surface the error
+// rather than silently switching providers.
+func (a *Agent) RunCerebrasAgent(term *tui.Terminal) (string, bool) {
+	if a.Cerebras == nil {
+		return "", false
+	}
+
+	tools := toolDefsToOpenAI(a.tools)
+
+	for iter := 0; iter < maxIterations; iter++ {
+		// Keep history valid + bounded before each call (mirrors the Claude loop).
+		session.SanitizeSessionMessages(a.History)
+		a.compressHistory()
+
+		system := a.buildSystemPrompt()
+		msgs := historyToOpenAI(system, a.History)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		a.cancelMu.Lock()
+		a.cancel = cancel
+		a.cancelMu.Unlock()
+
+		term.StartThinking()
+		resp, err := a.Cerebras.Chat(ctx, msgs, tools)
+		term.StopThinking()
+
+		a.cancelMu.Lock()
+		a.cancel = nil
+		a.cancelMu.Unlock()
+		cancel()
+
+		if err != nil {
+			if ctx.Err() != nil {
+				return "", false // interrupted
+			}
+			if a.Logger != nil {
+				a.Logger.Error("cerebras", err.Error())
+			}
+			term.PrintError(fmt.Sprintf("Cerebras request failed: %v", err))
+			return "", false
+		}
+		if len(resp.Choices) == 0 {
+			term.PrintError("Cerebras returned no choices")
+			return "", false
+		}
+
+		choice := resp.Choices[0]
+		a.Usage.InputTokens += resp.Usage.PromptTokens
+		a.Usage.OutputTokens += resp.Usage.CompletionTokens
+		a.Usage.Requests++
+
+		// Reconstruct the assistant turn as Anthropic-shaped blocks so the rest
+		// of qmax (history compression, session persistence, cloud upload) sees
+		// a uniform shape regardless of provider.
+		var blocks []api.ContentBlock
+		if choice.Message.Content != "" {
+			blocks = append(blocks, api.ContentBlock{Type: "text", Text: choice.Message.Content})
+		}
+		for _, tc := range choice.Message.ToolCalls {
+			var input interface{}
+			if err := json.Unmarshal([]byte(tc.Function.Arguments), &input); err != nil {
+				input = map[string]interface{}{}
+			}
+			blocks = append(blocks, api.ContentBlock{
+				Type:  "tool_use",
+				ID:    tc.ID,
+				Name:  tc.Function.Name,
+				Input: input,
+			})
+		}
+		if len(blocks) == 0 {
+			blocks = append(blocks, api.ContentBlock{Type: "text", Text: ""})
+		}
+		a.History = append(a.History, api.Message{Role: "assistant", Content: blocks})
+
+		// Tool round: execute every requested tool, append results, loop.
+		if len(choice.Message.ToolCalls) > 0 {
+			if choice.Message.Content != "" {
+				// PrintAssistant (not FinishMarkdown): this path is non-streaming,
+				// so the streaming flag FinishMarkdown checks is never set and it
+				// would silently drop the text.
+				term.PrintAssistant(choice.Message.Content)
+			}
+
+			var toolUse []api.ContentBlock
+			for _, b := range blocks {
+				if b.Type == "tool_use" {
+					toolUse = append(toolUse, b)
+					term.PrintToolIcon(b.Name)
+					term.PrintToolStart(b.Name, b.Input)
+				}
+			}
+
+			tctx, tcancel := context.WithCancel(context.Background())
+			a.cancelMu.Lock()
+			a.cancel = tcancel
+			a.cancelMu.Unlock()
+			results := a.executeToolCallsWithUI(toolUse, term, tctx)
+			a.cancelMu.Lock()
+			a.cancel = nil
+			a.cancelMu.Unlock()
+			tcancel()
+
+			a.History = append(a.History, api.Message{Role: "user", Content: results})
+			continue
+		}
+
+		// Final answer. PrintAssistant renders unconditionally (non-streaming path).
+		term.PrintAssistant(choice.Message.Content)
+		term.PrintTokenUsage(a.Usage)
+		return choice.Message.Content, true
+	}
+
+	return "", false
+}

--- a/internal/agent/cerebras_test.go
+++ b/internal/agent/cerebras_test.go
@@ -153,6 +153,39 @@ func TestHistoryToOpenAIToolRoundTrip(t *testing.T) {
 	}
 }
 
+func TestHistoryToOpenAIImageBlocksBecomeOpenAIContentParts(t *testing.T) {
+	hist := []api.Message{
+		{Role: "user", Content: []api.ContentBlock{
+			{Type: "image", Source: &api.ImageSource{
+				Type:      "base64",
+				MediaType: "image/png",
+				Data:      "iVBORw0KGgo=",
+			}},
+			{Type: "text", Text: "What is visible?"},
+		}},
+	}
+	msgs := historyToOpenAI("", hist)
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	parts, ok := msgs[0].Content.([]oaiContentPart)
+	if !ok {
+		t.Fatalf("content type = %T, want []oaiContentPart", msgs[0].Content)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("expected image+text parts, got %d (%+v)", len(parts), parts)
+	}
+	if parts[0].Type != "image_url" || parts[0].ImageURL == nil {
+		t.Fatalf("first part should be image_url: %+v", parts[0])
+	}
+	if got := parts[0].ImageURL.URL; got != "data:image/png;base64,iVBORw0KGgo=" {
+		t.Fatalf("image URL = %q", got)
+	}
+	if parts[1].Type != "text" || parts[1].Text != "What is visible?" {
+		t.Fatalf("text part mismatch: %+v", parts[1])
+	}
+}
+
 func TestHistoryToOpenAIPostJSONInterfaceBlocks(t *testing.T) {
 	// After a session JSON round-trip, []api.ContentBlock becomes []interface{}
 	// of map[string]interface{}. The converter must handle that shape too.

--- a/internal/agent/cerebras_test.go
+++ b/internal/agent/cerebras_test.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
+)
+
+func TestValidateCerebrasKey(t *testing.T) {
+	cases := []struct {
+		name      string
+		key       string
+		wantErr   bool
+		wantLooks bool
+	}{
+		{"valid csk key", "csk-vv52c6kwywjmejmnp8xd8c2p4", false, true},
+		{"valid but no prefix", "abc123def456", false, false},
+		{"empty", "", true, false},
+		{"pasted shell command", "cp /Users/x/qmax-code /usr/local/bin/qmax-code", true, false},
+		{"trailing space", "csk-abc ", true, false},
+		{"internal tab", "csk-\tabc", true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			looks, err := api.ValidateCerebrasKey(c.key)
+			if (err != nil) != c.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, c.wantErr)
+			}
+			if looks != c.wantLooks {
+				t.Errorf("looksLikeKey = %v, want %v", looks, c.wantLooks)
+			}
+		})
+	}
+}
+
+func TestNewCerebrasClientNilWithoutKey(t *testing.T) {
+	if c := NewCerebrasClient(&api.Config{}); c != nil {
+		t.Fatalf("expected nil client without CerebrasKey, got %+v", c)
+	}
+	if c := NewCerebrasClient(nil); c != nil {
+		t.Fatalf("expected nil client for nil config, got %+v", c)
+	}
+}
+
+func TestNewCerebrasClientDefaults(t *testing.T) {
+	c := NewCerebrasClient(&api.Config{CerebrasKey: "csk-test"})
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if c.BaseURL != api.CerebrasAPIBase {
+		t.Errorf("BaseURL = %q, want default %q", c.BaseURL, api.CerebrasAPIBase)
+	}
+	if c.Model != api.CerebrasDefaultModel {
+		t.Errorf("Model = %q, want default %q", c.Model, api.CerebrasDefaultModel)
+	}
+}
+
+func TestNewCerebrasClientOverrides(t *testing.T) {
+	c := NewCerebrasClient(&api.Config{
+		CerebrasKey:     "csk-test",
+		CerebrasModel:   "zai-glm-4.7",
+		CerebrasBaseURL: "https://proxy.internal/v1/", // trailing slash must be trimmed
+	})
+	if c.Model != "zai-glm-4.7" {
+		t.Errorf("Model = %q, want override", c.Model)
+	}
+	if c.BaseURL != "https://proxy.internal/v1" {
+		t.Errorf("BaseURL = %q, want trailing slash trimmed", c.BaseURL)
+	}
+}
+
+func TestToolDefsToOpenAI(t *testing.T) {
+	defs := []api.ToolDef{
+		{
+			Name:        "list_projects",
+			Description: "List all projects",
+			InputSchema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{}},
+		},
+		{Name: "nilschema", Description: "no schema"}, // InputSchema nil → defaulted
+	}
+	out := toolDefsToOpenAI(defs)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(out))
+	}
+	if out[0].Type != "function" || out[0].Function.Name != "list_projects" {
+		t.Errorf("tool 0 mismatch: %+v", out[0])
+	}
+	if out[1].Function.Parameters == nil {
+		t.Errorf("nil InputSchema should be defaulted to a non-nil object schema")
+	}
+	if out[1].Function.Parameters["type"] != "object" {
+		t.Errorf("defaulted schema type = %v, want object", out[1].Function.Parameters["type"])
+	}
+}
+
+func TestHistoryToOpenAIPlainStrings(t *testing.T) {
+	hist := []api.Message{
+		{Role: "user", Content: "hello"},
+		{Role: "assistant", Content: "hi there"},
+	}
+	msgs := historyToOpenAI("system prompt", hist)
+	if len(msgs) != 3 {
+		t.Fatalf("expected system+2 messages, got %d", len(msgs))
+	}
+	if msgs[0].Role != "system" || msgs[0].Content != "system prompt" {
+		t.Errorf("system message mismatch: %+v", msgs[0])
+	}
+	if msgs[1].Content != "hello" || msgs[2].Content != "hi there" {
+		t.Errorf("content mismatch: %+v %+v", msgs[1], msgs[2])
+	}
+}
+
+func TestHistoryToOpenAIToolRoundTrip(t *testing.T) {
+	// assistant tool_use → OpenAI assistant.tool_calls; user tool_result → role:"tool".
+	hist := []api.Message{
+		{Role: "user", Content: "list my projects"},
+		{Role: "assistant", Content: []api.ContentBlock{
+			{Type: "text", Text: "Let me check."},
+			{Type: "tool_use", ID: "call_1", Name: "list_projects", Input: map[string]interface{}{"limit": 10}},
+		}},
+		{Role: "user", Content: []api.ContentBlock{
+			{Type: "tool_result", ToolUseID: "call_1", Content: `{"projects":[]}`},
+		}},
+	}
+	msgs := historyToOpenAI("", hist)
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d: %+v", len(msgs), msgs)
+	}
+
+	asst := msgs[1]
+	if asst.Role != "assistant" || asst.Content != "Let me check." {
+		t.Errorf("assistant text mismatch: %+v", asst)
+	}
+	if len(asst.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(asst.ToolCalls))
+	}
+	tc := asst.ToolCalls[0]
+	if tc.ID != "call_1" || tc.Type != "function" || tc.Function.Name != "list_projects" {
+		t.Errorf("tool call fields mismatch: %+v", tc)
+	}
+	var args map[string]interface{}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		t.Fatalf("arguments not valid JSON: %v (%q)", err, tc.Function.Arguments)
+	}
+	if args["limit"] != float64(10) {
+		t.Errorf("arguments = %v, want limit=10", args)
+	}
+
+	toolMsg := msgs[2]
+	if toolMsg.Role != "tool" || toolMsg.ToolCallID != "call_1" || toolMsg.Content != `{"projects":[]}` {
+		t.Errorf("tool result message mismatch: %+v", toolMsg)
+	}
+}
+
+func TestHistoryToOpenAIPostJSONInterfaceBlocks(t *testing.T) {
+	// After a session JSON round-trip, []api.ContentBlock becomes []interface{}
+	// of map[string]interface{}. The converter must handle that shape too.
+	hist := []api.Message{
+		{Role: "assistant", Content: []interface{}{
+			map[string]interface{}{"type": "tool_use", "id": "call_x", "name": "run_test", "input": map[string]interface{}{"script_id": 5}},
+		}},
+		{Role: "user", Content: []interface{}{
+			map[string]interface{}{"type": "tool_result", "tool_use_id": "call_x", "content": "passed"},
+		}},
+	}
+	msgs := historyToOpenAI("", hist)
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(msgs))
+	}
+	if len(msgs[0].ToolCalls) != 1 || msgs[0].ToolCalls[0].Function.Name != "run_test" {
+		t.Errorf("interface tool_use not converted: %+v", msgs[0])
+	}
+	if msgs[1].Role != "tool" || msgs[1].Content != "passed" {
+		t.Errorf("interface tool_result not converted: %+v", msgs[1])
+	}
+}

--- a/internal/api/cerebras.go
+++ b/internal/api/cerebras.go
@@ -1,0 +1,15 @@
+package api
+
+// Cerebras inference (OpenAI-compatible). The cerebras backend drives the
+// native qmax agent loop — full tool set, native function-calling — through
+// Cerebras's /v1/chat/completions endpoint, which is fast and low-cost.
+//
+// Auth is a Bearer token (CEREBRAS_API_KEY), not the x-api-key header the
+// Anthropic Messages API uses. Base URL and model are overridable via config
+// or the CEREBRAS_API_BASE / CEREBRAS_MODEL env vars.
+const (
+	// CerebrasAPIBase is the default OpenAI-compatible base URL.
+	CerebrasAPIBase = "https://api.cerebras.ai/v1"
+	// CerebrasDefaultModel is a fast, capable general/coding model on Cerebras.
+	CerebrasDefaultModel = "gpt-oss-120b"
+)

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -2,8 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"unicode"
 )
 
 // Config holds persistent user preferences for qmax-code.
@@ -26,11 +29,24 @@ type Config struct {
 	OllamaModel      string `json:"ollama_model,omitempty"`       // e.g. "gemma3:4b-it-q4_K_M" (chat)
 	OllamaAgentModel string `json:"ollama_agent_model,omitempty"` // e.g. "gemma3:12b-it-q4_K_M" (tools, heavier tasks)
 
+	// Cerebras integration — drive the native agent loop (full tool set) through
+	// Cerebras's OpenAI-compatible inference, which is fast and low-cost. Selected
+	// via backend="cerebras". Unlike the Ollama path (prompt-based dispatch over a
+	// handful of actions), Cerebras uses native function-calling against the full
+	// qmax tool set, so it can handle all coding tasks directly.
+	// The API key is stored in the OS keychain, never in JSON.
+	CerebrasKey     string `json:"-"`
+	CerebrasModel   string `json:"cerebras_model,omitempty"`    // default "gpt-oss-120b"
+	CerebrasBaseURL string `json:"cerebras_base_url,omitempty"` // default "https://api.cerebras.ai/v1"
+
 	// Backend selects the LLM inference backend.
 	//   ""  / "api" → Anthropic API directly (default, requires ANTHROPIC_API_KEY)
 	//   "cc"        → Claude Code CLI subprocess (no QM API key; `claude --print`
 	//                 uses the user's Agent SDK credit starting 2026-06-15)
 	//   "codex"     → OpenAI Codex CLI subprocess (uses OpenAI subscription, no API key needed)
+	//   "cerebras"  → Cerebras OpenAI-compatible API (requires CEREBRAS_API_KEY).
+	//                 Drives the native qmax agent loop with the full tool set via
+	//                 native function calling — fast and low-cost.
 	// In both CLI modes qmax tools are served to the CLI via an embedded MCP server.
 	Backend string `json:"backend,omitempty"`
 
@@ -102,6 +118,11 @@ func LoadQMaxCodeConfig() *Config {
 		cfg.AnthropicKey = key
 	}
 
+	// Load Cerebras key from OS keychain (never stored in JSON)
+	if key, err := LoadFromKeychain("cerebras_key"); err == nil && key != "" {
+		cfg.CerebrasKey = key
+	}
+
 	// Env vars override config file for Ollama (useful for Railway/CI)
 	if url := os.Getenv("OLLAMA_BASE_URL"); url != "" {
 		cfg.OllamaURL = url
@@ -110,12 +131,50 @@ func LoadQMaxCodeConfig() *Config {
 		cfg.OllamaModel = model
 	}
 
+	// Env vars override config/keychain for Cerebras (useful for Railway/CI)
+	if key := os.Getenv("CEREBRAS_API_KEY"); key != "" {
+		cfg.CerebrasKey = key
+	}
+	if base := os.Getenv("CEREBRAS_API_BASE"); base != "" {
+		cfg.CerebrasBaseURL = base
+	}
+	if model := os.Getenv("CEREBRAS_MODEL"); model != "" {
+		cfg.CerebrasModel = model
+	}
+
 	return cfg
 }
 
 // SaveAnthropicKey securely stores the Anthropic API key in the OS keychain.
 func SaveAnthropicKey(key string) error {
 	return SaveToKeychain("anthropic_key", key)
+}
+
+// SaveCerebrasKey securely stores the Cerebras API key in the OS keychain.
+func SaveCerebrasKey(key string) error {
+	return SaveToKeychain("cerebras_key", key)
+}
+
+// ValidateCerebrasKey sanity-checks a Cerebras API key before it's saved.
+// It catches the common no-echo paste mistakes (an empty value, or a whole
+// shell command / multi-token paste landing in the hidden prompt) by rejecting
+// anything containing whitespace or non-printable bytes. The expected key is a
+// single opaque token (Cerebras keys start with "csk-"); a missing prefix is a
+// soft signal returned via the bool, not a hard error, so future key formats
+// keep working.
+func ValidateCerebrasKey(key string) (looksLikeKey bool, err error) {
+	if key == "" {
+		return false, fmt.Errorf("key is empty")
+	}
+	for _, r := range key {
+		if unicode.IsSpace(r) {
+			return false, fmt.Errorf("key contains whitespace — looks like a pasted command or multiple values, not a single API key")
+		}
+		if !unicode.IsPrint(r) {
+			return false, fmt.Errorf("key contains a non-printable character")
+		}
+	}
+	return strings.HasPrefix(key, "csk-"), nil
 }
 
 // Save persists the config to ~/.qmax-code/config.json.

--- a/internal/repl/backend_switch_test.go
+++ b/internal/repl/backend_switch_test.go
@@ -1,0 +1,23 @@
+package repl
+
+import (
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/agent"
+)
+
+func TestDeactivateEmbeddedBackendsClearsCerebrasAndOllamaMode(t *testing.T) {
+	ag := &agent.Agent{
+		Mode:     agent.OllamaModeFull,
+		Cerebras: &agent.CerebrasClient{Model: "gemma-4-31b"},
+	}
+
+	deactivateEmbeddedBackends(ag)
+
+	if ag.Mode != agent.OllamaModeOff {
+		t.Fatalf("Mode = %v, want off", ag.Mode)
+	}
+	if ag.Cerebras != nil {
+		t.Fatalf("Cerebras client was not cleared")
+	}
+}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -379,6 +379,7 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				OllamaModel:    cfg.OllamaModel,
 				CCInstalled:    agent.FindClaudeCode() != "",
 				CodexInstalled: agent.FindCodex() != "",
+				CerebrasKeySet: cfg.CerebrasKey != "",
 			})
 			if !result.Confirmed {
 				continue
@@ -406,10 +407,55 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 					cliAgent = nil
 				}
 				ag.Mode = agent.OllamaModeFull
+				ag.Cerebras = nil
 				cfg.Backend = ""
 				ag.Cfg.Context.Backend = ""
 				_ = cfg.Save()
 				term.PrintSystem(fmt.Sprintf("Backend: Ollama  model: %s  endpoint: %s", cfg.OllamaModel, sysutil.MaskURL(cfg.OllamaURL)))
+				continue
+			}
+
+			// ── Cerebras selected ─────────────────────────────────────────────
+			if result.Backend == "cerebras" {
+				// Prompt for the API key now if it isn't configured yet. Optional —
+				// leaving it blank cancels the switch without changing anything.
+				if cfg.CerebrasKey == "" {
+					term.PrintSystem("Cerebras needs an API key (get one at https://cloud.cerebras.ai).")
+					key := setup.ReadSecret("  Paste your Cerebras key (blank to cancel): ")
+					if key == "" {
+						term.PrintSystem("No key entered — backend not changed.")
+						continue
+					}
+					looks, verr := api.ValidateCerebrasKey(key)
+					if verr != nil {
+						term.PrintError(fmt.Sprintf("That doesn't look like an API key (%v). Backend not changed.", verr))
+						continue
+					}
+					if !looks {
+						term.PrintSystem("  Note: key doesn't start with \"csk-\" — saving anyway.")
+					}
+					if err := api.SaveCerebrasKey(key); err != nil {
+						term.PrintError(fmt.Sprintf("Could not save key: %v", err))
+						continue
+					}
+					cfg.CerebrasKey = key
+					term.PrintSystem("  Saved to OS keychain.")
+				}
+				// Apply the chosen Cerebras model.
+				if result.ModelID != "" {
+					cfg.CerebrasModel = result.ModelID
+				}
+				// Tear down any active CLI agent / Ollama mode.
+				if cliAgent != nil {
+					cliAgent.Cleanup()
+					cliAgent = nil
+				}
+				ag.Mode = agent.OllamaModeOff
+				ag.Cerebras = agent.NewCerebrasClient(cfg)
+				cfg.Backend = "cerebras"
+				ag.Cfg.Context.Backend = "cerebras"
+				_ = cfg.Save()
+				term.PrintSystem(fmt.Sprintf("Backend: Cerebras  model: %s", cfg.CerebrasModel))
 				continue
 			}
 
@@ -446,12 +492,13 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				}
 			}
 
-			// Tear down current CLI agent and disable Ollama if switching away from it.
+			// Tear down current CLI agent and disable Ollama/Cerebras if switching away.
 			if cliAgent != nil {
 				cliAgent.Cleanup()
 				cliAgent = nil
 			}
 			ag.Mode = agent.OllamaModeOff
+			ag.Cerebras = nil
 
 			// Spin up the new agent with selected model + effort.
 			switch result.Backend {

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -497,8 +497,7 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				cliAgent.Cleanup()
 				cliAgent = nil
 			}
-			ag.Mode = agent.OllamaModeOff
-			ag.Cerebras = nil
+			deactivateEmbeddedBackends(ag)
 
 			// Spin up the new agent with selected model + effort.
 			switch result.Backend {
@@ -594,6 +593,7 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				cliAgent.Cleanup()
 				cliAgent = nil
 			}
+			deactivateEmbeddedBackends(ag)
 
 			switch wantBackend {
 			case "cc":
@@ -674,6 +674,11 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 			if ag.Ollama == nil {
 				ag.Ollama = agent.NewOllamaClient(cfg)
 			}
+			if cliAgent != nil {
+				cliAgent.Cleanup()
+				cliAgent = nil
+			}
+			ag.Cerebras = nil
 			switch ag.Mode {
 			case agent.OllamaModeOff:
 				ag.Mode = agent.OllamaModeChat
@@ -1578,6 +1583,11 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dm", int(d.Minutes()))
 	}
 	return fmt.Sprintf("%dh", int(d.Hours()))
+}
+
+func deactivateEmbeddedBackends(ag *agent.Agent) {
+	ag.Mode = agent.OllamaModeOff
+	ag.Cerebras = nil
 }
 
 // sdkCreditCutover is the date Anthropic moves `claude --print` /

--- a/internal/tui/tui_backend.go
+++ b/internal/tui/tui_backend.go
@@ -44,6 +44,9 @@ var (
 	pickerIconOllama = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("71")) // green — Ollama ⬡
 
+	pickerIconCerebras = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("208")) // orange — Cerebras ◆
+
 	pickerDotGreen = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
 	pickerDotRed   = lipgloss.NewStyle().Foreground(lipgloss.Color("160"))
 
@@ -147,6 +150,15 @@ var apiModels = []pickerEntry{
 	{backend: "", modelID: api.ModelHaiku, label: "Haiku 4.5"},
 }
 
+// cerebrasModels are run through Cerebras's OpenAI-compatible API (native
+// function calling, full tool set). external=↗ marks them as a third-party
+// hosted provider.
+var cerebrasModels = []pickerEntry{
+	{backend: "cerebras", modelID: "gpt-oss-120b", label: "GPT-OSS 120B", subLabel: "fast", isFav: true, external: true},
+	{backend: "cerebras", modelID: "zai-glm-4.7", label: "GLM 4.7", subLabel: "premium", external: true},
+	{backend: "cerebras", modelID: "gemma-4-31b", label: "Gemma 4 31B", subLabel: "vision · preview", external: true},
+}
+
 var effortLevels = []string{"low", "medium", "high"}
 
 // probeOllamaReachable returns true if the Ollama base URL responds within 2s.
@@ -200,15 +212,19 @@ type modelPickerModel struct {
 	ollamaURL       string
 	ollamaReachable bool
 
+	// Cerebras metadata
+	cerebrasKeySet bool
+
 	cancelled bool
 	chosen    *pickerEntry
 }
 
-func newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, ollamaModel string, ccInstalled, codexInstalled bool) modelPickerModel {
-	entries := make([]pickerEntry, 0, len(ccModels)+len(codexModels)+len(apiModels)+1)
+func newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, ollamaModel string, ccInstalled, codexInstalled, cerebrasKeySet bool) modelPickerModel {
+	entries := make([]pickerEntry, 0, len(ccModels)+len(codexModels)+len(apiModels)+len(cerebrasModels)+1)
 	entries = append(entries, ccModels...)
 	entries = append(entries, codexModels...)
 	entries = append(entries, apiModels...)
+	entries = append(entries, cerebrasModels...)
 
 	// Append Ollama entry if configured.
 	if ollamaURL != "" && ollamaModel != "" {
@@ -245,6 +261,7 @@ func newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, olla
 		ollamaURL:      ollamaURL,
 		ccInstalled:    ccInstalled,
 		codexInstalled: codexInstalled,
+		cerebrasKeySet: cerebrasKeySet,
 	}
 }
 
@@ -388,6 +405,27 @@ func (m modelPickerModel) View() string {
 		b.WriteByte('\n')
 	}
 
+	// ── Cerebras section ─────────────────────────────────────────────
+	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+	b.WriteByte('\n')
+	cerebrasDot := pickerDotRed.Render("●")
+	cerebrasStatus := "no key — will prompt"
+	if m.cerebrasKeySet {
+		cerebrasDot = pickerDotGreen.Render("●")
+		cerebrasStatus = "key set"
+	}
+	sectionLabelCerebras := fmt.Sprintf("%s  Cerebras  %s %s",
+		pickerIconCerebras.Render("◆"), cerebrasDot, pickerBadgeExt.Render(cerebrasStatus))
+	b.WriteString(pickerSectionHeader.Render(sectionLabelCerebras))
+	b.WriteByte('\n')
+	for i, e := range m.allEntries {
+		if e.backend != "cerebras" {
+			continue
+		}
+		b.WriteString(m.renderRow(i, e, "cerebras"))
+		b.WriteByte('\n')
+	}
+
 	// ── Ollama section ───────────────────────────────────────────────
 	hasOllama := false
 	for _, e := range m.allEntries {
@@ -454,6 +492,8 @@ func (m modelPickerModel) renderRow(idx int, e pickerEntry, backend string) stri
 		icon = pickerIconCodex.Render("⊗")
 	case "ollama":
 		icon = pickerIconOllama.Render("⬡")
+	case "cerebras":
+		icon = pickerIconCerebras.Render("◆")
 	default:
 		icon = pickerIconAPI.Render("○")
 	}
@@ -537,6 +577,8 @@ func (m modelPickerModel) renderStatusBar() string {
 		icon = pickerStatusIconCodex.Render("⊗")
 	case "ollama":
 		icon = pickerStatusBar.Render("⬡")
+	case "cerebras":
+		icon = pickerStatusBar.Render("◆")
 	default:
 		icon = pickerStatusIcon.Render("○")
 	}
@@ -686,19 +728,20 @@ func ShowThemePicker(currentTheme string) (string, bool) {
 // break, and so the boolean flags don't read as mystery true/false at the
 // call site.
 type ModelPickerOpts struct {
-	CurrentBackend string // "" | "cc" | "codex" | "ollama" — drives initial cursor position
+	CurrentBackend string // "" | "cc" | "codex" | "ollama" | "cerebras" — drives initial cursor position
 	CurrentModelID string // specific model ID currently active, or ""
 	Effort         string // "low" | "medium" | "high"; empty defaults to "high"
 	OllamaURL      string // currently configured Ollama endpoint; "" hides the section
 	OllamaModel    string // currently configured Ollama model; "" hides the section
 	CCInstalled    bool   // pre-resolved (don't shell out from picker.View per frame)
 	CodexInstalled bool
+	CerebrasKeySet bool // true when a Cerebras API key is configured (drives the section status dot)
 }
 
 // ShowModelPicker opens the unified model + effort TUI.
 // Returns the result; Confirmed=false means the user cancelled.
 func ShowModelPicker(opts ModelPickerOpts) ModelPickerResult {
-	m := newModelPickerModel(opts.CurrentBackend, opts.CurrentModelID, opts.Effort, opts.OllamaURL, opts.OllamaModel, opts.CCInstalled, opts.CodexInstalled)
+	m := newModelPickerModel(opts.CurrentBackend, opts.CurrentModelID, opts.Effort, opts.OllamaURL, opts.OllamaModel, opts.CCInstalled, opts.CodexInstalled, opts.CerebrasKeySet)
 	p := tea.NewProgram(m)
 	result, err := p.Run()
 	if err != nil {

--- a/internal/tui/tui_backend_cerebras_test.go
+++ b/internal/tui/tui_backend_cerebras_test.go
@@ -1,0 +1,50 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPickerIncludesCerebrasEntries(t *testing.T) {
+	m := newModelPickerModel("", "", "high", "", "", true, true, false)
+	var got []string
+	for _, e := range m.allEntries {
+		if e.backend == "cerebras" {
+			got = append(got, e.modelID)
+		}
+	}
+	if len(got) != len(cerebrasModels) {
+		t.Fatalf("expected %d cerebras entries, got %d (%v)", len(cerebrasModels), len(got), got)
+	}
+	if got[0] != "gpt-oss-120b" {
+		t.Errorf("first cerebras model = %q, want gpt-oss-120b", got[0])
+	}
+}
+
+func TestPickerCerebrasSectionRenders(t *testing.T) {
+	// No key configured → status should advertise the inline prompt.
+	m := newModelPickerModel("", "", "high", "", "", true, true, false)
+	view := m.View()
+	if !strings.Contains(view, "Cerebras") {
+		t.Error("picker view missing Cerebras section header")
+	}
+	if !strings.Contains(view, "no key") {
+		t.Error("picker should show 'no key' status when CerebrasKeySet is false")
+	}
+
+	// Key configured → status should say so.
+	m2 := newModelPickerModel("", "", "high", "", "", true, true, true)
+	if !strings.Contains(m2.View(), "key set") {
+		t.Error("picker should show 'key set' status when CerebrasKeySet is true")
+	}
+}
+
+func TestPickerCerebrasCursorOnCurrent(t *testing.T) {
+	// When cerebras is the active backend, the cursor should land on the
+	// matching model entry.
+	m := newModelPickerModel("cerebras", "zai-glm-4.7", "high", "", "", true, true, true)
+	cur := m.allEntries[m.cursor]
+	if cur.backend != "cerebras" || cur.modelID != "zai-glm-4.7" {
+		t.Errorf("cursor on %s/%s, want cerebras/zai-glm-4.7", cur.backend, cur.modelID)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	professional := flag.Bool("professional", false, "Disable cat personality, be direct and professional")
 	quiet := flag.Bool("q", false, "Quiet mode — no banner, minimal output (for CI)")
 	showVersion := flag.Bool("version", false, "Show version")
-	backendFlag := flag.String("backend", "", "Orchestration backend: cc, codex, or api (overrides saved config)")
+	backendFlag := flag.String("backend", "", "Orchestration backend: cc, codex, cerebras, or api (overrides saved config)")
 	flag.Parse()
 	_ = quiet // reserved for future CI mode
 
@@ -157,14 +157,14 @@ func main() {
 	// --backend flag overrides saved config for this session only.
 	if *backendFlag != "" {
 		switch *backendFlag {
-		case "cc", "codex", "api", "":
+		case "cc", "codex", "cerebras", "api", "":
 			if *backendFlag == "api" {
 				appConfig.Backend = ""
 			} else {
 				appConfig.Backend = *backendFlag
 			}
 		default:
-			fmt.Fprintf(os.Stderr, "Error: --backend must be cc, codex, or api\n")
+			fmt.Fprintf(os.Stderr, "Error: --backend must be cc, codex, cerebras, or api\n")
 			os.Exit(2)
 		}
 	}
@@ -269,6 +269,37 @@ func main() {
 			_ = appConfig.Save()
 			anthropicKey = "__codex_mode__" // skip Anthropic key gate below
 		}
+	} else if cliBackend == "cerebras" {
+		// Cerebras drives the native qmax agent loop (full tool set, native
+		// function calling) via its OpenAI-compatible API. No Anthropic key,
+		// no external CLI, no MCP subprocess — qmax owns the loop directly.
+		if appConfig.CerebrasKey == "" {
+			fmt.Println()
+			fmt.Println("  Cerebras API key needed (powers fast, low-cost inference).")
+			fmt.Println("  Get one at: https://cloud.cerebras.ai")
+			fmt.Println()
+			key := setup.ReadSecret("  Paste your Cerebras key: ")
+			if key != "" {
+				if looks, verr := api.ValidateCerebrasKey(key); verr != nil {
+					fmt.Fprintf(os.Stderr, "  That doesn't look like an API key: %v\n", verr)
+				} else {
+					if !looks {
+						fmt.Println("  Note: key doesn't start with \"csk-\" — saving anyway.")
+					}
+					appConfig.CerebrasKey = key
+					if err := api.SaveCerebrasKey(key); err == nil {
+						fmt.Println("  Saved to OS keychain.")
+					}
+				}
+			}
+		}
+		if appConfig.CerebrasKey == "" {
+			fmt.Fprintln(os.Stderr, "\nError: Cerebras API key required for backend=cerebras.")
+			fmt.Fprintln(os.Stderr, "  export CEREBRAS_API_KEY=csk-...")
+			fmt.Fprintln(os.Stderr, "  Or switch backend: qmax-code config set backend api")
+			os.Exit(1)
+		}
+		anthropicKey = "__cerebras_mode__" // skip Anthropic key gate below
 	}
 
 	// If connected but missing Anthropic key, prompt for it (skipped in CLI backend modes).
@@ -343,7 +374,11 @@ func main() {
 	})
 	ag.AppConfig = appConfig
 	ag.Ollama = agent.NewOllamaClient(appConfig)
-	if ag.Ollama != nil {
+	// Cerebras backend takes precedence: when selected it owns every turn
+	// (native function calling over the full tool set), so leave Ollama mode off.
+	if appConfig.Backend == "cerebras" {
+		ag.Cerebras = agent.NewCerebrasClient(appConfig)
+	} else if ag.Ollama != nil {
 		ag.Mode = agent.OllamaModeFull // default to full when configured
 	}
 
@@ -395,6 +430,19 @@ func main() {
 			term := tui.NewTerminal()
 			defer term.Close()
 			_, err := cliAgent.Run(prompt, term)
+			return err
+		}
+		if ag.Cerebras != nil {
+			// Cerebras runs the full native tool loop, streaming UI to a Terminal.
+			// repl.Run owns the Logger in interactive mode; create one here so the
+			// one-shot tool loop (which logs each tool call) doesn't nil-panic.
+			if ag.Logger == nil {
+				ag.Logger = sysutil.NewLogger("oneshot")
+				defer ag.Logger.Close()
+			}
+			term := tui.NewTerminal()
+			defer term.Close()
+			_, err := ag.RunStreaming(prompt, term)
 			return err
 		}
 		// Direct-API path: non-streaming. Print the returned text ourselves.


### PR DESCRIPTION
## Summary

Adds **`backend=cerebras`** as a fourth inference backend alongside `api` / `cc` / `codex`. It drives the **full native qmax agent loop** — the complete tool set, native OpenAI-compatible function calling — through Cerebras's `/v1/chat/completions`. Fast and low-cost; no Anthropic key or external CLI required.

This is distinct from the Ollama path (which only does prompt-based dispatch over ~10 hardcoded actions). The integration mirrors how qa-rag-app wires Cerebras (OpenAI-compatible, Bearer auth, `gpt-oss-120b` / `zai-glm-4.7` / `gemma-4-31b`).

## What's included

- **Client + loop** — `CerebrasClient`, OpenAI wire types, converters from qmax `ToolDef`→OpenAI tools and Anthropic-shaped history→OpenAI messages (handles both `[]ContentBlock` and post-JSON `[]interface{}`), and `RunCerebrasAgent`, a self-contained multi-round tool loop reusing `ExecuteTool` + terminal UI.
- **Config** — `CerebrasKey` (OS keychain, never in JSON), `CerebrasModel`, `CerebrasBaseURL`, plus `CEREBRAS_API_KEY` / `CEREBRAS_API_BASE` / `CEREBRAS_MODEL` env overrides.
- **Activation** — `qmax-code config set backend cerebras`, `--backend cerebras`, or env. Works in interactive **and** one-shot modes.
- **`/orch` picker** — its own Cerebras section (`gpt-oss-120b`, `zai-glm-4.7`, `gemma-4-31b`) with a key-status indicator; selecting it prompts for the key inline (no-echo, blank cancels) and saves to the keychain.
- **Key validation** — `ValidateCerebrasKey` rejects whitespace / non-printable pastes (catches the "pasted a shell command into the hidden prompt" mistake) and warns when a key doesn't start with `csk-`. Wired into the picker, `config set`, and the launch prompt.
- **Display fix** — non-streaming replies use `PrintAssistant` (not `FinishMarkdown`, which is a no-op when the streaming flag isn't set), so answers actually render.

## Testing

- `go build`, `go vet`, full `go test ./...` all green.
- New tests: client construction/defaults/overrides, tool-def + history converters (incl. tool round-trip and post-JSON shape), key validation (incl. the pasted-command case), picker entries/section/cursor, and backend/config validation.
- **Live-verified** end-to-end through `gemma-4-31b`: the `/v1/models` endpoint lists all three models, function-calling works, and interactive REPL turns reply correctly.

## Notes / follow-ups

- Gemma is currently sent **text-only** (images dropped) and the loop is **non-streaming** per turn (Cerebras is fast enough that this keeps tool-call parsing simple). Multimodal/vision input is a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)