### PR TITLE
Fix MCP stdout isolation for Codex rmcp sessions

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,10 +1,15 @@
 package mcp
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qualitymax/qmax-code/internal/api"
 )
@@ -108,5 +113,121 @@ func TestServeMCPOutputIsCleanJSON(t *testing.T) {
 	responses := strings.Count(out.String(), "\"jsonrpc\"")
 	if responses != 2 {
 		t.Fatalf("expected 2 JSON-RPC responses, got %d (notifications must not be echoed)", responses)
+	}
+}
+
+func TestRunServerRedirectsProcessStdoutAwayFromJSONRPC(t *testing.T) {
+	origStdin := os.Stdin
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restore := func() {
+		os.Stdin = origStdin
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}
+	defer func() {
+		restore()
+		_ = inR.Close()
+		_ = inW.Close()
+		_ = outR.Close()
+		_ = outW.Close()
+		_ = errR.Close()
+		_ = errW.Close()
+	}()
+
+	os.Stdin = inR
+	os.Stdout = outW
+	os.Stderr = errW
+
+	done := make(chan struct{})
+	go func() {
+		RunServer("test")
+		close(done)
+	}()
+
+	if _, err := fmt.Fprintln(inW, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`); err != nil {
+		t.Fatal(err)
+	}
+
+	stdoutReader := bufio.NewReader(outR)
+	lineCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		line, err := stdoutReader.ReadString('\n')
+		if err != nil {
+			errCh <- err
+			return
+		}
+		lineCh <- line
+	}()
+
+	var firstLine string
+	select {
+	case firstLine = <-lineCh:
+	case err := <-errCh:
+		t.Fatalf("reading initialize response: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for initialize response")
+	}
+
+	var msg response
+	if err := json.Unmarshal([]byte(firstLine), &msg); err != nil {
+		t.Fatalf("initialize response is not JSON-RPC: %v: %q", err, firstLine)
+	}
+	if msg.JSONRPC != "2.0" || msg.ID != float64(1) {
+		t.Fatalf("initialize response = %+v, want JSON-RPC response with id 1", msg)
+	}
+
+	const stray = "stray stdout from tool path"
+	if _, err := fmt.Fprintln(os.Stdout, stray); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := inW.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for RunServer to exit")
+	}
+	restore()
+
+	if err := outW.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := errW.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	remainingStdout, err := io.ReadAll(stdoutReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderrBytes, err := io.ReadAll(errR)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if stdout := firstLine + string(remainingStdout); strings.Contains(stdout, stray) {
+		t.Fatalf("stray process stdout leaked onto JSON-RPC stdout: %q", stdout)
+	}
+	if stderr := string(stderrBytes); !strings.Contains(stderr, stray) {
+		t.Fatalf("stray process stdout was not redirected to stderr; stderr = %q", stderr)
 	}
 }


### PR DESCRIPTION
## Summary
- reserve the real MCP stdout exclusively for JSON-RPC responses
- redirect stray process stdout from tool/TUI paths to stderr in MCP mode
- recover panicking tool dispatches as JSON-RPC internal errors
- add regression coverage for clean MCP output and RunServer stdout redirection

## Tests
- go test ./internal/mcp
- go test -race ./internal/mcp
- go test ./...
- git diff --check