### PR TITLE
Route Gemma 4 through Cerebras backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,34 @@ Get your QualityMax API key at: https://app.qualitymax.io/settings
 
 **Local:** read_file, write_file, run_command, run_local_test
 
+## Gemma 4 on Cerebras (multimodal, ultra-fast)
+
+qmax-code can drive its entire agent loop through **Google DeepMind's Gemma 4 31B** hosted on **Cerebras** — multimodal vision, native function-calling over the full tool set, and optional reasoning, at Cerebras inference speed. Every response surfaces the live `tokens/sec` and time-to-first-token straight from Cerebras's `time_info`, so the speed advantage is visible in the terminal.
+
+```bash
+# One-shot activation inside the REPL
+> /gemma                 # backend→Cerebras, model→gemma-4-31b, reasoning: low
+> /gemma high            # max thinking
+> /gemma none            # fastest (reasoning off) — best for a pure speed demo
+> /gemma off             # back to the Anthropic API
+
+# Or pre-configure:
+qmax-code config set backend cerebras
+qmax-code config set cerebras_model gemma             # resolves to gemma-4-31b
+qmax-code config set cerebras_reasoning_effort medium
+```
+
+**Signature demo — screenshot → Playwright test:** paste a picture of a web page and Gemma 4 reads the pixels (buttons, forms, navigation, the primary user flow) and generates a runnable Playwright e2e test, then runs it.
+
+```
+> /gemma
+> /screenshot            # capture any web page → Gemma 4 generates + verifies a test
+# or
+> /paste                 # paste an image from clipboard
+```
+
+The multimodal path works because qmax converts image attachments into OpenAI `image_url` base64 data-URI parts (`internal/agent/cerebras.go`), which is exactly the format Cerebras accepts for Gemma 4. Env overrides: `CEREBRAS_API_KEY`, `CEREBRAS_MODEL`, `CEREBRAS_REASONING_EFFORT`.
+
 ## Requirements
 
 - Go 1.24+ (for building from source)

--- a/config_command.go
+++ b/config_command.go
@@ -114,6 +114,11 @@ func printConfig() {
 		cerebrasBase = api.CerebrasAPIBase + " (default)"
 	}
 	fmt.Printf("    cerebras_base_url = %q\n", cerebrasBase)
+	cerebrasReasoning := cfg.CerebrasReasoningEffort
+	if cerebrasReasoning == "" {
+		cerebrasReasoning = "none (default — Gemma 4 thinking off)"
+	}
+	fmt.Printf("    cerebras_reasoning_effort = %q\n", cerebrasReasoning)
 	backend := cfg.Backend
 	if backend == "" {
 		backend = "api"
@@ -251,10 +256,22 @@ func setConfigField(key, value string) error {
 		return api.SaveCerebrasKey(value)
 
 	case "cerebras_model":
-		cfg.CerebrasModel = value
+		// Resolve aliases (e.g. "gemma" → "gemma-4-31b"); unknown values pass
+		// through unchanged so raw model IDs keep working.
+		cfg.CerebrasModel = api.ResolveCerebrasModel(value)
 
 	case "cerebras_base_url":
 		cfg.CerebrasBaseURL = value
+
+	case "cerebras_reasoning_effort", "cerebras-reasoning-effort":
+		if value == "" {
+			cfg.CerebrasReasoningEffort = ""
+			break
+		}
+		if !api.ValidCerebrasReasoningEffort(value) {
+			return fmt.Errorf("invalid cerebras_reasoning_effort %q; allowed: none, low, medium, high", value)
+		}
+		cfg.CerebrasReasoningEffort = api.NormalizeCerebrasReasoningEffort(value)
 
 	case "theme":
 		return tui.SaveTheme(cfg, value)

--- a/config_command_test.go
+++ b/config_command_test.go
@@ -80,6 +80,46 @@ func TestSetConfigField_CerebrasModelAndBaseURL(t *testing.T) {
 	}
 }
 
+func TestSetConfigField_CerebrasModelResolvesGemmaAlias(t *testing.T) {
+	withTempHome(t)
+
+	if err := setConfigField("cerebras_model", "gemma"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	loaded := api.LoadQMaxCodeConfig()
+	if loaded.CerebrasModel != api.CerebrasGemma4Model {
+		t.Errorf("CerebrasModel: got %q, want %q (alias resolved)", loaded.CerebrasModel, api.CerebrasGemma4Model)
+	}
+}
+
+func TestSetConfigField_CerebrasReasoningEffort(t *testing.T) {
+	withTempHome(t)
+
+	// Valid values normalize to canonical lowercase.
+	for _, in := range []string{"none", "low", "Medium", " HIGH "} {
+		if err := setConfigField("cerebras_reasoning_effort", in); err != nil {
+			t.Fatalf("unexpected error for %q: %v", in, err)
+		}
+	}
+	loaded := api.LoadQMaxCodeConfig()
+	if loaded.CerebrasReasoningEffort != "high" {
+		t.Errorf("last value: got %q, want high", loaded.CerebrasReasoningEffort)
+	}
+
+	// Invalid value rejected.
+	if err := setConfigField("cerebras_reasoning_effort", "turbo"); err == nil {
+		t.Error("expected error for invalid reasoning_effort")
+	}
+
+	// Empty clears it.
+	if err := setConfigField("cerebras_reasoning_effort", ""); err != nil {
+		t.Fatalf("unexpected error clearing: %v", err)
+	}
+	if loaded := api.LoadQMaxCodeConfig(); loaded.CerebrasReasoningEffort != "" {
+		t.Errorf("expected empty after clear, got %q", loaded.CerebrasReasoningEffort)
+	}
+}
+
 func TestConfigSetDisplayValueRedactsCerebrasKey(t *testing.T) {
 	secret := "csk-vv52c6kwywjmejmnp8xd8c2p4"
 	got := configSetDisplayValue("cerebras_key", secret)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1104,6 +1104,16 @@ Always state your confidence: "Confidence: HIGH — the button selector changed 
 For any multi-step task (e.g. generate→run→heal, gap analysis across cases, CI/CD setup), call update_plan FIRST to lay out your steps, then update it as you go — mark a step "in_progress" when you start it and "done" when you finish, always passing the COMPLETE ordered list. Skip it for single-step questions; don't narrate the plan in prose when the tool already shows it.
 `
 
+	// Vision guidance — only appended when Cerebras is driving (the Gemma 4
+	// multimodal path). Routes image attachments straight to test generation,
+	// so the demo flow is: paste a screenshot → Playwright test → run it.
+	if a.Cerebras != nil && api.IsCerebrasGemma4Model(a.Cerebras.Model) {
+		prompt += `
+## Vision (multimodal — Gemma 4 on Cerebras)
+You have vision. When the user attaches a screenshot or image of a web page or UI: read the pixels. Identify the page, visible headings, buttons, links, form fields, navigation, and the primary user flow shown. Then call generate_test_code to produce a Playwright e2e test that covers that flow, and run it to verify (run_test). Treat the image as the spec — only ask for a URL if the image is clearly not a web page. After running, summarize pass/fail concisely. This is the signature capability: a picture in, a passing test out.
+`
+	}
+
 	// Dashboard URLs
 	cloudURL := a.Cfg.Context.QMaxCfg.CloudURL
 	if cloudURL != "" {

--- a/internal/agent/cerebras.go
+++ b/internal/agent/cerebras.go
@@ -21,10 +21,11 @@ import (
 
 // CerebrasClient wraps HTTP calls to a Cerebras (OpenAI-compatible) endpoint.
 type CerebrasClient struct {
-	BaseURL string // e.g. "https://api.cerebras.ai/v1"
-	Model   string // e.g. "gpt-oss-120b"
-	APIKey  string
-	HTTP    *http.Client
+	BaseURL         string // e.g. "https://api.cerebras.ai/v1"
+	Model           string // e.g. "gpt-oss-120b" or "gemma-4-31b"
+	APIKey          string
+	ReasoningEffort string // "", "none", "low", "medium", "high" (Gemma 4 thinking)
+	HTTP            *http.Client
 }
 
 // NewCerebrasClient builds a client from config, or returns nil if no API key
@@ -37,15 +38,13 @@ func NewCerebrasClient(cfg *api.Config) *CerebrasClient {
 	if base == "" {
 		base = api.CerebrasAPIBase
 	}
-	model := cfg.CerebrasModel
-	if model == "" {
-		model = api.CerebrasDefaultModel
-	}
+	model := api.ResolveCerebrasModel(cfg.CerebrasModel)
 	return &CerebrasClient{
-		BaseURL: strings.TrimRight(base, "/"),
-		Model:   model,
-		APIKey:  cfg.CerebrasKey,
-		HTTP:    &http.Client{Timeout: 300 * time.Second},
+		BaseURL:         strings.TrimRight(base, "/"),
+		Model:           model,
+		APIKey:          cfg.CerebrasKey,
+		ReasoningEffort: api.NormalizeCerebrasReasoningEffort(cfg.CerebrasReasoningEffort),
+		HTTP:            &http.Client{Timeout: 300 * time.Second},
 	}
 }
 
@@ -91,12 +90,13 @@ type oaiImageURL struct {
 }
 
 type oaiChatRequest struct {
-	Model       string       `json:"model"`
-	Messages    []oaiMessage `json:"messages"`
-	Tools       []oaiTool    `json:"tools,omitempty"`
-	MaxTokens   int          `json:"max_tokens,omitempty"`
-	Temperature float64      `json:"temperature"`
-	Stream      bool         `json:"stream"`
+	Model           string       `json:"model"`
+	Messages        []oaiMessage `json:"messages"`
+	Tools           []oaiTool    `json:"tools,omitempty"`
+	MaxTokens       int          `json:"max_tokens,omitempty"`
+	Temperature     float64      `json:"temperature"`
+	Stream          bool         `json:"stream"`
+	ReasoningEffort string       `json:"reasoning_effort,omitempty"` // Gemma 4 thinking: low|medium|high (none omitted)
 }
 
 type oaiChatResponse struct {
@@ -111,20 +111,97 @@ type oaiChatResponse struct {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
 	} `json:"usage"`
+	// TimeInfo carries Cerebras-specific request timing (tokens/sec, TTFT,
+	// total time). Parsed loosely as a map so key-name changes don't break us.
+	TimeInfo map[string]interface{} `json:"time_info,omitempty"`
+}
+
+// reasoningEffortIsOn reports whether the configured effort will actually
+// engage Gemma 4 thinking (i.e. one of low/medium/high).
+func reasoningEffortIsOn(effort string) bool {
+	switch effort {
+	case "low", "medium", "high":
+		return true
+	}
+	return false
+}
+
+func effectiveCerebrasReasoningEffort(model, effort string) string {
+	effort = api.NormalizeCerebrasReasoningEffort(effort)
+	if !api.IsCerebrasGemma4Model(model) || !reasoningEffortIsOn(effort) {
+		return ""
+	}
+	return effort
+}
+
+// CerebrasTokensPerSecond pulls a tokens/sec figure from a Cerebras
+// time_info object, trying common key names. Returns 0 if unavailable.
+func CerebrasTokensPerSecond(ti map[string]interface{}) float64 {
+	if ti == nil {
+		return 0
+	}
+	for _, k := range []string{
+		"tokens_per_second",
+		"output_tokens_per_second",
+		"completion_tokens_per_second",
+		"generation_tokens_per_second",
+		"tps",
+	} {
+		if v, ok := ti[k]; ok {
+			if f, ok := toFloat64(v); ok && f > 0 {
+				return f
+			}
+		}
+	}
+	return 0
+}
+
+// CerebrasTTFTSec pulls time-to-first-token (in seconds) from time_info if present.
+func CerebrasTTFTSec(ti map[string]interface{}) float64 {
+	if ti == nil {
+		return 0
+	}
+	for _, k := range []string{"time_to_first_token_sec", "ttft_sec", "time_to_first_token"} {
+		if v, ok := ti[k]; ok {
+			if f, ok := toFloat64(v); ok && f >= 0 {
+				return f
+			}
+		}
+	}
+	// Some responses report TTFT in milliseconds.
+	for _, k := range []string{"time_to_first_token_ms", "ttft_ms"} {
+		if v, ok := ti[k]; ok {
+			if f, ok := toFloat64(v); ok && f > 0 {
+				return f / 1000.0
+			}
+		}
+	}
+	return 0
+}
+
+func toFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case json.Number:
+		if f, err := n.Float64(); err == nil {
+			return f, true
+		}
+	}
+	return 0, false
 }
 
 // Chat performs a single non-streaming chat completion. Cerebras is fast
 // enough (~1000+ tok/s) that non-streaming keeps the tool loop simple and the
 // tool-call parsing reliable.
 func (c *CerebrasClient) Chat(ctx context.Context, msgs []oaiMessage, tools []oaiTool) (*oaiChatResponse, error) {
-	reqBody := oaiChatRequest{
-		Model:       c.Model,
-		Messages:    msgs,
-		Tools:       tools,
-		MaxTokens:   8192,
-		Temperature: 0,
-		Stream:      false,
-	}
+	reqBody := c.chatRequest(msgs, tools)
 	data, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -156,6 +233,26 @@ func (c *CerebrasClient) Chat(ctx context.Context, msgs []oaiMessage, tools []oa
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 	return &out, nil
+}
+
+func (c *CerebrasClient) chatRequest(msgs []oaiMessage, tools []oaiTool) oaiChatRequest {
+	reasoningEffort := effectiveCerebrasReasoningEffort(c.Model, c.ReasoningEffort)
+	// Gemma 4 thinking consumes output tokens; give the model more room when
+	// reasoning is engaged so high-effort answers don't truncate. The hackathon
+	// grants a 32K completion cap, so 16K is a safe default for reasoning turns.
+	maxTokens := 8192
+	if reasoningEffortIsOn(reasoningEffort) {
+		maxTokens = 16384
+	}
+	return oaiChatRequest{
+		Model:           c.Model,
+		Messages:        msgs,
+		Tools:           tools,
+		MaxTokens:       maxTokens,
+		Temperature:     0,
+		Stream:          false,
+		ReasoningEffort: reasoningEffort,
+	}
 }
 
 // toolDefsToOpenAI converts qmax tool definitions (Anthropic-shaped:

--- a/internal/agent/cerebras_agent.go
+++ b/internal/agent/cerebras_agent.go
@@ -99,6 +99,7 @@ func (a *Agent) RunCerebrasAgent(term *tui.Terminal) (string, bool) {
 				// would silently drop the text.
 				term.PrintAssistant(choice.Message.Content)
 			}
+			printCerebrasSpeed(term, resp, a.Cerebras.Model)
 
 			var toolUse []api.ContentBlock
 			for _, b := range blocks {
@@ -126,8 +127,36 @@ func (a *Agent) RunCerebrasAgent(term *tui.Terminal) (string, bool) {
 		// Final answer. PrintAssistant renders unconditionally (non-streaming path).
 		term.PrintAssistant(choice.Message.Content)
 		term.PrintTokenUsage(a.Usage)
+		printCerebrasSpeed(term, resp, a.Cerebras.Model)
 		return choice.Message.Content, true
 	}
 
 	return "", false
+}
+
+// printCerebrasSpeed surfaces the live Cerebras inference rate from a
+// response's time_info object. This is the headline "Speed in Action" signal
+// for the Cerebras + Gemma 4 demo — seeing ~2000+ tok/s in the terminal makes
+// the latency advantage tangible. No-op when time_info is absent.
+func printCerebrasSpeed(term *tui.Terminal, resp *oaiChatResponse, model string) {
+	if resp == nil {
+		return
+	}
+	tps := CerebrasTokensPerSecond(resp.TimeInfo)
+	ttft := CerebrasTTFTSec(resp.TimeInfo)
+	if tps <= 0 && ttft <= 0 {
+		return
+	}
+	modelLabel := model
+	if modelLabel == "" {
+		modelLabel = "cerebras"
+	}
+	switch {
+	case tps > 0 && ttft > 0:
+		term.PrintSystem(fmt.Sprintf("⚡ %s on Cerebras: %.0f tok/s · TTFT %.2fs", modelLabel, tps, ttft))
+	case tps > 0:
+		term.PrintSystem(fmt.Sprintf("⚡ %s on Cerebras: %.0f tok/s", modelLabel, tps))
+	default:
+		term.PrintSystem(fmt.Sprintf("⚡ %s on Cerebras: TTFT %.2fs", modelLabel, ttft))
+	}
 }

--- a/internal/agent/cerebras_test.go
+++ b/internal/agent/cerebras_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/qualitymax/qmax-code/internal/api"
@@ -67,6 +68,132 @@ func TestNewCerebrasClientOverrides(t *testing.T) {
 	}
 	if c.BaseURL != "https://proxy.internal/v1" {
 		t.Errorf("BaseURL = %q, want trailing slash trimmed", c.BaseURL)
+	}
+}
+
+func TestNewCerebrasClientResolvesGemmaAlias(t *testing.T) {
+	c := NewCerebrasClient(&api.Config{
+		CerebrasKey:   "csk-test",
+		CerebrasModel: "gemma", // alias must resolve to the full model ID
+	})
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if c.Model != api.CerebrasGemma4Model {
+		t.Errorf("Model = %q, want %q (alias resolved)", c.Model, api.CerebrasGemma4Model)
+	}
+}
+
+func TestNewCerebrasClientPropagatesReasoningEffort(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"medium", "medium"},
+		{"High", "high"}, // case-insensitive
+		{"none", "none"},
+		{"", ""},
+		{"bogus", ""}, // invalid → omitted (off)
+	}
+	for _, tc := range cases {
+		c := NewCerebrasClient(&api.Config{
+			CerebrasKey:             "csk-test",
+			CerebrasModel:           api.CerebrasGemma4Model,
+			CerebrasReasoningEffort: tc.in,
+		})
+		if c.ReasoningEffort != tc.want {
+			t.Errorf("ReasoningEffort(%q) = %q, want %q", tc.in, c.ReasoningEffort, tc.want)
+		}
+	}
+}
+
+func TestReasoningEffortOmittedWhenEmpty(t *testing.T) {
+	// Empty effort must not serialize reasoning_effort (Cerebras default = off).
+	c := NewCerebrasClient(&api.Config{CerebrasKey: "csk-test"})
+	body, err := json.Marshal(c.chatRequest(nil, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "reasoning_effort") {
+		t.Errorf("empty effort should be omitted; got %s", body)
+	}
+
+	// "none" is stored as an explicit user choice but omitted from the API
+	// request, matching Cerebras's default thinking-off behavior.
+	c2 := NewCerebrasClient(&api.Config{
+		CerebrasKey:             "csk-test",
+		CerebrasModel:           api.CerebrasGemma4Model,
+		CerebrasReasoningEffort: "none",
+	})
+	body2, err := json.Marshal(c2.chatRequest(nil, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body2), "reasoning_effort") {
+		t.Errorf("none effort should be omitted; got %s", body2)
+	}
+
+	// "high" must serialize for Gemma 4.
+	c3 := NewCerebrasClient(&api.Config{
+		CerebrasKey:             "csk-test",
+		CerebrasModel:           api.CerebrasGemma4Model,
+		CerebrasReasoningEffort: "high",
+	})
+	body3, err := json.Marshal(c3.chatRequest(nil, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body3), `"reasoning_effort":"high"`) {
+		t.Errorf("high effort should serialize for Gemma; got %s", body3)
+	}
+
+	// Non-Gemma Cerebras models should not receive Gemma-only reasoning params.
+	c4 := NewCerebrasClient(&api.Config{
+		CerebrasKey:             "csk-test",
+		CerebrasModel:           api.CerebrasDefaultModel,
+		CerebrasReasoningEffort: "high",
+	})
+	body4, err := json.Marshal(c4.chatRequest(nil, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body4), "reasoning_effort") {
+		t.Errorf("non-Gemma effort should be omitted; got %s", body4)
+	}
+}
+
+func TestCerebrasTokensPerSecond(t *testing.T) {
+	cases := []struct {
+		name string
+		ti   map[string]interface{}
+		want float64
+	}{
+		{"nil", nil, 0},
+		{"empty", map[string]interface{}{}, 0},
+		{"tokens_per_second", map[string]interface{}{"tokens_per_second": 2150.4}, 2150.4},
+		{"tps fallback", map[string]interface{}{"tps": float64(990)}, 990},
+		{"int value", map[string]interface{}{"output_tokens_per_second": 1800}, 1800},
+		{"zero ignored", map[string]interface{}{"tokens_per_second": 0.0}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CerebrasTokensPerSecond(tc.ti); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCerebrasTTFTSec(t *testing.T) {
+	if got := CerebrasTTFTSec(nil); got != 0 {
+		t.Errorf("nil → %v, want 0", got)
+	}
+	if got := CerebrasTTFTSec(map[string]interface{}{"time_to_first_token_sec": 0.08}); got != 0.08 {
+		t.Errorf("sec → %v, want 0.08", got)
+	}
+	// ms field converts to seconds.
+	if got := CerebrasTTFTSec(map[string]interface{}{"time_to_first_token_ms": 80.0}); got < 0.079 || got > 0.081 {
+		t.Errorf("ms → %v, want ~0.08", got)
 	}
 }
 

--- a/internal/api/cerebras.go
+++ b/internal/api/cerebras.go
@@ -1,5 +1,7 @@
 package api
 
+import "strings"
+
 // Cerebras inference (OpenAI-compatible). The cerebras backend drives the
 // native qmax agent loop — full tool set, native function-calling — through
 // Cerebras's /v1/chat/completions endpoint, which is fast and low-cost.
@@ -12,4 +14,53 @@ const (
 	CerebrasAPIBase = "https://api.cerebras.ai/v1"
 	// CerebrasDefaultModel is a fast, capable general/coding model on Cerebras.
 	CerebrasDefaultModel = "gpt-oss-120b"
+	// CerebrasGemma4Model is Google DeepMind's Gemma 4 31B as hosted on
+	// Cerebras. It is multimodal (text + image input, text output) and exposes
+	// reasoning via the top-level reasoning_effort parameter (off by default).
+	// Model ID per the Cerebras + Gemma 4 hackathon docs.
+	CerebrasGemma4Model = "gemma-4-31b"
 )
+
+// ResolveCerebrasModel expands shorthand aliases to full Cerebras model IDs.
+// Unknown values pass through unchanged so users can set raw model IDs.
+//
+//	""            → CerebrasDefaultModel (gpt-oss-120b)
+//	"gemma"       → CerebrasGemma4Model (gemma-4-31b)
+//	"gemma-4-31b" → CerebrasGemma4Model
+func ResolveCerebrasModel(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "", "default":
+		return CerebrasDefaultModel
+	case "gemma", "gemma4", "gemma-4", "gemma-4-31b", "gemma4-31b", "gemma-4-31":
+		return CerebrasGemma4Model
+	}
+	return name
+}
+
+// IsCerebrasGemma4Model reports whether modelID is the Gemma 4 31B variant.
+// Used to gate Gemma-specific behavior (reasoning, multimodal nudges).
+func IsCerebrasGemma4Model(modelID string) bool {
+	return ResolveCerebrasModel(modelID) == CerebrasGemma4Model
+}
+
+// ValidCerebrasReasoningEffort reports whether s is an accepted
+// reasoning_effort value. Empty and "none" keep Gemma 4 thinking off (the
+// Cerebras default); "low", "medium", and "high" turn it on.
+func ValidCerebrasReasoningEffort(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "none", "low", "medium", "high":
+		return true
+	}
+	return false
+}
+
+// NormalizeCerebrasReasoningEffort canonicalizes a reasoning_effort value.
+// Invalid input maps to "" (omit from the request → Cerebras default = off).
+func NormalizeCerebrasReasoningEffort(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	switch s {
+	case "", "none", "low", "medium", "high":
+		return s
+	}
+	return ""
+}

--- a/internal/api/cerebras_test.go
+++ b/internal/api/cerebras_test.go
@@ -1,0 +1,70 @@
+package api
+
+import "testing"
+
+func TestResolveCerebrasModel(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", CerebrasDefaultModel},
+		{"default", CerebrasDefaultModel},
+		{"DEFAULT", CerebrasDefaultModel}, // case-insensitive
+		{"gemma", CerebrasGemma4Model},
+		{"Gemma-4", CerebrasGemma4Model},
+		{"gemma4", CerebrasGemma4Model},
+		{"gemma-4-31b", CerebrasGemma4Model},
+		{"gemma4-31b", CerebrasGemma4Model},
+		{"gemma-4-31", CerebrasGemma4Model},
+		{"zai-glm-4.7", "zai-glm-4.7"},     // unknown passes through
+		{"  gemma  ", CerebrasGemma4Model}, // whitespace trimmed
+	}
+	for _, c := range cases {
+		if got := ResolveCerebrasModel(c.in); got != c.want {
+			t.Errorf("ResolveCerebrasModel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsCerebrasGemma4Model(t *testing.T) {
+	if !IsCerebrasGemma4Model("gemma") {
+		t.Error(`"gemma" should be recognized as Gemma 4`)
+	}
+	if !IsCerebrasGemma4Model(CerebrasGemma4Model) {
+		t.Error("gemma-4-31b should be recognized as Gemma 4")
+	}
+	if IsCerebrasGemma4Model(CerebrasDefaultModel) {
+		t.Error("default model should not be Gemma 4")
+	}
+}
+
+func TestValidCerebrasReasoningEffort(t *testing.T) {
+	valid := []string{"", "none", "low", "medium", "high", " None ", "HIGH"}
+	for _, v := range valid {
+		if !ValidCerebrasReasoningEffort(v) {
+			t.Errorf("expected %q to be valid", v)
+		}
+	}
+	invalid := []string{"max", "1", "ultra"}
+	for _, v := range invalid {
+		if ValidCerebrasReasoningEffort(v) {
+			t.Errorf("expected %q to be invalid", v)
+		}
+	}
+}
+
+func TestNormalizeCerebrasReasoningEffort(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"none", "none"},
+		{"Medium", "medium"},
+		{"  high ", "high"},
+		{"bogus", ""}, // invalid normalizes to "" (off / omitted)
+	}
+	for _, c := range cases {
+		if got := NormalizeCerebrasReasoningEffort(c.in); got != c.want {
+			t.Errorf("NormalizeCerebrasReasoningEffort(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -575,7 +575,7 @@ func (c *APIClient) CreateTestCase(ctx context.Context, projectID int, title, de
 		body["category"] = category
 	}
 	if priority != "" {
-		body["priority"] = priority
+		body["priority"] = parseTestCasePriority(priority)
 	}
 	return c.post(ctx, "/api/test-cases/", body)
 }
@@ -592,12 +592,38 @@ func (c *APIClient) UpdateTestCase(ctx context.Context, testCaseID int, title, d
 		body["category"] = category
 	}
 	if priority != "" {
-		body["priority"] = priority
+		body["priority"] = parseTestCasePriority(priority)
 	}
 	if status != "" {
 		body["status"] = status
 	}
 	return c.put(ctx, fmt.Sprintf("/api/test-cases/%d", testCaseID), body)
+}
+
+func parseTestCasePriority(value string) int {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "critical":
+		return 1
+	case "high":
+		return 2
+	case "medium", "":
+		return 3
+	case "low":
+		return 4
+	case "trivial", "very low", "very-low", "very_low":
+		return 5
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 3
+	}
+	if n < 1 {
+		return 1
+	}
+	if n > 5 {
+		return 5
+	}
+	return n
 }
 
 func (c *APIClient) DeleteTestCase(ctx context.Context, testCaseID int) string {

--- a/internal/api/client_native_test.go
+++ b/internal/api/client_native_test.go
@@ -206,6 +206,83 @@ func TestGenerateTestCode_RejectsInvalidFramework(t *testing.T) {
 	}
 }
 
+// ---- Test Cases ----
+
+func TestCreateTestCase_MapsPriorityNamesToIntegers(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]interface{}
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_, _ = w.Write([]byte(`{"id":123}`))
+	})
+
+	client.CreateTestCase(context.Background(), 242, "Login", "Verify login", "functional", "critical")
+
+	if gotMethod != "POST" {
+		t.Errorf("method: got %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/test-cases/" {
+		t.Errorf("path: got %q, want /api/test-cases/", gotPath)
+	}
+	if gotBody["project_id"].(float64) != 242 {
+		t.Errorf("project_id: got %v, want 242", gotBody["project_id"])
+	}
+	if gotBody["priority"].(float64) != 1 {
+		t.Errorf("priority: got %v, want 1 for critical", gotBody["priority"])
+	}
+}
+
+func TestUpdateTestCase_MapsPriorityNamesToIntegers(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]interface{}
+	client, _ := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		_, _ = w.Write([]byte(`{"id":123}`))
+	})
+
+	client.UpdateTestCase(context.Background(), 123, "", "", "", "low", "")
+
+	if gotMethod != "PUT" {
+		t.Errorf("method: got %q, want PUT", gotMethod)
+	}
+	if gotPath != "/api/test-cases/123" {
+		t.Errorf("path: got %q, want /api/test-cases/123", gotPath)
+	}
+	if gotBody["priority"].(float64) != 4 {
+		t.Errorf("priority: got %v, want 4 for low", gotBody["priority"])
+	}
+}
+
+func TestParseTestCasePriority(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"critical", 1},
+		{"High", 2},
+		{" medium ", 3},
+		{"low", 4},
+		{"trivial", 5},
+		{"very low", 5},
+		{"1", 1},
+		{"5", 5},
+		{"0", 1},
+		{"99", 5},
+		{"unexpected", 3},
+	}
+	for _, tc := range cases {
+		if got := parseTestCasePriority(tc.in); got != tc.want {
+			t.Errorf("parseTestCasePriority(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
 // ---- ImportRepo ----
 
 func TestImportRepo_OmitsTrainingConsentByDefault(t *testing.T) {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -36,8 +36,13 @@ type Config struct {
 	// qmax tool set, so it can handle all coding tasks directly.
 	// The API key is stored in the OS keychain, never in JSON.
 	CerebrasKey     string `json:"-"`
-	CerebrasModel   string `json:"cerebras_model,omitempty"`    // default "gpt-oss-120b"
+	CerebrasModel   string `json:"cerebras_model,omitempty"`    // default "gpt-oss-120b"; "gemma-4-31b" for Gemma 4
 	CerebrasBaseURL string `json:"cerebras_base_url,omitempty"` // default "https://api.cerebras.ai/v1"
+	// CerebrasReasoningEffort toggles Gemma 4 thinking on Cerebras. Empty or
+	// "none" keeps reasoning off (fastest, the Cerebras default). "low" /
+	// "medium" / "high" turn it on, trading latency for more thorough answers.
+	// Maps to the top-level reasoning_effort Chat Completions parameter.
+	CerebrasReasoningEffort string `json:"cerebras_reasoning_effort,omitempty"`
 
 	// Backend selects the LLM inference backend.
 	//   ""  / "api" → Anthropic API directly (default, requires ANTHROPIC_API_KEY)
@@ -140,6 +145,9 @@ func LoadQMaxCodeConfig() *Config {
 	}
 	if model := os.Getenv("CEREBRAS_MODEL"); model != "" {
 		cfg.CerebrasModel = model
+	}
+	if re := os.Getenv("CEREBRAS_REASONING_EFFORT"); re != "" {
+		cfg.CerebrasReasoningEffort = re
 	}
 
 	return cfg

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -371,10 +371,19 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 			if ag.Mode == agent.OllamaModeFull {
 				currentBackend = "ollama"
 			}
+			currentModelID := cfg.ModelOverride
+			currentEffort := cfg.Effort
+			if currentBackend == "cerebras" {
+				currentModelID = api.ResolveCerebrasModel(cfg.CerebrasModel)
+				currentEffort = api.NormalizeCerebrasReasoningEffort(cfg.CerebrasReasoningEffort)
+				if currentEffort == "" || currentEffort == "none" {
+					currentEffort = "low"
+				}
+			}
 			result := tui.ShowModelPicker(tui.ModelPickerOpts{
 				CurrentBackend: currentBackend,
-				CurrentModelID: cfg.ModelOverride,
-				Effort:         cfg.Effort,
+				CurrentModelID: currentModelID,
+				Effort:         currentEffort,
 				OllamaURL:      cfg.OllamaURL,
 				OllamaModel:    cfg.OllamaModel,
 				CCInstalled:    agent.FindClaudeCode() != "",
@@ -443,7 +452,10 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				}
 				// Apply the chosen Cerebras model.
 				if result.ModelID != "" {
-					cfg.CerebrasModel = result.ModelID
+					cfg.CerebrasModel = api.ResolveCerebrasModel(result.ModelID)
+				}
+				if api.IsCerebrasGemma4Model(cfg.CerebrasModel) {
+					cfg.CerebrasReasoningEffort = api.NormalizeCerebrasReasoningEffort(result.Effort)
 				}
 				// Tear down any active CLI agent / Ollama mode.
 				if cliAgent != nil {
@@ -455,7 +467,11 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				cfg.Backend = "cerebras"
 				ag.Cfg.Context.Backend = "cerebras"
 				_ = cfg.Save()
-				term.PrintSystem(fmt.Sprintf("Backend: Cerebras  model: %s", cfg.CerebrasModel))
+				if api.IsCerebrasGemma4Model(cfg.CerebrasModel) {
+					term.PrintSystem(fmt.Sprintf("Backend: Cerebras  model: %s  reasoning: %s", cfg.CerebrasModel, cfg.CerebrasReasoningEffort))
+				} else {
+					term.PrintSystem(fmt.Sprintf("Backend: Cerebras  model: %s", cfg.CerebrasModel))
+				}
 				continue
 			}
 
@@ -656,6 +672,84 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				term.PrintSystem("Backend → Anthropic API (direct)")
 			}
 			ag.Cfg.Context.Backend = cfg.Backend
+			continue
+
+		case input == "/gemma" || strings.HasPrefix(input, "/gemma "):
+			// Activate Gemma 4 31B on Cerebras in one shot — the Cerebras +
+			// Gemma 4 hackathon entrypoint. Selects the multimodal model,
+			// sets reasoning_effort, and flips the live backend. Optional
+			// argument: none|low|medium|high (default low). "/gemma off"
+			// returns to the direct Anthropic API backend.
+			cfg := ag.AppConfig
+			if cfg == nil {
+				term.PrintError("api.Config not loaded.")
+				continue
+			}
+			arg := strings.TrimSpace(strings.TrimPrefix(input, "/gemma"))
+
+			if strings.EqualFold(arg, "off") || strings.EqualFold(arg, "api") {
+				deactivateEmbeddedBackends(ag)
+				if cliAgent != nil {
+					cliAgent.Cleanup()
+					cliAgent = nil
+				}
+				cfg.Backend = ""
+				ag.Cfg.Context.Backend = ""
+				_ = cfg.Save()
+				term.PrintSystem("Gemma disabled → Anthropic API (direct)")
+				continue
+			}
+
+			effort := "low" // default: thinking on, but fast
+			if arg != "" {
+				if !api.ValidCerebrasReasoningEffort(arg) {
+					term.PrintError(fmt.Sprintf("Usage: /gemma [none|low|medium|high|off]; %q is invalid.", arg))
+					continue
+				}
+				effort = api.NormalizeCerebrasReasoningEffort(arg)
+			}
+
+			if cfg.CerebrasKey == "" {
+				term.PrintSystem("Cerebras needs an API key (get one at https://cloud.cerebras.ai).")
+				key := setup.ReadSecret("  Paste your Cerebras key (blank to cancel): ")
+				if key == "" {
+					term.PrintSystem("No key entered — Gemma not activated.")
+					continue
+				}
+				looks, verr := api.ValidateCerebrasKey(key)
+				if verr != nil {
+					term.PrintError(fmt.Sprintf("That doesn't look like an API key (%v). Gemma not activated.", verr))
+					continue
+				}
+				if !looks {
+					term.PrintSystem("  Note: key doesn't start with \"csk-\" — saving anyway.")
+				}
+				if err := api.SaveCerebrasKey(key); err != nil {
+					term.PrintError(fmt.Sprintf("Could not save key: %v", err))
+					continue
+				}
+				cfg.CerebrasKey = key
+				term.PrintSystem("  Saved to OS keychain.")
+			}
+
+			cfg.CerebrasModel = api.CerebrasGemma4Model
+			cfg.CerebrasReasoningEffort = effort
+			if cliAgent != nil {
+				cliAgent.Cleanup()
+				cliAgent = nil
+			}
+			ag.Mode = agent.OllamaModeOff
+			ag.Cerebras = agent.NewCerebrasClient(cfg)
+			cfg.Backend = "cerebras"
+			ag.Cfg.Context.Backend = "cerebras"
+			_ = cfg.Save()
+
+			reasoningLabel := "reasoning off"
+			if effort == "low" || effort == "medium" || effort == "high" {
+				reasoningLabel = "reasoning: " + effort
+			}
+			term.PrintSystem(fmt.Sprintf("Backend: Cerebras · model: %s · %s", cfg.CerebrasModel, reasoningLabel))
+			term.PrintSystem("Multimodal: /screenshot or /paste a page → Gemma 4 reads it and generates a Playwright test.")
 			continue
 
 		case input == "/ollama":
@@ -1205,10 +1299,12 @@ Commands:
   /orch          Cycle orchestration backend: off → CC → Codex → off
   /theme         Live-preview color scheme picker
   /cloudsync     Toggle cloud session sync (enabled/disabled)
-  /cc            Switch to Claude Code backend (no QM API key; Agent SDK credit)
-  /codex         Switch to Codex CLI backend (OpenAI subscription, no API tokens)
-  /api           Switch back to direct Anthropic API
-  /ollama        Toggle Ollama on/off (self-hosted LLM for chat)
+   /cc            Switch to Claude Code backend (no QM API key; Agent SDK credit)
+   /codex         Switch to Codex CLI backend (OpenAI subscription, no API tokens)
+   /api           Switch back to direct Anthropic API
+   /gemma [none|low|medium|high|off]
+                  Activate Gemma 4 31B on Cerebras (multimodal + reasoning)
+   /ollama        Toggle Ollama on/off (self-hosted LLM for chat)
   /set output_verbose true|false
                  Toggle compact vs detailed Codex/CC answers
   /config        Show current config settings
@@ -1331,7 +1427,7 @@ func handleSetCommand(input string, ag *agent.Agent, term *tui.Terminal) {
 	parts := strings.Fields(input)
 	if len(parts) < 3 {
 		term.PrintError("Usage: /set <key> <value>")
-		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, live_feed, output_verbose, budget, apikey, ollama, backend, theme")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, live_feed, output_verbose, budget, apikey, ollama, backend, cerebras_model, cerebras_reasoning_effort, theme")
 		return
 	}
 	key := strings.ToLower(parts[1])
@@ -1504,9 +1600,36 @@ func handleSetCommand(input string, ag *agent.Agent, term *tui.Terminal) {
 			cfg.Backend = ""
 			term.PrintSystem("Backend set to Anthropic API. Restart or use /api to switch live.")
 		default:
-			term.PrintError("Valid backends: cc, codex, api")
+			term.PrintError("Valid backends: cc, codex, api (use /gemma for cerebras)")
 			return
 		}
+
+	case "cerebras_model", "cerebras-model":
+		cfg.CerebrasModel = api.ResolveCerebrasModel(value)
+		// Apply live if Cerebras is the active backend.
+		if ag.Cerebras != nil {
+			ag.Cerebras.Model = api.ResolveCerebrasModel(value)
+		}
+		term.PrintSystem(fmt.Sprintf("Cerebras model set to: %s", cfg.CerebrasModel))
+
+	case "cerebras_reasoning_effort", "cerebras-reasoning-effort":
+		if value == "" {
+			cfg.CerebrasReasoningEffort = ""
+		} else {
+			if !api.ValidCerebrasReasoningEffort(value) {
+				term.PrintError(fmt.Sprintf("Invalid value %q; allowed: none, low, medium, high", value))
+				return
+			}
+			cfg.CerebrasReasoningEffort = api.NormalizeCerebrasReasoningEffort(value)
+		}
+		if ag.Cerebras != nil {
+			ag.Cerebras.ReasoningEffort = cfg.CerebrasReasoningEffort
+		}
+		label := cfg.CerebrasReasoningEffort
+		if label == "" {
+			label = "none (off)"
+		}
+		term.PrintSystem(fmt.Sprintf("Cerebras reasoning_effort set to: %s", label))
 
 	case "theme":
 		valid := tui.ThemeNames()
@@ -1538,7 +1661,7 @@ func handleSetCommand(input string, ag *agent.Agent, term *tui.Terminal) {
 
 	default:
 		term.PrintError(fmt.Sprintf("Unknown config key: %s", key))
-		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, live_feed, output_verbose, budget, apikey, ollama, backend, theme")
+		term.PrintSystem("Keys: model, project, professional, autosave, cloud_sync, live_feed, output_verbose, budget, apikey, ollama, backend, cerebras_model, cerebras_reasoning_effort, theme")
 		return
 	}
 

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -90,32 +90,18 @@ var toolIcons = map[string]string{
 // spinnerFrames is the braille animation cycle.
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
-// spinnerMessages are shown next to the spinner while Claude is thinking.
+// spinnerMessages are shown next to the spinner while the agent is working.
 var spinnerMessages = []string{
-	"drinking cat milk",
-	"watching the dog's tail",
-	"scaring the bugs",
-	"feeding the kitten",
-	"knocking tests off the table",
-	"chasing the cursor",
-	"napping on the keyboard",
-	"consulting with senior cat",
-	"pawing at the error logs",
-	"sitting on the warm server",
-	"demanding treats from the API",
-	"judging your code silently",
-	"batting at floating variables",
-	"ignoring the flaky tests",
-	"dreaming about tuna endpoints",
-	"staring at a wall suspiciously",
-	"filing a bug against gravity",
-	"debugging with paws",
-	"sniffing the dependency tree",
-	"meowing at the CI pipeline",
-	"questioning life choices",
-	"blaming the last commit",
-	"checking if tests pass by vibes",
-	"doing absolutely nothing (probably)",
+	"thinking",
+	"checking context",
+	"planning next step",
+	"reading tool results",
+	"preparing request",
+	"waiting for model",
+	"reviewing response",
+	"running tool loop",
+	"checking test status",
+	"validating output",
 }
 
 // spinner is a running thinking animation.


### PR DESCRIPTION
## Summary
- add Gemma 4 31B model aliases and Cerebras reasoning_effort config/env support
- route the existing /orch Cerebras picker path through Gemma reasoning, including active Cerebras model selection
- add /gemma shortcut for the hackathon demo flow and gate the vision test-generation prompt to Gemma on Cerebras
- surface Cerebras time_info speed metrics in the terminal and document the screenshot-to-test demo
- fix QualityMax test-case tool calls by mapping priority names like critical/high/medium/low to the API's numeric priority scale
- replace novelty spinner phrases with neutral agent status text

## Verification
- go test ./...
- go vet ./...
- go build ./...