### PR TITLE
fix: isolate MCP stdout so tool-handler writes don't kill rmcp transport

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"strconv"
 
@@ -48,8 +50,31 @@ func RunServer(version string) {
 		sctx.LiveFeed = true
 	}
 
-	encoder := json.NewEncoder(os.Stdout)
-	scanner := bufio.NewScanner(os.Stdin)
+	// Pin the real stdout for exclusive use by the JSON-RPC encoder, then
+	// repoint the process-level os.Stdout at stderr. Tool handlers — and
+	// the TUI helpers they call (progress bars, browser animations,
+	// banners in internal/tui) — freely fmt.Print to os.Stdout. In MCP
+	// mode those writes corrupt the newline-delimited JSON-RPC stream the
+	// client (Codex/CC rmcp) reads: an empty line from fmt.Println()
+	// deserializes to nothing (serde "line: 0, column: 0") and a progress
+	// bar deserializes to garbage, either of which kills the transport
+	// worker with "data did not match any variant of untagged enum
+	// JsonRpcMessage". Redirecting os.Stdout to stderr sends every stray
+	// write to diagnostics instead of the wire the parser reads.
+	realStdout := os.Stdout
+	os.Stdout = os.Stderr
+	defer func() { os.Stdout = realStdout }()
+
+	serveMCP(os.Stdin, realStdout, sctx, version)
+}
+
+// serveMCP runs the newline-delimited JSON-RPC read/respond loop against the
+// given reader (client stdin) and writer (client stdout). Extracted from
+// RunServer so the output contract — only valid JSON-RPC lines on out — can be
+// tested without swapping global os.Stdin/os.Stdout.
+func serveMCP(in io.Reader, out io.Writer, sctx *api.SessionContext, version string) {
+	encoder := json.NewEncoder(out)
+	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, 1<<20), 1<<20) // 1 MiB — tool results can be verbose
 
 	for scanner.Scan() {
@@ -119,7 +144,18 @@ type callParams struct {
 
 // --- Request dispatcher ---
 
-func dispatch(req request, sctx *api.SessionContext, version string) response {
+// dispatch routes a parsed JSON-RPC request to the appropriate handler. A
+// deferred recover ensures a panicking tool handler (nil deref, index out of
+// range, etc.) yields a JSON-RPC error response rather than crashing the
+// server process — a crash would EOF stdout and kill the client's transport
+// worker the same way stray stdout writes do.
+func dispatch(req request, sctx *api.SessionContext, version string) (resp response) {
+	defer func() {
+		if r := recover(); r != nil {
+			resp = errResp(req.ID, -32603, fmt.Sprintf("internal error: %v", r))
+		}
+	}()
+
 	switch req.Method {
 	case "initialize":
 		return okResp(req.ID, map[string]interface{}{

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,6 +1,9 @@
 package mcp
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/qualitymax/qmax-code/internal/api"
@@ -33,5 +36,77 @@ func TestHandleLineRejectsInvalidJSONRPCVersion(t *testing.T) {
 	}
 	if resp.Error == nil || resp.Error.Code != -32600 {
 		t.Fatalf("response = %+v, want invalid request error", resp)
+	}
+}
+
+// TestDispatchRecoversFromPanic verifies that a panicking tool handler yields
+// a JSON-RPC error response (-32603) instead of crashing the server process.
+// A crash would EOF stdout and kill the client's rmcp transport worker — the
+// same failure mode as stray stdout writes.
+func TestDispatchRecoversFromPanic(t *testing.T) {
+	// A nil sctx causes agent.ExecuteTool to nil-deref, exercising the
+	// deferred recover. Whether LoadQMaxCodeConfig returns nil or not, the
+	// panic fires (either at sctx.LiveFeed or sctx.API) and is recovered.
+	req := request{
+		JSONRPC: "2.0",
+		ID:      42,
+		Method:  "tools/call",
+		Params:  json.RawMessage(`{"name":"list_projects","arguments":{}}`),
+	}
+	resp := dispatch(req, nil, "test")
+	if resp.JSONRPC != "2.0" {
+		t.Fatalf("JSONRPC = %q, want 2.0", resp.JSONRPC)
+	}
+	if resp.ID != 42 {
+		t.Fatalf("ID = %v, want 42", resp.ID)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected an internal-error response, got nil error")
+	}
+	if resp.Error.Code != -32603 {
+		t.Fatalf("error code = %d, want -32603 (internal error)", resp.Error.Code)
+	}
+}
+
+// TestServeMCPOutputIsCleanJSON drives the serve loop through a standard
+// initialize → tools/list handshake and asserts every non-empty line on the
+// output writer is valid JSON-RPC. This is the output contract the rmcp
+// transport depends on: a single corrupt or empty line deserializes to
+// nothing and kills the worker.
+func TestServeMCPOutputIsCleanJSON(t *testing.T) {
+	input := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}`,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
+		"",
+	}, "\n")
+
+	var out bytes.Buffer
+	serveMCP(strings.NewReader(input), &out, &api.SessionContext{}, "test")
+
+	if out.Len() == 0 {
+		t.Fatal("serveMCP produced no output")
+	}
+
+	for i, line := range strings.Split(strings.TrimRight(out.String(), "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			t.Fatalf("line %d: empty line on JSON-RPC output — this is exactly "+
+				"what triggers rmcp's line:0,column:0 fatal", i)
+		}
+		var msg response
+		if err := json.Unmarshal([]byte(line), &msg); err != nil {
+			t.Fatalf("line %d: not valid JSON-RPC (%v): %s", i, err, line)
+		}
+		if msg.JSONRPC != "2.0" {
+			t.Fatalf("line %d: jsonrpc = %q, want 2.0", i, msg.JSONRPC)
+		}
+	}
+
+	// The notification must not produce a response — only two replies
+	// (initialize + tools/list) should be on the wire.
+	responses := strings.Count(out.String(), "\"jsonrpc\"")
+	if responses != 2 {
+		t.Fatalf("expected 2 JSON-RPC responses, got %d (notifications must not be echoed)", responses)
 	}
 }


### PR DESCRIPTION
## Problem

Codex orch sessions died mid tool-loop with:

```
ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed,
when Deserialize(Error("data did not match any variant of untagged enum JsonRpcMessage", line: 0, column: 0))
✗ codex exited with error: exit status 1
```

`line: 0, column: 0` means rmcp tried to deserialize **empty input** — an empty line on the MCP server's stdout.

## Root cause

The qmax MCP server (`qmax-code serve --mcp`) shared `os.Stdout` between the JSON-RPC transport and terminal UI code. Tool handlers — and the TUI helpers they call — freely `fmt.Print` to `os.Stdout`:

- `runTestWithProgress` calls `fmt.Println()` (writes `\n` → empty line) at `internal/agent/tools.go:1043`
- `internal/tui/*` writes progress bars, browser animations, banners via `fmt.Print*`

These non-JSON bytes landed on the same newline-delimited stream Codex's rmcp client reads. An empty line from `fmt.Println()` deserialized to nothing (`serde` line 0, column 0); a progress bar deserialized to garbage. Either kills the transport worker → Codex exits 1.

## Fix (`internal/mcp/server.go`)

1. **Stdout isolation** — `RunServer` pins the real stdout for exclusive use by the JSON-RPC encoder, then repoints the process-level `os.Stdout` at stderr. Every stray `fmt.Print` from a tool handler now lands on stderr (diagnostics), never on the wire the parser reads.

2. **Panic recovery** — `dispatch` gets a deferred `recover` so a panicking tool handler (nil deref, index out of range) yields a `-32603` JSON-RPC error response instead of crashing the server. A crash would EOF stdout and kill the transport the same way.

3. **Extracted `serveMCP(in, out)`** — the read/respond loop is now testable without swapping global `os.Stdin`/`os.Stdout`.

## Tests (`internal/mcp/server_test.go`)

- `TestDispatchRecoversFromPanic` — nil-deref in `agent.ExecuteTool` is caught by the deferred recover and returns a `-32603` response.
- `TestServeMCPOutputIsCleanJSON` — `initialize` → `notifications/initialized` → `tools/list` handshake produces only valid JSON-RPC lines (no empty or corrupt lines), and the notification is not echoed.

## Test plan

- [x] `go test ./internal/mcp/ -v` — all 5 tests pass
- [x] `go test ./...` — full suite green
- [x] `go vet` / `gofmt` clean
- [ ] Manual: run a Codex orch session that triggers qmax tools (e.g. `run_test`) and confirm the tool loop completes without the rmcp transport fatal