### PR TITLE
Fix qmax-code installer guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+### Fixed
+- Updated the installer flow to remove stale qmax CLI guidance, show the
+  installed qmax-code version, and point users at standalone setup commands.
+
 ## [1.20.3] - 2026-06-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@
 
 **AI-powered terminal agent for QualityMax.** Named after Max, the real cat who inspired it all.
 
-qmax-code is the LLM brain that orchestrates the open-source [`qmax`](https://github.com/Quality-Max/qmax-local-agent) CLI. It connects to the Claude API, understands your testing intent in natural language, and translates it into structured CLI operations — crawling sites, generating tests, running scripts, reviewing repos.
+qmax-code is a standalone terminal agent for QualityMax. It connects directly to
+the QualityMax API, understands testing intent in natural language, and runs
+structured workflows for crawling sites, generating tests, running scripts, and
+reviewing repos. No separate `qmax` CLI is required.
 
 > **License:** Source-available under the [Functional Source License (FSL-1.1-ALv2)](LICENSE) — created by [Sentry](https://fsl.software). Free for any non-competing use (internal use, modifications, contributions, education, research, professional services). Two years after each release, the code automatically converts to plain Apache 2.0. The "Other" tag GitHub shows in the sidebar is a quirk of its licensee detector — FSL isn't on the SPDX list.
 
@@ -33,12 +36,12 @@ qmax-code is the LLM brain that orchestrates the open-source [`qmax`](https://gi
 ```
   You  →  "test the login flow on staging"
                     │
-              qmax-code (Claude API)
+              qmax-code
                     │
           ┌─────────┼─────────┐
           ▼         ▼         ▼
-     qmax crawl  qmax test  qmax test
-       start      generate     run
+      crawl     generate     run
+      site        tests      scripts
 ```
 
 Claude picks the right tools, chains them together, and reports back — all in a colorful terminal with cat personality.
@@ -53,7 +56,7 @@ Claude picks the right tools, chains them together, and reports back — all in 
 ## Install
 
 ```bash
-curl -sL https://raw.githubusercontent.com/Quality-Max/qmax-code/main/install.sh | bash
+curl -sL https://qualitymax.io/static/install-qmax-code.txt | bash
 ```
 
 ## Quick start

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # QualityMax Code Agent Installer
-# Usage: curl -sL https://raw.githubusercontent.com/Quality-Max/qmax-code/main/install.sh | bash
+# Usage: curl -sL https://qualitymax.io/static/install-qmax-code.txt | bash
 
 set -e
 
-REPO="Quality-Max/qmax-code"
+REPO="Quality-Max/qmax-code-releases"
 BINARY="qmax-code"
 
 echo "QualityMax Code Agent Installer"
@@ -82,9 +82,11 @@ chmod +x "$INSTALL_DIR/$BINARY"
 echo "Installed to: $INSTALL_DIR/$BINARY"
 
 # Symlink to /usr/local/bin
+RUN_CMD="$INSTALL_DIR/$BINARY"
 if [ -w /usr/local/bin ]; then
     ln -sf "$INSTALL_DIR/$BINARY" /usr/local/bin/$BINARY
     echo "Linked: /usr/local/bin/$BINARY"
+    RUN_CMD="$BINARY"
 else
     echo ""
     echo "To make '$BINARY' available globally:"
@@ -96,18 +98,32 @@ fi
 
 echo ""
 
-# Check for API key
-if [ -z "$ANTHROPIC_API_KEY" ]; then
-    echo "Setup:"
-    echo "  1. Set your Anthropic API key:"
-    echo "     export ANTHROPIC_API_KEY=sk-ant-..."
-    echo "  2. Login to QualityMax:"
-    echo "     qmax login"
-    echo "  3. Start the agent:"
-    echo "     qmax-code"
+INSTALLED_VERSION="$("$INSTALL_DIR/$BINARY" --version 2>/dev/null | awk '{print $NF}' || true)"
+if [ -n "$INSTALLED_VERSION" ]; then
+    echo "Installed version: $INSTALLED_VERSION"
 else
-    echo "Ready! Run: qmax-code"
+    echo "Installed version: unknown"
+fi
+if [ -n "$VERSION" ]; then
+    echo "Release: https://github.com/$REPO/releases/tag/$VERSION"
+else
+    echo "Release: https://github.com/$REPO/releases/latest"
 fi
 
+echo ""
+echo "qmax CLI is not required. qmax-code works standalone with the QualityMax API."
+echo ""
+echo "Next steps:"
+echo "  1. Start qmax-code and finish interactive setup:"
+echo "     $RUN_CMD"
+echo "  2. Optional: connect QualityMax now:"
+echo "     $RUN_CMD login"
+echo "  3. Optional: attach Codex for QualityMax mobile runs:"
+echo "     $RUN_CMD codex connect"
+echo ""
+echo "Auth options:"
+echo "  - Browser login: $RUN_CMD login"
+echo "  - API key:       $RUN_CMD login --api-key qm-YOUR-API-KEY"
+echo "  - Anthropic:     set ANTHROPIC_API_KEY or save it when prompted"
 echo ""
 echo "Docs: https://qualitymax.io/docs/qmax-code"


### PR DESCRIPTION
## Summary
- remove stale qmax CLI install/login guidance from the qmax-code installer
- show the installed qmax-code version and release URL after install
- point users at standalone qmax-code setup commands and auth options
- update README install/intro text to match the standalone API flow

## Tests
- bash -n install.sh
- go test ./...
- git diff --check