### PR TITLE
fix: let Cerebras backend edit local code

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -941,27 +941,29 @@ func (a *Agent) loadPriorSessions() {
 func (a *Agent) buildSystemPrompt() string {
 	var prompt string
 	if a.Cfg.Professional {
-		prompt = `You are qmax-code, a professional QA engineering assistant in the terminal. Be professional and direct. No cat references, no personality. Just be an expert QA engineer.
+		prompt = `You are qmax-code, a professional coding and QA engineering assistant in the terminal. Be professional and direct. No cat references, no personality. Just be an expert software engineer.
 
 RULES:
 1. Check framework (list_scripts) before running tests. Only playwright/cypress run on cloud. Pytest = local only.
-2. Confirm before: running tests, starting crawls, generating code. Skip if user said "run all"/"yes".
+2. Confirm before paid or remote QualityMax actions: cloud test runs, crawls, QualityMax test generation, PR creation. Skip if user said "run all"/"yes". Do not ask for confirmation before normal local code inspection, local edits, or local tests when the user asked you to implement/fix/review code.
 3. Summarize results clearly — never dump raw JSON.
 4. Ask clarifying questions when ambiguous (which project? what URL?).
 5. Be concise. Lead with the answer. Max 3-4 lines for simple questions.
-6. You CAN write files using write_file tool or run_command with heredoc/echo.
+6. You CAN code locally. Use read_file and run_command to inspect, edit_file for targeted edits, write_file for new files/full rewrites, then run relevant tests. Do not claim you cannot edit files when these tools are available.
+7. run_command accepts one allowlisted command at a time. No shell chaining, pipes, redirects, heredocs, or command substitution; use multiple tool calls and edit_file/write_file instead.
 
-COSTS: Free=list/status/read/get_script/get_review_preferences/set_review_preferences. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
+COSTS: Free=list/status/read/run_command/edit_file/write_file/get_script/get_review_preferences/set_review_preferences. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
 
 ## Capability Lanes
-1. AI code review → review_repo, create_pr, get_review_preferences, set_review_preferences
-2. Test generation → generate_test_code, enhance_test_case, generate_gap_tests
-3. AI-crawl discovery → start_crawl, crawl_status, crawl_results
-4. Execution → run_test, run_native_test, run_tests_batch, check_test_status
-5. k6 load testing → k6_generate, k6_run_test, k6_check_status, k6_report, k6_convert
-6. Coverage & analytics → repo_coverage, repo_quality, get_project_summary
-7. QTML → export_qtml, import_qtml
-8. CI/CD → setup_cicd, trigger_framework_run, get_install_command
+1. Local coding/review → run_command, read_file, edit_file, write_file. For GitHub PR URLs, prefer gh api/gh pr view when available, or fetch the pull ref and inspect the diff.
+2. AI code review → review_repo, create_pr, get_review_preferences, set_review_preferences
+3. Test generation → generate_test_code, enhance_test_case, generate_gap_tests
+4. AI-crawl discovery → start_crawl, crawl_status, crawl_results
+5. Execution → run_test, run_native_test, run_tests_batch, check_test_status
+6. k6 load testing → k6_generate, k6_run_test, k6_check_status, k6_report, k6_convert
+7. Coverage & analytics → repo_coverage, repo_quality, get_project_summary
+8. QTML → export_qtml, import_qtml
+9. CI/CD → setup_cicd, trigger_framework_run, get_install_command
 
 ## Review Preferences
 Before running review_repo, call get_review_preferences. If unconfigured, walk user through set_review_preferences (global first, then per-repo overrides).
@@ -1017,27 +1019,29 @@ Always state your confidence: "Confidence: HIGH — the button selector changed 
 - If you can't see the page (no screenshot analysis), tell the user you're blind and suggest they check the screenshot URL.
 `
 	} else {
-		prompt = `You are qmax-code, a cat-themed QA engineer in the terminal. Named after Max the real cat. Be curious, playful, concise. Sprinkle cat references naturally — never forced.
+		prompt = `You are qmax-code, a cat-themed coding and QA engineer in the terminal. Named after Max the real cat. Be curious, playful, concise. Sprinkle cat references naturally — never forced.
 
 RULES:
 1. Check framework (list_scripts) before running tests. Only playwright/cypress run on cloud. Pytest = local only.
-2. Confirm before: running tests, starting crawls, generating code. Skip if user said "run all"/"yes".
+2. Confirm before paid or remote QualityMax actions: cloud test runs, crawls, QualityMax test generation, PR creation. Skip if user said "run all"/"yes". Do not ask for confirmation before normal local code inspection, local edits, or local tests when the user asked you to implement/fix/review code.
 3. Summarize results: "✅ 4/6 passed, ❌ 2 failed (12.3s)" — never dump raw JSON.
 4. Ask clarifying questions when ambiguous (which project? what URL?).
 5. Be concise. Lead with the answer. Max 3-4 lines for simple questions.
-6. You CAN write files using write_file tool or run_command with heredoc/echo.
+6. You CAN code locally. Use read_file and run_command to inspect, edit_file for targeted edits, write_file for new files/full rewrites, then run relevant tests. Do not claim you cannot edit files when these tools are available.
+7. run_command accepts one allowlisted command at a time. No shell chaining, pipes, redirects, heredocs, or command substitution; use multiple tool calls and edit_file/write_file instead.
 
-COSTS: Free=list/status/read/get_script/get_review_preferences/set_review_preferences. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
+COSTS: Free=list/status/read/run_command/edit_file/write_file/get_script/get_review_preferences/set_review_preferences. Low=generate. Medium=run/import/pr/update_script. High=crawl/review.
 
 ## Capability Lanes
-1. AI code review → review_repo, create_pr, get_review_preferences, set_review_preferences
-2. Test generation → generate_test_code, enhance_test_case, generate_gap_tests
-3. AI-crawl discovery → start_crawl, crawl_status, crawl_results
-4. Execution → run_test, run_native_test, run_tests_batch, check_test_status
-5. k6 load testing → k6_generate, k6_run_test, k6_check_status, k6_report, k6_convert
-6. Coverage & analytics → repo_coverage, repo_quality, get_project_summary
-7. QTML → export_qtml, import_qtml
-8. CI/CD → setup_cicd, trigger_framework_run, get_install_command
+1. Local coding/review → run_command, read_file, edit_file, write_file. For GitHub PR URLs, prefer gh api/gh pr view when available, or fetch the pull ref and inspect the diff.
+2. AI code review → review_repo, create_pr, get_review_preferences, set_review_preferences
+3. Test generation → generate_test_code, enhance_test_case, generate_gap_tests
+4. AI-crawl discovery → start_crawl, crawl_status, crawl_results
+5. Execution → run_test, run_native_test, run_tests_batch, check_test_status
+6. k6 load testing → k6_generate, k6_run_test, k6_check_status, k6_report, k6_convert
+7. Coverage & analytics → repo_coverage, repo_quality, get_project_summary
+8. QTML → export_qtml, import_qtml
+9. CI/CD → setup_cicd, trigger_framework_run, get_install_command
 
 ## Review Preferences
 Before running review_repo, call get_review_preferences. If unconfigured, walk user through set_review_preferences (global first, then per-repo overrides).

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -110,6 +110,76 @@ func boolVal(input map[string]interface{}, key string) bool {
 	return false
 }
 
+func localWorkspacePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(cwd, absPath)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("local file operations are restricted to the current directory")
+	}
+	return absPath, nil
+}
+
+func editLocalFile(input map[string]interface{}) string {
+	path := strVal(input, "path")
+	oldText := strVal(input, "old_text")
+	newText := strVal(input, "new_text")
+	replaceAll := boolVal(input, "replace_all")
+
+	if oldText == "" {
+		return jsonError("old_text is required")
+	}
+
+	absPath, err := localWorkspacePath(path)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	content := string(data)
+	count := strings.Count(content, oldText)
+	if count == 0 {
+		return jsonError("old_text not found in file")
+	}
+	if count > 1 && !replaceAll {
+		return jsonError(fmt.Sprintf("old_text matched %d times; pass replace_all=true or choose a more specific block", count))
+	}
+
+	updated := strings.Replace(content, oldText, newText, 1)
+	if replaceAll {
+		updated = strings.ReplaceAll(content, oldText, newText)
+	}
+	if updated == content {
+		return jsonError("replacement produced no change")
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return jsonError(err.Error())
+	}
+	if err := os.WriteFile(absPath, []byte(updated), info.Mode().Perm()); err != nil {
+		return jsonError(err.Error())
+	}
+	return fmt.Sprintf(`{"success": true, "path": %q, "replacements": %d, "bytes": %d}`, path, count, len(updated))
+}
+
 // experimentalToolNames lists tools that are gated behind QMAX_EXPERIMENTAL=1.
 // These surfaces work but lack public docs / support guarantees, per
 // OPEN_SOURCE_SCOPE.md Phase 2. Set QMAX_EXPERIMENTAL=1 to expose them to the
@@ -665,14 +735,24 @@ func buildAllToolDefs() []api.ToolDef {
 		},
 		{
 			Name:        "run_command",
-			Description: "Run a shell command locally. Use for git operations, npm commands, checking project structure, etc.",
+			Description: "Run one allowlisted shell command locally. Use for git/gh operations, rg searches, package-manager commands, and tests. Do not use shell chaining, pipes, redirects, heredocs, or command substitution; call this tool multiple times instead.",
 			InputSchema: obj(props(
 				prop("command", "string", "Shell command to execute", true),
 			)),
 		},
 		{
+			Name:        "edit_file",
+			Description: "Edit a local file by replacing an exact text block. Read the file first, then provide old_text copied exactly from the file and new_text with the replacement. Use this for code changes; use write_file only for new files or full rewrites.",
+			InputSchema: obj(props(
+				prop("path", "string", "File path to edit", true),
+				prop("old_text", "string", "Exact text block to replace", true),
+				prop("new_text", "string", "Replacement text", true),
+				prop("replace_all", "boolean", "Replace every occurrence instead of requiring exactly one match", false),
+			)),
+		},
+		{
 			Name:        "write_file",
-			Description: "Write content to a local file. Use for creating test files, configs, etc.",
+			Description: "Write content to a local file. Use for creating new files or deliberate full-file rewrites. Prefer edit_file for modifying existing source files.",
 			InputSchema: obj(props(
 				prop("path", "string", "File path to write", true),
 				prop("content", "string", "File content to write", true),
@@ -1465,21 +1545,19 @@ func executeToolViaQMax(name string, rawInput interface{}, sctx *api.SessionCont
 		}
 		return runShell(ctx, "sh", "-c", cmd)
 
+	case "edit_file":
+		return editLocalFile(input)
+
 	case "write_file":
 		path := fmt.Sprintf("%v", input["path"])
 		content := fmt.Sprintf("%v", input["content"])
 
-		// Security: restrict to current directory
-		absPath, err := filepath.Abs(path)
+		absPath, err := localWorkspacePath(path)
 		if err != nil {
 			return fmt.Sprintf(`{"error": %q}`, err.Error())
 		}
-		cwd, _ := os.Getwd()
-		if !strings.HasPrefix(absPath, cwd) {
-			return `{"error": "write_file restricted to current directory for security"}`
-		}
 
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(absPath, []byte(content), 0644); err != nil {
 			return fmt.Sprintf(`{"error": %q}`, err.Error())
 		}
 		return fmt.Sprintf(`{"success": true, "path": %q, "bytes": %d}`, path, len(content))
@@ -1624,8 +1702,8 @@ func ToolCost(name string) string {
 	switch name {
 	case "list_projects", "list_test_cases", "list_scripts", "check_test_status",
 		"crawl_status", "crawl_results", "list_crawl_jobs", "list_repos",
-		"repo_coverage", "repo_quality", "read_file", "run_command", "write_file",
-		"get_script", "update_plan":
+		"repo_coverage", "repo_quality", "read_file", "run_command", "edit_file",
+		"write_file", "get_script", "update_plan":
 		return "free" // read-only or local, no cost
 	case "generate_test_code":
 		return "low" // AI generation, small cost

--- a/internal/agent/tools_test.go
+++ b/internal/agent/tools_test.go
@@ -1,12 +1,17 @@
 package agent
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
 )
 
 func TestToolCost_Free(t *testing.T) {
-	freeTools := []string{"list_projects", "list_test_cases", "list_scripts", "read_file", "run_command", "write_file", "get_script"}
+	freeTools := []string{"list_projects", "list_test_cases", "list_scripts", "read_file", "run_command", "edit_file", "write_file", "get_script"}
 	for _, tool := range freeTools {
 		if cost := ToolCost(tool); cost != "free" {
 			t.Errorf("ToolCost(%q) = %q, want free", tool, cost)
@@ -63,5 +68,83 @@ func TestSummarizeToolResult_CrawlStatus(t *testing.T) {
 	result := SummarizeToolResult("crawl_status", `{"id":"abc","status":"crawling","progress":50}`)
 	if !strings.Contains(result, "crawling") || !strings.Contains(result, "50") {
 		t.Errorf("Expected crawl status, got: %s", result)
+	}
+}
+
+func TestEditFileReplacesExactBlock(t *testing.T) {
+	dir := t.TempDir()
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	path := filepath.Join(dir, "subject.txt")
+	if err := os.WriteFile(path, []byte("alpha\nbeta\ngamma\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ExecuteTool("edit_file", map[string]interface{}{
+		"path":     "subject.txt",
+		"old_text": "beta\n",
+		"new_text": "delta\n",
+	}, &api.SessionContext{}, context.Background())
+	if !strings.Contains(out, `"success": true`) {
+		t.Fatalf("edit_file output = %s", out)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "alpha\ndelta\ngamma\n" {
+		t.Fatalf("file content = %q", got)
+	}
+}
+
+func TestEditFileRejectsAmbiguousMatch(t *testing.T) {
+	dir := t.TempDir()
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	if err := os.WriteFile("subject.txt", []byte("same\nsame\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := ExecuteTool("edit_file", map[string]interface{}{
+		"path":     "subject.txt",
+		"old_text": "same\n",
+		"new_text": "other\n",
+	}, &api.SessionContext{}, context.Background())
+	if !strings.Contains(out, "matched 2 times") {
+		t.Fatalf("edit_file output = %s", out)
+	}
+}
+
+func TestWriteFileRejectsParentTraversal(t *testing.T) {
+	dir := t.TempDir()
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCwd) })
+
+	out := ExecuteTool("write_file", map[string]interface{}{
+		"path":    "../outside.txt",
+		"content": "nope",
+	}, &api.SessionContext{}, context.Background())
+	if !strings.Contains(out, "restricted to the current directory") {
+		t.Fatalf("write_file output = %s", out)
 	}
 }

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -293,6 +293,8 @@ var allowedCommands = map[string]bool{
 	"wc":      true,
 	"find":    true,
 	"grep":    true,
+	"rg":      true,
+	"gh":      true,
 	"npm":     true,
 	"npx":     true,
 	"node":    true,
@@ -369,7 +371,7 @@ func ValidateCommand(cmd string) string {
 		return "empty command"
 	}
 	if !allowedCommands[fields[0]] {
-		return "command not in allowlist. Allowed: git, ls, cat, npm, npx, node, go, python, qmax, etc."
+		return "command not in allowlist. Allowed: git, gh, rg, ls, cat, npm, npx, node, go, python, qmax, etc."
 	}
 
 	return "" // safe

--- a/internal/security/security_test.go
+++ b/internal/security/security_test.go
@@ -197,6 +197,8 @@ func TestValidateCommandAllowsSimpleKnownCommands(t *testing.T) {
 		"go test ./...",
 		"python3 -m pytest",
 		"qmax projects --json",
+		"gh api repos/Quality-Max/qamax-rag-app/pulls/1126",
+		"rg -n Cerebras internal",
 	} {
 		if got := ValidateCommand(cmd); got != "" {
 			t.Errorf("ValidateCommand(%q) = %q, want allowed", cmd, got)


### PR DESCRIPTION
## Summary
- make the Cerebras/native prompt treat local coding and PR review as first-class workflows
- add an exact-match edit_file tool for targeted workspace edits instead of relying on blocked heredocs/redirects
- allow gh and rg in the local command validator so PR/code inspection works from Cerebras
- add regression coverage for edit_file, path confinement, and command allowlist changes

## Tests
- go test ./internal/agent
- go test ./internal/security
- go test -timeout 20s ./internal/tui
- go test -timeout 20s ./internal/vnc
- git diff --check

Note: go test ./... was started; completed packages passed, but the run hung on an existing orphaned fake-Claude subprocess from a CC-agent test, so it was terminated and relevant packages were run separately.