### PR TITLE
fix(httpx): close request-body completion race in egress recorder

### DIFF
--- a/internal/httpx/httpx.go
+++ b/internal/httpx/httpx.go
@@ -145,6 +145,17 @@ type hashingBody struct {
 	// A server can respond before consuming a request body, in which case a
 	// prefix hash would be misleading and must not be signed as complete.
 	complete bool
+	// closed is closed exactly once, when the transport closes the request body.
+	// A conformant RoundTripper always closes req.Body after it finishes writing
+	// it (including the final EOF read), so waiting on closed lets RoundTrip read
+	// `complete` after the async body-write goroutine has settled rather than
+	// racing it. See RoundTrip for why that race exists.
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newHashingBody(rc io.ReadCloser) *hashingBody {
+	return &hashingBody{rc: rc, h: sha256.New(), closed: make(chan struct{})}
 }
 
 func (b *hashingBody) Read(p []byte) (int, error) {
@@ -161,7 +172,12 @@ func (b *hashingBody) Read(p []byte) (int, error) {
 	return n, err
 }
 
-func (b *hashingBody) Close() error { return b.rc.Close() }
+func (b *hashingBody) Close() error {
+	if b.closed != nil {
+		b.closeOnce.Do(func() { close(b.closed) })
+	}
+	return b.rc.Close()
+}
 
 func (b *hashingBody) snapshot() (bytes int64, sha256 string, complete bool) {
 	b.mu.Lock()
@@ -190,11 +206,27 @@ func (t *receiptTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	// Wrap the body so it is hashed+counted as it streams to the wire.
 	var hb *hashingBody
 	if req.Body != nil {
-		hb = &hashingBody{rc: req.Body, h: sha256.New()}
+		hb = newHashingBody(req.Body)
 		req.Body = hb
 	}
 
 	resp, err := t.base.RoundTrip(req)
+
+	// net/http writes the request body on a separate goroutine and returns from
+	// RoundTrip as soon as the response headers arrive — which can happen before
+	// that goroutine has read the body through EOF and marked it complete. On a
+	// successful round trip, wait for the transport to close the body (a
+	// conformant RoundTripper always does, once the write has finished) so
+	// `complete` reflects the settled write instead of a race. The wait is
+	// bounded by the request context, which the client's Timeout cancels. On a
+	// transport error the write was aborted and the body is legitimately
+	// incomplete, so there is nothing to wait for.
+	if hb != nil && err == nil {
+		select {
+		case <-hb.closed:
+		case <-req.Context().Done():
+		}
+	}
 
 	// A body hash is only trustworthy after EOF. If a peer responds before the
 	// body is drained, report the metadata as unavailable rather than signing a

--- a/internal/httpx/httpx_test.go
+++ b/internal/httpx/httpx_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -88,6 +90,113 @@ func TestRecordsRequestHashAndSize(t *testing.T) {
 	}
 }
 
+// TestConcurrentRealRequestsRecordCompleteBody hammers the real transport with
+// many simultaneous requests. net/http writes each request body on its own
+// goroutine and returns from RoundTrip when the response headers arrive, so a
+// naive read of the completeness flag races that write and intermittently
+// records a fully-sent body as incomplete (bytes:0, hash:""). Every request
+// here sends the same fully-consumed body, so every receipt entry must report
+// the complete byte count and hash. Run with -race and -count to exercise it.
+func TestConcurrentRealRequestsRecordCompleteBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	body := strings.Repeat("prompt-", 1000) // ~7KB
+	wantBytes := int64(len(body))
+	wantHash := sha256.Sum256([]byte(body))
+	client := NewClient(10 * time.Second)
+
+	const n = 64
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, rec := receipt.Begin(context.Background(), "test:concurrent")
+			req, err := NewRequest(ctx, http.MethodPost, srv.URL+"/v1/messages", strings.NewReader(body))
+			if err != nil {
+				errs <- err
+				return
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				errs <- err
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+
+			if rec.EntryCount() != 1 {
+				errs <- fmt.Errorf("entries = %d, want 1", rec.EntryCount())
+				return
+			}
+			e := rec.Entries[0]
+			if e.ReqBytes != wantBytes || e.ReqSHA256 != hex.EncodeToString(wantHash[:]) {
+				errs <- fmt.Errorf("recorded incomplete body: bytes=%d hash=%q note=%q", e.ReqBytes, e.ReqSHA256, e.Note)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// TestFullBodyRecordedWhenTransportFinishesWritingAfterResponse reproduces the
+// ordering net/http actually exhibits: RoundTrip returns as soon as the
+// response headers arrive, while the request body is still being written (and
+// therefore hashed) on a separate goroutine. The recorder must wait for that
+// write to settle before reading the completeness flag; otherwise it snapshots
+// mid-write and signs a fully-sent body as incomplete. The fake transport here
+// closes the body only after a release signal fired past RoundTrip's return,
+// so the assertion below fails deterministically without the completion barrier.
+func TestFullBodyRecordedWhenTransportFinishesWritingAfterResponse(t *testing.T) {
+	rec := receipt.NewCurrent("test:async-write")
+	body := strings.Repeat("prompt-", 1000)
+
+	release := make(chan struct{})
+	transport := &receiptTransport{base: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		// Model net/http: hand back the response now, finish reading and closing
+		// the body later on another goroutine.
+		go func() {
+			<-release
+			_, _ = io.Copy(io.Discard, req.Body)
+			_ = req.Body.Close()
+		}()
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+	})}
+
+	req, err := NewRequest(context.Background(), http.MethodPost, "http://example.test/v1/messages", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	// Release the write only after RoundTrip has had time to return and (in the
+	// unfixed code) snapshot the still-empty body.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(release)
+	}()
+
+	if _, err := transport.RoundTrip(req); err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+
+	if rec.EntryCount() != 1 {
+		t.Fatalf("entries = %d, want 1", rec.EntryCount())
+	}
+	e := rec.Entries[0]
+	wantHash := sha256.Sum256([]byte(body))
+	if e.ReqBytes != int64(len(body)) || e.ReqSHA256 != hex.EncodeToString(wantHash[:]) {
+		t.Errorf("recorded body = bytes:%d hash:%q note:%q, want the complete byte count and hash", e.ReqBytes, e.ReqSHA256, e.Note)
+	}
+}
+
 // TestTransportErrorStillRecorded proves an egress attempt that never connects
 // is still accounted for — no request leaves the machine unrecorded.
 func TestTransportErrorStillRecorded(t *testing.T) {
@@ -149,6 +258,10 @@ func TestIncompleteRequestBodyIsNotSignedAsACompleteHash(t *testing.T) {
 		if _, err := req.Body.Read(buf); err != nil {
 			t.Fatalf("read partial body: %v", err)
 		}
+		// A conformant RoundTripper always closes the request body once it is
+		// done with it; model that so the recorder can observe that the write
+		// has settled without draining the body through EOF.
+		_ = req.Body.Close()
 		return &http.Response{StatusCode: http.StatusRequestEntityTooLarge, Body: io.NopCloser(strings.NewReader(""))}, nil
 	})}
 	if _, err := transport.RoundTrip(req); err != nil {
@@ -291,7 +404,7 @@ func TestFailedWebSocketHandshakeIsRecorded(t *testing.T) {
 
 func TestHashingBodySnapshotConcurrentWithRead(t *testing.T) {
 	body := bytes.Repeat([]byte("x"), 64*1024)
-	hb := &hashingBody{rc: io.NopCloser(bytes.NewReader(body)), h: sha256.New()}
+	hb := newHashingBody(io.NopCloser(bytes.NewReader(body)))
 	done := make(chan error, 1)
 	go func() {
 		buf := make([]byte, 1)


### PR DESCRIPTION
## What broke

CI on `main` (`release: v1.22.2`) went red on a single test:

```
internal/httpx  TestRecordsRequestHashAndSize
  httpx_test.go:77: req_bytes = 0, want 7000
  httpx_test.go:81: req_sha256 = "", want "3e5a27be…"
```

(The `tar: Cannot open: File exists` spam and the `QualityMax report failed (HTTP 401)` line in that run are unrelated, non-fatal noise from the cache-restore and reporting steps.)

The test passes locally at that exact commit, including `-count=500`, `-race`, and `-cpu=1` — it's a **timing flake**, not a regression.

## Root cause

`net/http` writes the request body on a **separate goroutine** and returns from `RoundTrip` as soon as the response headers arrive. `receiptTransport.RoundTrip` read `hashingBody.complete` synchronously right after `RoundTrip` returned, so on a loaded runner it could snapshot **mid-write** — before the body-write goroutine had read the body through `io.EOF` and set `complete`. Result: a fully-sent body recorded as incomplete (`ReqBytes=0`, `ReqSHA256=""`, `request-body-incomplete` note).

This is mostly a flaky test, but the same window could occasionally under-report real egress metadata in the receipt.

## Fix

A conformant `RoundTripper` always closes `req.Body` after the write settles (including the final EOF read). So `hashingBody` now closes a `closed` channel on `Close()`, and on a successful round trip `RoundTrip` waits on it (bounded by the request context, which the client `Timeout` cancels) before snapshotting. Transport-error and no-body paths are unchanged; the genuine "server responded before consuming the body" case still records incomplete, because `Close` still fires with `complete == false`.

## Tests

- **`TestFullBodyRecordedWhenTransportFinishesWritingAfterResponse`** — deterministic: models net/http's async-write ordering with a fake transport that closes the body after `RoundTrip` returns. Reproduces the exact CI symptom (`bytes:0 hash:""`) **without** the barrier and passes with it.
- **`TestConcurrentRealRequestsRecordCompleteBody`** — 64 concurrent real-loopback requests, each asserting a complete byte count + hash.
- Updated `TestIncompleteRequestBodyIsNotSignedAsACompleteHash`'s fake to close the body (models a conformant `RoundTripper`); it still correctly records incomplete.

Full `internal/httpx` suite passes under `-race -count=3`.

---

## Changes at a glance (2 files, +148 −3)

| File | Δ | Purpose |
|---|---|---|
| `internal/httpx/httpx.go` | **+36 −3** | Close the request-body completion race: hash finalized only after body EOF, ordered with response writeback |
| `internal/httpx/httpx_test.go` | **+115** | Deterministic race repro + concurrent real-transport stress test |

```mermaid
sequenceDiagram
    participant R as Recorder (egress)
    participant B as Request body stream
    participant H as Body hash
    Note over R,H: Before: hash could finalize before body EOF
    R->>B: read chunk
    B->>H: update hash
    B-->>R: EOF (completion signal)
    R->>H: finalize hash after EOF
    R->>R: emit record (hash + body consistent)
```
