### PR TITLE
release: v1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to qmax-code. Versions follow [Semantic Versioning](https://semver.org/).
 
-## [1.22.2] - 2026-08-04
-
 ## [Unreleased]
+
+## [1.23.0] - 2026-08-08
 
 ### Added
 - Coding-plan usage-window tracking for the subscription orchestration backends
@@ -47,6 +47,8 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
   fully-sent request body as incomplete (`ReqBytes=0`, empty SHA-256) — the
   flake behind the red Go Tests run on v1.22.2. The recorder now waits for the
   transport to close the body before capturing its byte count and hash.
+
+## [1.22.2] - 2026-08-04
 
 ## [1.22.1] - 2026-08-03
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.22.2"
+var Version = "1.23.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Cuts **v1.23.0**.

- Bumps `main.go` `Version` → `1.23.0`.
- Promotes the `[Unreleased]` CHANGELOG section under a dated `## [1.23.0] - 2026-08-08` heading and opens a fresh empty `[Unreleased]`.
- Fixes changelog ordering (the empty `[1.22.2]` heading now sits below `[1.23.0]`, newest-first).

**Why minor, not patch:** this is the first *tagged* release to ship the coding-plan usage-window tracking feature (#157) — that feature is not present in the `v1.22.2` tag — so semver calls for a minor bump. It also carries the OpenCode backend fixes and the httpx egress body-hash race fix (#162).

`go vet ./...` and `go test ./...` pass locally (mirrors the release workflow's gate).

After this merges, push the `v1.23.0` tag to trigger `.github/workflows/release.yml` (build + publish).

---

## Changes at a glance — v1.23.0 (19 files, +1386 −24)

| PR | Files | Δ | What shipped |
|---|---|---|---|
| **#157** | 16 | **+1227 −18** | Coding-plan usage window (planlimit + planwindow + REPL/TUI) & OpenCode backend fixes |
| **#162** | 2 | **+148 −3** | httpx egress recorder: request-body completion race fix |
| **#163** | 1 | +6 | Changelog note for #162 |
| **#164** | 2 | +5 −3 | Version bump 1.23.0 + changelog promotion |

```mermaid
flowchart LR
    subgraph release["v1.23.0 · first release with usage-window tracking"]
        subgraph P157["#157 · plan window + agents"]
            PW["planlimit.go +85<br/>planwindow.go +174<br/>planwindow_test.go +175<br/>planwindow_turn_test.go +100"]
            REPL["repl.go +101 · tui/input.go +15 · terminal.go +39<br/>config_command.go +21 · api/config.go +7"]
            OC["opencode_agent.go +233<br/>opencode_stream_test.go +162"]
            CX["codex_agent.go +84 · cc_agent.go +10"]
        end
        subgraph P162["#162 · egress fix"]
            HX["httpx.go +36 · httpx_test.go +115<br/>body-hash completion race"]
        end
        REL["#164 · CHANGELOG + main.go<br/>Version → 1.23.0"]
    end
    PW --> REPL
    OC --> PW
    CX --> PW
    HX --> REL
    P157 --> REL
```
