### PR TITLE
chore: release 1.20.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.20.9] - 2026-07-13
+
+### Fixed
+- Activating the OpenCode backend no longer aborts skill install with
+  `skills: unknown backend "opencode"`. OpenCode is now a first-class skills
+  backend: the QA skill catalog materializes into `~/.config/opencode/skills/`
+  (name + description frontmatter, matching OpenCode's recognized schema) on
+  activation and on every launch, alongside Claude Code and Codex. `/skills`
+  status and `/skills install` now cover the OpenCode (`oc`) backend too.
+
 ## [1.20.8] - 2026-07-13
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.20.8"
+var Version = "1.20.9"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Patch release bumping the opencode skills-backend fix from #147.

## Changes
- `main.go`: `Version` 1.20.8 → 1.20.9
- `CHANGELOG.md`: `[1.20.9]` entry under `### Fixed`

## What ships in 1.20.9
- OpenCode backend activation no longer crashes skill install (`skills: unknown backend "opencode"`). OpenCode is now a first-class skills backend, materializing the QA catalog into `~/.config/opencode/skills/` on activation + every launch. `/skills` status and `/skills install` include the `oc` backend.

After merge, I'll tag `v1.20.9` to trigger `release.yml` (6-platform build + publish to the public `qmax-code-releases` repo).