### PR TITLE
release: v1.22.1 — ship the QUA-1580 cloud MCP routing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.22.1] - 2026-08-03
+
+### Fixed
+- `serve --mcp` now routes authenticated QualityMax tool calls through the
+  cloud MCP endpoint instead of calling the REST API directly. Calls made via
+  the local MCP server were previously invisible to the platform — they never
+  set trace context, so they produced no session history — and they returned
+  UI-shaped REST payloads carrying every script's full source, which no
+  server-side response budget could reach. Local tools, standalone mode, and
+  REST lifecycle traffic are unchanged (#158).
+- Browser login now mints an MCP-compatible token, so the cloud routing above
+  is actually usable straight after `qmax-code` sign-in rather than silently
+  falling back (#159).
+
+### Note
+- These fixes merged on 2026-07-28 but were never released: the v1.22.0 tag
+  points at the commit immediately before them, so no published build has
+  contained them until now.
+
 ## [1.22.0] - 2026-07-24
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.22.0"
+var Version = "1.22.1"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Refs [QUA-1725](https://linear.app/quality-max/issue/QUA-1725/qmax-code-mcp-proxy-returns-rest-shaped-payloads-full-script-code-per), [QUA-1580](https://linear.app/quality-max/issue/QUA-1580/qmax-code-serve-mcp-proxies-to-rest-every-tool-call-through-the-local).

## The problem

**The QUA-1580 fix merged on 2026-07-28 and has never been released.**

```
v1.22.0     -> 29a5fd2   feat: standalone local-only mode (#156)
origin/main -> 56a5940   QUA-1580: mint MCP-compatible token (#159)

git log v1.21.2..origin/main
  56a5940  QUA-1580: mint MCP-compatible token after browser login (#159)
  8f816d2  QUA-1580: Route authenticated tool calls through cloud MCP
  29a5fd2  feat: standalone local-only mode + docs refresh (#156)
```

`main` is exactly two commits ahead of the newest tag, and those two commits *are* the fix. Checked every recent tag for `8f816d2`:

| tag | contains the fix |
|---|---|
| **v1.22.0** | **no** |
| v1.21.2 | no |
| v1.21.1 | no |
| v1.21.0 | no |
| v1.20.9 | no |
| v1.20.8 | no |

The installer resolves `releases/latest`, so **every user who installed qmax-code since Jul 28 got a binary without the fix.** Their `serve --mcp` still calls REST directly, which means:

1. Tool calls set no trace context — no session history at all. This is the exact regression QUA-1580 was closed for.
2. Responses are UI-shaped REST payloads carrying every script's full source. On a 19-script project that's 44,240 chars (~11K tokens) in one `list_scripts` call, and no server-side response budget can reach it — the platform-side work in QUA-1724 only covers `/api/mcp/`.

QUA-1580 was marked Done on a merged PR. Merged ≠ shipped.

## This PR

Changelog entry + version constant. **No functional change** — the fix itself is already on `main`.

- `CHANGELOG.md` — new `## [1.22.1]` section. Both commits landed with no changelog entry, so `[Unreleased]` was empty despite the fix sitting there.
- `main.go` — `Version` 1.22.0 → 1.22.1. Cosmetic for released builds (`release.yml` stamps the tag via ldflags) but correct for `go build` from source.

Patch, not minor: bug fix plus the token minting it needs, no new surface.

## Verification

- Branched from freshly fetched `origin/main`, 0 ahead / 0 behind at time of branching; both fix commits confirmed present.
- **CI is green on `56a5940`** — the exact base commit — for both `CI` and `QualityMax Go Tests`.
- `go vet ./...` clean locally. Local `go test ./...` shows `internal/mcp` ok; five packages (`setup`, `skills`, `sysutil`, `tui`, `vnc`) hit the 11m budget on this machine for want of a TTY/network, which is why the CI result above is the load-bearing signal rather than my laptop.

## After merge

Tag `v1.22.1` on the merge commit and push — `release.yml` fires on `v*` and handles tests, six-platform builds, archives, and the GitHub release. **I have not tagged anything;** that's the deliberate manual step.

## Loose end, not fixed here

`Desperado/update-qmax-docs-orch-mode` carries a commit `7601b2b test+release: … release v1.22.0` that differs from the actual `v1.22.0` tag (`29a5fd2`). If that branch merges as-is you'd get a second, conflicting 1.22.0. Worth untangling separately.