### PR TITLE
feat: add Codex GPT-5.6 Terra/Sol/Luna to /orch picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+### Added
+- Added GPT-5.6 Terra, Sol, and Luna to the Codex `/orch` model picker, ahead
+  of GPT-5.5. Codex number shortcuts 6–0 now map to Terra, Sol, Luna, GPT-5.5,
+  and o4-mini (o3, o3-mini, and GPT-4o remain selectable without shortcuts);
+  o4-mini stays the default Codex row. Confirmed Claude Fable 5 and Sonnet 5
+  (1M ctx) from #138 are already present in the Claude Code picker.
+
 ## [1.20.5] - 2026-07-02
 
 ### Added

--- a/internal/tui/tui_backend.go
+++ b/internal/tui/tui_backend.go
@@ -138,11 +138,14 @@ var ccModels = []pickerEntry{
 }
 
 var codexModels = []pickerEntry{
-	{backend: "codex", modelID: "gpt-5.5", label: "GPT-5.5", isNew: true, external: true, shortcut: '6'},
-	{backend: "codex", modelID: "o4-mini", label: "o4-mini", external: true, isFav: true, shortcut: '7'},
-	{backend: "codex", modelID: "o3", label: "o3", external: true, shortcut: '8'},
-	{backend: "codex", modelID: "o3-mini", label: "o3-mini", external: true, shortcut: '9'},
-	{backend: "codex", modelID: "gpt-4o", label: "GPT-4o", external: true, shortcut: '0'},
+	{backend: "codex", modelID: "gpt-5.6-terra", label: "GPT-5.6 Terra", isNew: true, external: true, shortcut: '6'},
+	{backend: "codex", modelID: "gpt-5.6-sol", label: "GPT-5.6 Sol", isNew: true, external: true, shortcut: '7'},
+	{backend: "codex", modelID: "gpt-5.6-luna", label: "GPT-5.6 Luna", isNew: true, external: true, shortcut: '8'},
+	{backend: "codex", modelID: "gpt-5.5", label: "GPT-5.5", external: true, shortcut: '9'},
+	{backend: "codex", modelID: "o4-mini", label: "o4-mini", external: true, isFav: true, shortcut: '0'},
+	{backend: "codex", modelID: "o3", label: "o3", external: true},
+	{backend: "codex", modelID: "o3-mini", label: "o3-mini", external: true},
+	{backend: "codex", modelID: "gpt-4o", label: "GPT-4o", external: true},
 }
 
 var apiModels = []pickerEntry{

--- a/internal/tui/tui_backend_cc_test.go
+++ b/internal/tui/tui_backend_cc_test.go
@@ -46,3 +46,37 @@ func TestPickerClaudeCodeDefaultCursorOnSonnet5(t *testing.T) {
 		t.Errorf("cursor on %s/%s, want cc/%s", cur.backend, cur.modelID, api.ModelSonnet5)
 	}
 }
+
+func TestPickerIncludesCodexGPT56Variants(t *testing.T) {
+	m := newModelPickerModel("codex", "", "high", "", "", true, true, false)
+
+	seen := map[string]pickerEntry{}
+	for _, e := range m.allEntries {
+		if e.backend == "codex" {
+			seen[e.modelID] = e
+		}
+	}
+
+	for id, wantLabel := range map[string]string{
+		"gpt-5.6-terra": "GPT-5.6 Terra",
+		"gpt-5.6-sol":   "GPT-5.6 Sol",
+		"gpt-5.6-luna":  "GPT-5.6 Luna",
+	} {
+		e, ok := seen[id]
+		if !ok {
+			t.Fatalf("Codex picker missing %s", id)
+		}
+		if e.label != wantLabel {
+			t.Errorf("%s label = %q, want %q", id, e.label, wantLabel)
+		}
+		if !e.isNew {
+			t.Errorf("%s should be flagged isNew", id)
+		}
+	}
+
+	// o4-mini remains the default Codex model — adding new rows above it
+	// must not silently change which model launches when none is specified.
+	if fav := seen["o4-mini"]; !fav.isFav {
+		t.Error("o4-mini should remain the default Codex picker row")
+	}
+}


### PR DESCRIPTION
## Summary
- Added GPT-5.6 Terra, Sol, and Luna to the Codex section of the `/orch` model picker, placed ahead of GPT-5.5.
- Reassigned Codex number shortcuts: `6`→Terra, `7`→Sol, `8`→Luna, `9`→GPT-5.5, `0`→o4-mini. o3, o3-mini, and GPT-4o remain selectable but without a shortcut (mirrors how Sonnet 4.6 / Haiku 4.5 lost their shortcuts when Fable 5 / Sonnet 5 were added in #138).
- `o4-mini` stays the default (`isFav`) Codex row — this PR only adds picker entries, it does not change what launches by default.
- Verified Claude Fable 5 and Claude Sonnet 5 (1M ctx) are already present in the Claude Code picker from #138 — no changes needed there.

## Test plan
- [x] Added `TestPickerIncludesCodexGPT56Variants`, asserting the three new entries exist with the right labels/`isNew` flag and that `o4-mini` remains the default.
- [x] `go build ./...` and `go test ./...` pass.