### PR TITLE
fix: surface real Cerebras request errors instead of a generic fallback

### DIFF
--- a/internal/agent/cerebras_agent.go
+++ b/internal/agent/cerebras_agent.go
@@ -42,13 +42,17 @@ func (a *Agent) RunCerebrasAgent(term *tui.Terminal) (string, bool) {
 		resp, err := a.Cerebras.Chat(ctx, msgs, tools)
 		term.StopThinking()
 
+		// Capture before the cleanup cancel() below, which would otherwise mark
+		// ctx as done unconditionally and make every real failure look "interrupted".
+		interrupted := ctx.Err() != nil
+
 		a.cancelMu.Lock()
 		a.cancel = nil
 		a.cancelMu.Unlock()
 		cancel()
 
 		if err != nil {
-			if ctx.Err() != nil {
+			if interrupted {
 				return "", false // interrupted
 			}
 			if a.Logger != nil {

--- a/internal/agent/cerebras_agent_test.go
+++ b/internal/agent/cerebras_agent_test.go
@@ -23,7 +23,7 @@ func captureStdout(t *testing.T, fn func()) string {
 		t.Fatalf("os.Pipe: %v", err)
 	}
 	os.Stdout = w
-	defer func() { os.Stdout = orig }()
+	t.Cleanup(func() { os.Stdout = orig })
 
 	fn()
 
@@ -45,7 +45,7 @@ func captureStdout(t *testing.T, fn func()) string {
 func TestRunCerebrasAgentSurfacesRequestErrorDetail(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte(`{"error":{"message":"invalid model gpt-oss-120b"}}`))
+		_, _ = w.Write([]byte(`{"error":{"message":"invalid model gpt-oss-120b"}}`))
 	}))
 	defer srv.Close()
 

--- a/internal/agent/cerebras_agent_test.go
+++ b/internal/agent/cerebras_agent_test.go
@@ -1,0 +1,77 @@
+package agent
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
+	"github.com/qualitymax/qmax-code/internal/tui"
+)
+
+// captureStdout redirects os.Stdout for the duration of fn and returns
+// everything written to it. Terminal.PrintError writes via fmt.Printf
+// directly to os.Stdout, so this is the only way to observe it from a test.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	w.Close()
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+// A real Cerebras request failure (bad model, auth error, malformed request,
+// network hiccup, etc.) must surface its actual reason to the user rather
+// than the generic top-level "cerebras backend request failed" fallback.
+//
+// Regression test for a bug where the cleanup `cancel()` call ran before the
+// `ctx.Err() != nil` check meant to detect a genuine user-initiated
+// interrupt (via Agent.CancelCurrent). Since cancel() unconditionally marks
+// the context done, ctx.Err() was always non-nil by the time it was checked,
+// so every failure — interrupted or not — took the silent "interrupted"
+// branch and the detailed term.PrintError message never ran.
+func TestRunCerebrasAgentSurfacesRequestErrorDetail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"invalid model gpt-oss-120b"}}`))
+	}))
+	defer srv.Close()
+
+	a := &Agent{
+		Cfg: AgentConfig{Context: &api.SessionContext{}},
+		Cerebras: &CerebrasClient{
+			BaseURL: srv.URL,
+			Model:   "gpt-oss-120b",
+			APIKey:  "csk-test",
+			HTTP:    srv.Client(),
+		},
+	}
+
+	var out string
+	var ok bool
+	out = captureStdout(t, func() {
+		_, ok = a.RunCerebrasAgent(&tui.Terminal{})
+	})
+
+	if ok {
+		t.Fatalf("expected ok=false for a failed request")
+	}
+	if !strings.Contains(out, "Cerebras request failed") {
+		t.Fatalf("expected the detailed Cerebras error to be printed, got: %q", out)
+	}
+	if !strings.Contains(out, "invalid model gpt-oss-120b") {
+		t.Fatalf("expected the underlying server error to be surfaced, got: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- The Cerebras backend's error path silently swallowed the actual failure reason. In `RunCerebrasAgent` (`internal/agent/cerebras_agent.go`), `cancel()` was called unconditionally right after every `Chat()` call for cleanup. But the very next line checked `ctx.Err() != nil` to detect a genuine user-initiated interrupt (Ctrl-C via `Agent.CancelCurrent`) — since `cancel()` had *just* run, `ctx.Err()` was always non-nil at that point, so every real failure (bad model, auth error, malformed request, network issue, etc.) took the silent "interrupted" branch and returned `false` with zero diagnostic output. The caller then only ever saw the generic top-level fallback: `cerebras backend request failed`.
- Fix: capture `ctx.Err()` *before* the cleanup `cancel()` call, so the interrupt check reflects whether the context was actually canceled externally during the request, not by our own post-hoc cleanup.

## Test plan
- [x] Added `TestRunCerebrasAgentSurfacesRequestErrorDetail`, which spins up an `httptest` server returning HTTP 400 and asserts the detailed error message is printed. Confirmed it fails on the old code and passes with the fix.
- [x] Reproduced locally end-to-end with a local fake Cerebras-compatible server (both a 400-error case and the happy-path case) via `qmax-code --backend cerebras -p "hey"`.
- [x] `go build ./...` and `go test ./...` pass.