### PR TITLE
docs: fix the version story and add orchestration, lifecycle, and family diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@
 
 # qmax-code
 
+[![Latest release](https://img.shields.io/github/v/release/Quality-Max/qmax-code?label=release&color=217a45)](https://github.com/Quality-Max/qmax-code/releases/latest)
 [![License: FSL-1.1-ALv2](https://img.shields.io/badge/license-FSL--1.1--ALv2-2ea44f.svg)](LICENSE)
 [![Future License: Apache 2.0](https://img.shields.io/badge/future%20license-Apache%202.0-blue.svg)](LICENSE)
-[![Made with Go](https://img.shields.io/badge/made%20with-Go-00ADD8.svg)](https://go.dev/)
+[![Made with Go](https://img.shields.io/badge/made%20with-Go%201.24+-00ADD8.svg)](https://go.dev/)
 [![Announcement](https://img.shields.io/badge/announcement-2026--05--01-7c6cf0.svg)](https://qualitymax.io/blog/qmax-code-open-source)
 
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-yellow?logo=buymeacoffee)](https://buymeacoffee.com/qualitymax)
@@ -34,6 +35,16 @@ Use the built-in agent with Anthropic, Cerebras, or Ollama, or use
 **orchestration mode** to run Claude Code, Codex, or OpenCode with the same qmax
 QA tools through MCP.
 
+![Five open QualityMax tools and where qmax-code sits among them](docs/img/family.svg)
+
+qmax-code is the terminal agent that drives a QA session. It sits alongside
+[free-qa-skills](https://github.com/Quality-Max/free-qa-skills) (read-only
+audits inside a coding agent), [qmax-mcp](https://github.com/Quality-Max/qmax-mcp)
+(scan a page, generate a repro, run it locally),
+[9lives](https://github.com/Quality-Max/9lives) (heal broken selectors), and
+[qmax-local-agent](https://github.com/Quality-Max/qmax-local-agent) (let the
+cloud reach a private network). Only hosted QualityMax needs an account.
+
 > **License:** Source-available under the
 > [Functional Source License (FSL-1.1-ALv2)](LICENSE), created by
 > [Sentry](https://fsl.software). It is free for non-competing use, including
@@ -41,6 +52,8 @@ QA tools through MCP.
 > professional services. Each release converts to Apache 2.0 after two years.
 
 ## What qmax-code can do
+
+![Plan, generate, execute, review, and ship, over a local repository lane](docs/img/lifecycle.svg)
 
 - **Plan and manage QA work:** list and manage projects and test cases, enhance
   cases, find coverage gaps, and import requirements or repositories.
@@ -64,11 +77,24 @@ Some advanced surfaces—k6, QTML, framework export/trigger operations, and
 background-job health—remain experimental and are only exposed when
 `QMAX_EXPERIMENTAL=1`.
 
-## What is new in v1.21
+## What is new
 
-- **Standalone local-only mode:** start with `--local` (or persist
+### v1.22
+
+- **Cloud-routed MCP tool calls (v1.22.1):** `serve --mcp` now routes
+  authenticated QualityMax tool calls through the cloud MCP endpoint instead of
+  calling the REST API directly. Calls made through the local MCP server were
+  previously invisible to the platform — they set no trace context, so they
+  produced no session history — and they returned UI-shaped REST payloads
+  carrying every script's full source. Browser login now mints an
+  MCP-compatible token, so the routing works immediately after sign-in.
+- **Standalone local-only mode (v1.22.0):** start with `--local` (or persist
   `local_only=true`) to skip QualityMax onboarding and expose only workspace
-  file, command, and planning tools.
+  file, command, and planning tools. MCP children inherit the mode, and
+  execution-time checks reject direct calls to hidden QualityMax tools.
+
+### v1.21
+
 - **Exposure Receipts:** every session that makes an outbound LLM or QualityMax
   API request writes a signed local egress manifest that can be inspected and
   verified offline.
@@ -188,20 +214,7 @@ a separate model and it does not create several agents. It selects which
 inference engine handles the conversation while keeping qmax-code as the host
 for terminal UX, QualityMax context, and tools.
 
-```text
-you
- │
- ▼
-qmax-code REPL ── /orch chooses one backend
- │
- ├─ built-in loop: Anthropic API / Cerebras / Ollama
- │
- └─ CLI agent: Claude Code / Codex / OpenCode
-                    │
-                    └─ embedded qmax MCP server
-                         ├─ connected: QualityMax + local QA tools
-                         └─ --local: workspace tools only
-```
+![The /orch picker selects one backend; mode decides which tools exist](docs/img/orchestration.svg)
 
 For CLI backends, qmax-code launches the selected agent as a subprocess and
 serves qmax tools through its embedded MCP server. On first activation you

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,6 +1,6 @@
 # Command reference
 
-This reference describes the qmax-code v1.21 command-line and interactive
+This reference describes the qmax-code v1.22 command-line and interactive
 surfaces. Run `qmax-code --help` for the flags compiled into your installed
 version and `/help` for its REPL commands.
 

--- a/docs/img/family.svg
+++ b/docs/img/family.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="390" viewBox="0 0 1000 390" role="img" aria-labelledby="title desc">
+  <title id="title">Where qmax-code sits among the QualityMax tools</title>
+  <desc id="desc">free-qa-skills audits, qmax-mcp proves one change, 9lives repairs broken tests, qmax-code orchestrates the session from a terminal, qmax-local-agent gives the cloud reach into a private network, and hosted QualityMax manages the QA program. Only the hosted service requires an account.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #14213d; }
+    .card { fill: #f7faff; stroke: #3159a7; stroke-width: 2; rx: 14; }
+    .self { fill: #eaf7ef; stroke: #217a45; stroke-width: 3.5; rx: 14; }
+    .cloud { fill: #fff6e5; stroke: #a76400; stroke-width: 2; stroke-dasharray: 8 6; rx: 14; }
+    .title { font-size: 20px; font-weight: 700; }
+    .name { font-size: 16px; font-weight: 700; }
+    .verb { font-size: 12.5px; font-weight: 700; letter-spacing: .06em; fill: #3159a7; }
+    .verbself { font-size: 12.5px; font-weight: 700; letter-spacing: .06em; fill: #217a45; }
+    .verbcloud { font-size: 12.5px; font-weight: 700; letter-spacing: .06em; fill: #a76400; }
+    .small { font-size: 13.5px; }
+    .muted { font-size: 13.5px; fill: #52596b; }
+    .you { font-size: 13px; font-weight: 700; fill: #217a45; }
+  </style>
+
+  <text x="500" y="30" text-anchor="middle" class="title">Five open tools, one QA program</text>
+
+  <rect x="24" y="52" width="304" height="112" class="card"/>
+  <text x="176" y="78" text-anchor="middle" class="verb">AUDIT</text>
+  <text x="176" y="103" text-anchor="middle" class="name">free-qa-skills</text>
+  <text x="176" y="128" text-anchor="middle" class="small">27 read-only QA skills, run</text>
+  <text x="176" y="148" text-anchor="middle" class="small">inside a coding agent</text>
+
+  <rect x="348" y="52" width="304" height="112" class="card"/>
+  <text x="500" y="78" text-anchor="middle" class="verb">PROVE</text>
+  <text x="500" y="103" text-anchor="middle" class="name">qmax-mcp</text>
+  <text x="500" y="128" text-anchor="middle" class="small">scan a page, generate a repro,</text>
+  <text x="500" y="148" text-anchor="middle" class="small">run it locally. No account.</text>
+
+  <rect x="672" y="52" width="304" height="112" class="card"/>
+  <text x="824" y="78" text-anchor="middle" class="verb">REPAIR</text>
+  <text x="824" y="103" text-anchor="middle" class="name">9lives</text>
+  <text x="824" y="128" text-anchor="middle" class="small">heal broken selectors and</text>
+  <text x="824" y="148" text-anchor="middle" class="small">show a diff for approval</text>
+
+  <rect x="24" y="188" width="304" height="112" class="self"/>
+  <text x="176" y="214" text-anchor="middle" class="verbself">ORCHESTRATE — YOU ARE HERE</text>
+  <text x="176" y="239" text-anchor="middle" class="name">qmax-code</text>
+  <text x="176" y="264" text-anchor="middle" class="small">the terminal agent that drives</text>
+  <text x="176" y="284" text-anchor="middle" class="small">the session, connected or local</text>
+
+  <rect x="348" y="188" width="304" height="112" class="card"/>
+  <text x="500" y="214" text-anchor="middle" class="verb">REACH</text>
+  <text x="500" y="239" text-anchor="middle" class="name">qmax-local-agent</text>
+  <text x="500" y="264" text-anchor="middle" class="small">lets the cloud run tests inside</text>
+  <text x="500" y="284" text-anchor="middle" class="small">a private network or CI runner</text>
+
+  <rect x="672" y="188" width="304" height="112" class="cloud"/>
+  <text x="824" y="214" text-anchor="middle" class="verbcloud">MANAGE — ACCOUNT REQUIRED</text>
+  <text x="824" y="239" text-anchor="middle" class="name">Hosted QualityMax</text>
+  <text x="824" y="264" text-anchor="middle" class="small">projects, suites, runs,</text>
+  <text x="824" y="284" text-anchor="middle" class="small">and observability</text>
+
+  <text x="500" y="336" text-anchor="middle" class="muted">Skills find issues · qmax-mcp proves a change · 9lives repairs the test · qmax-code runs the session · hosted QualityMax keeps the program</text>
+  <text x="500" y="366" text-anchor="middle" class="muted">Everything except the amber card works without a QualityMax account.</text>
+</svg>

--- a/docs/img/lifecycle.svg
+++ b/docs/img/lifecycle.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="272" viewBox="0 0 1000 272" role="img" aria-labelledby="title desc">
+  <title id="title">What qmax-code covers across the QA lifecycle</title>
+  <desc id="desc">Five connected stages — plan, generate, execute, review, ship — sitting on top of a local repository lane that also works without a QualityMax account.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #14213d; }
+    .stage { fill: #f7faff; stroke: #3159a7; stroke-width: 2; rx: 12; }
+    .base { fill: #eaf7ef; stroke: #217a45; stroke-width: 2; rx: 12; }
+    .arrow { stroke: #415a77; stroke-width: 2.5; fill: none; marker-end: url(#arrow); }
+    .title { font-size: 20px; font-weight: 700; }
+    .kicker { font-size: 13px; font-weight: 700; letter-spacing: .07em; fill: #3159a7; }
+    .small { font-size: 12.5px; }
+    .baselabel { font-size: 14px; font-weight: 700; }
+    .muted { font-size: 12.5px; fill: #52596b; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#415a77"/>
+    </marker>
+  </defs>
+
+  <text x="500" y="30" text-anchor="middle" class="title">One agent across the QA lifecycle</text>
+
+  <rect x="12" y="56" width="176" height="112" class="stage"/>
+  <text x="100" y="82" text-anchor="middle" class="kicker">PLAN</text>
+  <text x="100" y="107" text-anchor="middle" class="small">projects and test cases</text>
+  <text x="100" y="127" text-anchor="middle" class="small">coverage gaps</text>
+  <text x="100" y="147" text-anchor="middle" class="small">requirement imports</text>
+  <path d="M188 112 H208" class="arrow"/>
+
+  <rect x="212" y="56" width="176" height="112" class="stage"/>
+  <text x="300" y="82" text-anchor="middle" class="kicker">GENERATE</text>
+  <text x="300" y="107" text-anchor="middle" class="small">Playwright · pytest</text>
+  <text x="300" y="127" text-anchor="middle" class="small">Go · Rust</text>
+  <text x="300" y="147" text-anchor="middle" class="small">from crawls or cases</text>
+  <path d="M388 112 H408" class="arrow"/>
+
+  <rect x="412" y="56" width="176" height="112" class="stage"/>
+  <text x="500" y="82" text-anchor="middle" class="kicker">EXECUTE</text>
+  <text x="500" y="107" text-anchor="middle" class="small">cloud browser runs</text>
+  <text x="500" y="127" text-anchor="middle" class="small">native Go/Rust runner</text>
+  <text x="500" y="147" text-anchor="middle" class="small">or locally</text>
+  <path d="M588 112 H608" class="arrow"/>
+
+  <rect x="612" y="56" width="176" height="112" class="stage"/>
+  <text x="700" y="82" text-anchor="middle" class="kicker">REVIEW</text>
+  <text x="700" y="107" text-anchor="middle" class="small">quality and coverage</text>
+  <text x="700" y="127" text-anchor="middle" class="small">security and risk</text>
+  <text x="700" y="147" text-anchor="middle" class="small">saved preferences</text>
+  <path d="M788 112 H808" class="arrow"/>
+
+  <rect x="812" y="56" width="176" height="112" class="stage"/>
+  <text x="900" y="82" text-anchor="middle" class="kicker">SHIP</text>
+  <text x="900" y="107" text-anchor="middle" class="small">open test PRs</text>
+  <text x="900" y="127" text-anchor="middle" class="small">generate a GitHub</text>
+  <text x="900" y="147" text-anchor="middle" class="small">Actions workflow</text>
+
+  <rect x="12" y="188" width="976" height="52" class="base"/>
+  <text x="500" y="211" text-anchor="middle" class="baselabel">Local repository lane — read, edit, search, run allowlisted commands and tests</text>
+  <text x="500" y="231" text-anchor="middle" class="muted">This lane is what standalone --local mode keeps. The stages above need a QualityMax connection.</text>
+</svg>

--- a/docs/img/orchestration.svg
+++ b/docs/img/orchestration.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="430" viewBox="0 0 1000 430" role="img" aria-labelledby="title desc">
+  <title id="title">qmax-code orchestration mode</title>
+  <desc id="desc">The /orch picker selects one inference backend for a qmax-code turn: the built-in agent loop running Anthropic, Cerebras, or Ollama, or a CLI subprocess running Claude Code, Codex, or OpenCode, which receives qmax tools through an embedded MCP server. Connected or standalone mode decides which tools exist, independently of the backend.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #14213d; }
+    .host { fill: #eaf7ef; stroke: #217a45; stroke-width: 2; rx: 14; }
+    .pick { fill: #f7faff; stroke: #3159a7; stroke-width: 2; rx: 14; }
+    .mode { fill: #fff6e5; stroke: #a76400; stroke-width: 2; stroke-dasharray: 8 6; rx: 14; }
+    .chip { fill: #ffffff; stroke: #b9c5da; stroke-width: 1.5; rx: 9; }
+    .arrow { stroke: #415a77; stroke-width: 2.5; fill: none; marker-end: url(#arrow); }
+    .title { font-size: 20px; font-weight: 700; }
+    .label { font-size: 17px; font-weight: 700; }
+    .chiptext { font-size: 14px; font-weight: 600; }
+    .small { font-size: 13.5px; }
+    .muted { font-size: 13.5px; fill: #52596b; }
+    .kicker { font-size: 12.5px; font-weight: 700; letter-spacing: .05em; fill: #217a45; }
+    .kickerb { font-size: 12.5px; font-weight: 700; letter-spacing: .05em; fill: #3159a7; }
+    .kickerg { font-size: 12.5px; font-weight: 700; letter-spacing: .05em; fill: #a76400; }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L9,3 z" fill="#415a77"/>
+    </marker>
+  </defs>
+
+  <text x="500" y="30" text-anchor="middle" class="title">One picker. Six backends. The same qmax tools.</text>
+
+  <rect x="24" y="58" width="104" height="62" class="pick"/>
+  <text x="76" y="95" text-anchor="middle" class="label">you</text>
+
+  <path d="M128 89 H158" class="arrow"/>
+
+  <rect x="163" y="52" width="330" height="74" class="host"/>
+  <text x="328" y="80" text-anchor="middle" class="label">qmax-code REPL</text>
+  <text x="328" y="105" text-anchor="middle" class="small">terminal UX · tool policy · QualityMax context</text>
+
+  <path d="M493 89 H523" class="arrow"/>
+
+  <rect x="528" y="52" width="270" height="74" class="pick"/>
+  <text x="663" y="80" text-anchor="middle" class="label">/orch</text>
+  <text x="663" y="105" text-anchor="middle" class="small">backend · model · effort</text>
+
+  <path d="M663 126 V150 H250 V176" class="arrow"/>
+  <path d="M663 126 V150 H750 V176" class="arrow"/>
+
+  <rect x="40" y="178" width="420" height="122" class="host"/>
+  <text x="250" y="203" text-anchor="middle" class="kicker">BUILT-IN AGENT LOOP</text>
+  <rect x="55" y="216" width="128" height="38" class="chip"/>
+  <text x="119" y="240" text-anchor="middle" class="chiptext">Anthropic API</text>
+  <rect x="191" y="216" width="118" height="38" class="chip"/>
+  <text x="250" y="240" text-anchor="middle" class="chiptext">Cerebras</text>
+  <rect x="317" y="216" width="128" height="38" class="chip"/>
+  <text x="381" y="240" text-anchor="middle" class="chiptext">Ollama</text>
+  <text x="250" y="281" text-anchor="middle" class="muted">qmax-code runs the tool loop itself</text>
+
+  <rect x="540" y="178" width="420" height="122" class="host"/>
+  <text x="750" y="203" text-anchor="middle" class="kicker">CLI SUBPROCESS</text>
+  <rect x="555" y="216" width="128" height="38" class="chip"/>
+  <text x="619" y="240" text-anchor="middle" class="chiptext">Claude Code</text>
+  <rect x="691" y="216" width="106" height="38" class="chip"/>
+  <text x="744" y="240" text-anchor="middle" class="chiptext">Codex</text>
+  <rect x="805" y="216" width="140" height="38" class="chip"/>
+  <text x="875" y="240" text-anchor="middle" class="chiptext">OpenCode</text>
+  <text x="750" y="281" text-anchor="middle" class="muted">qmax tools arrive through the embedded MCP server</text>
+
+  <path d="M250 300 V326 H480 V344" class="arrow"/>
+  <path d="M750 300 V326 H520 V344" class="arrow"/>
+
+  <rect x="150" y="346" width="700" height="66" class="mode"/>
+  <text x="500" y="370" text-anchor="middle" class="kickerg">WHICH TOOLS EXIST IS SET BY MODE, NOT BY BACKEND</text>
+  <text x="500" y="396" text-anchor="middle" class="small">connected: QualityMax + local QA tools   ·   --local: workspace tools only</text>
+</svg>


### PR DESCRIPTION
A documentation and visual pass. No code changes — `go build` and `go vet ./...` pass.

## The version story was wrong

The README's headline section was titled **"What is new in v1.21"** while the latest release is **v1.22.1**. It also listed `--local` standalone mode among the v1.21 items, but the CHANGELOG puts that in **v1.22.0**.

More importantly, **v1.22.1's cloud MCP routing fix was not mentioned in the README at all.** That fix is why tool calls made through the local MCP server are visible to the platform — before it they set no trace context, produced no session history, and returned UI-shaped REST payloads carrying every script's full source. A reader of the README would never have learned it happened.

The section is now split by release with each feature attributed correctly. `docs/COMMANDS.md` carried the same stale v1.21 reference.

## Three diagrams

All three share the house style already used by the qmax-mcp architecture diagram, so the org's repos read as one family.

| Diagram | Where | Why |
| --- | --- | --- |
| `orchestration.svg` | Orchestration mode | Replaces the ASCII flow. Makes the point the prose works hardest to convey: `/orch` picks a **backend**, but **mode** decides which tools exist. |
| `lifecycle.svg` | What qmax-code can do | Gives the bullet wall a shape, and shows which lane survives in standalone mode. |
| `family.svg` | Intro | Places qmax-code among free-qa-skills, qmax-mcp, 9lives, and qmax-local-agent. That positioning existed nowhere public. |

The ASCII flow removed from the README is not lost — an equivalent tree already lives in `docs/ORCHESTRATION.md`, so plain-text readers keep it.

Each SVG carries `<title>` and `<desc>` for screen readers, and every diagram was rendered and visually checked rather than committed sight-unseen.

## Also

- Release badge, and the Go badge pinned to 1.24+ to match the build requirement already stated under Install.