### PR TITLE
Release 1.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.20.4] - 2026-06-30
+
 ### Fixed
 - Updated the installer flow to remove stale qmax CLI guidance, show the
   installed qmax-code version, and point users at standalone setup commands.

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.20.3"
+var Version = "1.20.4"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- bump qmax-code version to 1.20.4
- move the installer-guidance fix into the 1.20.4 changelog entry

## Tests
- go test ./...
- git diff --check