### PR TITLE
chore: release 1.20.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.20.7] - 2026-07-12
+
+### Fixed
+- `--save-session` (and a persisted `auto_save=true`) now also persists
+  one-shot (`-p` / positional-arg) sessions to disk. Previously the flag
+  only set an in-memory config field that the one-shot dispatch path never
+  read, so scripted/CI single-prompt runs were silently never saved.
+- MCP mode (`serve --mcp`) now redirects raw fd 1 writes, not just Go's
+  `os.Stdout` variable, to stderr on Unix. Subprocess/library writes below
+  the Go runtime could otherwise still corrupt the JSON-RPC stdout stream.
+- `/set cloud_sync` (the documented key) now works; previously only the
+  undocumented `cloudsync` alias was recognized.
+
 ## [1.20.6] - 2026-07-11
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.20.6"
+var Version = "1.20.7"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
Version bump covering the two fixes merged since 1.20.6:
- #142 — one-shot (`-p` / positional-arg) sessions now persist when `--save-session`/`auto_save` is enabled
- #143 — MCP mode redirects raw fd 1 writes to stderr (not just Go's `os.Stdout`), plus `/set cloud_sync` alias

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 ./...`