### PR TITLE
fix(tui): handle spacebar in turn-running input viewport

### DIFF
--- a/internal/tui/turn_viewport.go
+++ b/internal/tui/turn_viewport.go
@@ -236,6 +236,11 @@ func (m turnViewportModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.cursor = 0
 	case tea.KeyEnd:
 		m.cursor = len(m.text)
+	case tea.KeySpace:
+		m.text = append(m.text, 0)
+		copy(m.text[m.cursor+1:], m.text[m.cursor:])
+		m.text[m.cursor] = ' '
+		m.cursor++
 	case tea.KeyRunes:
 		if msg.Alt && len(msg.Runes) == 1 {
 			switch msg.Runes[0] {

--- a/internal/tui/turn_viewport_test.go
+++ b/internal/tui/turn_viewport_test.go
@@ -93,6 +93,18 @@ func TestTurnViewportEditingMatchesMainInput(t *testing.T) {
 	}
 }
 
+func TestTurnViewportInsertsSpaceKey(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m.text = []rune("hello")
+	m.cursor = len(m.text)
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeySpace})
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("world")})
+
+	if got, want := string(m.text), "hello world"; got != want {
+		t.Fatalf("text = %q, want %q (space key was dropped)", got, want)
+	}
+}
+
 func TestTurnViewportPreservesDraftWhenTurnFinishes(t *testing.T) {
 	m := newTurnViewportModel("qmax > ", nil, nil)
 	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("follow up")})


### PR DESCRIPTION
## Problem

When the agent is processing a task and the user types a new message in the chat terminal, **spaces are silently dropped** — the message appears without spaces (e.g. `helloworld` instead of `hello world`).

## Root cause

Bubble Tea v1.3.10 delivers the spacebar as `tea.KeySpace`, **not** `tea.KeyRunes` ([bubbletea/key.go:699-701](https://github.com/charmbracelet/bubbletea/blob/v1.3.10/key.go#L699-L701)):

```go
if len(runes) == 1 && runes[0] == ' ' {
    k.Type = KeySpace
}
```

The idle input widget ([`input.go:289`](internal/tui/input.go#L289)) already handles `tea.KeySpace` correctly. But the turn-running viewport ([`turnViewportModel.updateKey`](internal/tui/turn_viewport.go#L172)) had **no** `case tea.KeySpace` — every space fell through to the default `return m, nil` and was dropped.

## Fix

Added the missing `case tea.KeySpace` handler in `turn_viewport.go` that inserts `' '` at the cursor position, matching the rune-insert pattern used by the rest of the switch.

## Test

Added regression test `TestTurnViewportInsertsSpaceKey` — verified it **fails without the fix** (`text = "helloworld"`) and **passes with it** (`text = "hello world"`).

```
=== RUN   TestTurnViewportInsertsSpaceKey
--- PASS: TestTurnViewportInsertsSpaceKey (0.00s)
```

All existing `TestTurnViewport*` tests still pass.