### PR TITLE
docs(changelog): note the httpx egress body-hash race fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
   every token-bearing event, keeping only the final step, while opencode emits
   usage on each `step-finish` — so a turn that called tools lost every earlier
   step. Usage now accumulates across steps.
+- The egress recorder no longer races net/http's asynchronous request-body
+  write. `RoundTrip` returns as soon as the response headers arrive, so reading
+  the body-completion flag synchronously could snapshot mid-write and record a
+  fully-sent request body as incomplete (`ReqBytes=0`, empty SHA-256) — the
+  flake behind the red Go Tests run on v1.22.2. The recorder now waits for the
+  transport to close the body before capturing its byte count and hash.
 
 ## [1.22.1] - 2026-08-03
 


### PR DESCRIPTION
Follow-up to #162. Adds the missing CHANGELOG entry under `[Unreleased] → Fixed` documenting the egress recorder request-body completion-race fix. No code change; docs only.

This rides with the next release rather than triggering its own tag (version constant stays `1.22.2`; `[Unreleased]` already carries the coding-plan feature, so the next cut is likely a minor bump).