### PR TITLE
test(receipt): cover concurrent body snapshots

### DIFF
--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -285,6 +286,38 @@ func TestFailedWebSocketHandshakeIsRecorded(t *testing.T) {
 	}
 	if e.Note != "transport-error" {
 		t.Errorf("note = %q, want generic transport error", e.Note)
+	}
+}
+
+func TestHashingBodySnapshotConcurrentWithRead(t *testing.T) {
+	body := bytes.Repeat([]byte("x"), 64*1024)
+	hb := &hashingBody{rc: io.NopCloser(bytes.NewReader(body)), h: sha256.New()}
+	done := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		for {
+			_, err := hb.Read(buf)
+			if err != nil {
+				done <- err
+				return
+			}
+		}
+	}()
+
+	for range 1000 {
+		_, _, _ = hb.snapshot()
+	}
+	if err := <-done; err != io.EOF {
+		t.Fatalf("Read error = %v, want EOF", err)
+	}
+
+	gotBytes, gotDigest, complete := hb.snapshot()
+	if !complete || gotBytes != int64(len(body)) {
+		t.Errorf("snapshot = bytes:%d complete:%t, want bytes:%d complete:true", gotBytes, complete, len(body))
+	}
+	wantDigest := sha256.Sum256(body)
+	if gotDigest != hex.EncodeToString(wantDigest[:]) {
+		t.Errorf("digest = %q, want %q", gotDigest, hex.EncodeToString(wantDigest[:]))
 	}
 }
 


### PR DESCRIPTION
## Summary
- add race-enabled coverage for hashingBody snapshots during concurrent reads
- verify the final request byte count, SHA-256 digest, and EOF completion state

## Context
Follow-up to the receipt egress hardening merged in #150. This PR contains only the remaining regression test that was not part of the merge.

## Validation
- go test -race ./internal/httpx
- go test ./...
- go vet ./...