### PR TITLE
feat(tui): render live file diffs consistently while the agent works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+### Added
+- Live code-change diffs in the TUI while the agent works. Every file-editing
+  tool call — built-in `edit_file`/`write_file`, Claude Code's `Edit`/`Write`,
+  and OpenCode's edit/write — now renders a compact colored diff (`path +N −M`
+  header, capped +/- lines with ellipsized context) as soon as the edit lands,
+  consistently across all backends. Context lines are collapsed and full-file
+  rewrites are capped at 40 diff lines so the transcript stays readable.
+
 ## [1.23.0] - 2026-08-08
 
 ### Added

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -865,7 +865,9 @@ func (a *Agent) executeToolCallsWithUI(toolCalls []api.ContentBlock, term *tui.T
 	var results []api.ContentBlock
 	for _, block := range toolCalls {
 		a.Logger.Info("tool", block.Name, map[string]interface{}{"cost": ToolCost(block.Name)})
+		snap := takeFileSnapshot(block.Name, strMapInput(block.Input))
 		output := executeTool(block.Name, block.Input, a.Cfg.Context, ctx, term)
+		printFileDiff(term, snap)
 
 		// update_plan renders a dedicated checklist from its input rather than
 		// the generic tool-result line (which would just echo {total,done}).

--- a/internal/agent/cc_agent.go
+++ b/internal/agent/cc_agent.go
@@ -73,6 +73,7 @@ type CCAgent struct {
 	mcpConfigInfo  os.FileInfo
 	sctx           *api.SessionContext
 	lastToolName   string // track last tool name for result display
+	fileSnaps      map[string]fileSnapshot // CC tool_use id → pre-edit snapshot
 	lastTurnIn     int    // token usage of the most recent turn (from CC's result event)
 	lastTurnOut    int
 	lastTurnOK     bool // true once a result event carried usage this turn
@@ -607,6 +608,12 @@ func (a *CCAgent) parseStream(stdout interface{ Read([]byte) (int, error) }, ter
 					displayName := stripMCPPrefix(block.Name)
 					a.mu.Lock()
 					a.lastToolName = displayName
+					if snap := takeFileSnapshot(block.Name, block.Input); snap.path != "" {
+						if a.fileSnaps == nil {
+							a.fileSnaps = map[string]fileSnapshot{}
+						}
+						a.fileSnaps[block.ID] = snap
+					}
 					a.mu.Unlock()
 					term.PrintToolIcon(displayName)
 					if a.outputVerbose {
@@ -627,7 +634,12 @@ func (a *CCAgent) parseStream(stdout interface{ Read([]byte) (int, error) }, ter
 				if block.Type == "tool_result" {
 					a.mu.Lock()
 					toolName := a.lastToolName
+					snap, haveSnap := a.fileSnaps[block.ToolUseID]
+					delete(a.fileSnaps, block.ToolUseID)
 					a.mu.Unlock()
+					if haveSnap {
+						printFileDiff(term, snap)
+					}
 					content := extractToolResultText(block.Content)
 					if a.outputVerbose {
 						term.PrintToolResult(toolName, tui.TruncateStr(content, 200))

--- a/internal/agent/filediff.go
+++ b/internal/agent/filediff.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/qualitymax/qmax-code/internal/tui"
+)
+
+// fileSnapshot captures a file's pre-edit content so the TUI can render a live
+// diff when the tool completes — regardless of which backend made the edit.
+type fileSnapshot struct {
+	path string
+	old  string
+}
+
+// strMapInput coerces a tool input (interface{} from content blocks) to a map.
+func strMapInput(input interface{}) map[string]interface{} {
+	if m, ok := input.(map[string]interface{}); ok {
+		return m
+	}
+	return nil
+}
+
+// isFileEditTool reports whether a tool (built-in, Claude Code, or OpenCode
+// naming) modifies workspace files and deserves a live diff.
+func isFileEditTool(name string) bool {
+	n := strings.ToLower(name)
+	if i := strings.LastIndex(n, "__"); i >= 0 {
+		n = n[i+2:] // strip mcp server prefixes like qmax__edit_file
+	}
+	return strings.Contains(n, "edit") ||
+		strings.Contains(n, "write") ||
+		strings.Contains(n, "patch") ||
+		n == "notebook"
+}
+
+// toolPath extracts the target file path from a tool input map, tolerating the
+// field names used by the built-in tools and CC/OpenCode backends.
+func toolPath(input map[string]interface{}) string {
+	if input == nil {
+		return ""
+	}
+	for _, k := range []string{"path", "file_path", "filePath", "notebook_path"} {
+		if v, ok := input[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	// OpenCode nests edit targets under files/edits maps.
+	for _, k := range []string{"files", "edits"} {
+		if nested, ok := input[k].(map[string]interface{}); ok {
+			if p := toolPath(nested); p != "" {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+// toolPathFromRaw decodes a raw JSON tool input and extracts its file path.
+func toolPathFromRaw(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var input map[string]interface{}
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return ""
+	}
+	return toolPath(input)
+}
+
+// takeFileSnapshot resolves the tool's target to an absolute path and captures
+// its current content. Returns a zero snapshot when the tool edits nothing.
+func takeFileSnapshot(name string, input map[string]interface{}) fileSnapshot {
+	if !isFileEditTool(name) {
+		return fileSnapshot{}
+	}
+	p := toolPath(input)
+	if p == "" {
+		return fileSnapshot{}
+	}
+	if !filepath.IsAbs(p) {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return fileSnapshot{}
+		}
+		p = abs
+	}
+	data, _ := os.ReadFile(p)
+	return fileSnapshot{path: p, old: string(data)}
+}
+
+// takeFileSnapshotRaw is takeFileSnapshot for raw JSON inputs (OpenCode events).
+func takeFileSnapshotRaw(name, path string) fileSnapshot {
+	if !isFileEditTool(name) || path == "" {
+		return fileSnapshot{}
+	}
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return fileSnapshot{}
+		}
+		path = abs
+	}
+	data, _ := os.ReadFile(path)
+	return fileSnapshot{path: path, old: string(data)}
+}
+
+// printFileDiff renders the change to the snapshot path since capture. No-op
+// for identical content (e.g. a rejected or no-op edit).
+func printFileDiff(term *tui.Terminal, snap fileSnapshot) {
+	if term == nil || snap.path == "" {
+		return
+	}
+	data, err := os.ReadFile(snap.path)
+	if err != nil {
+		return // deleted target: nothing sensible to diff against
+	}
+	if string(data) == snap.old {
+		return
+	}
+	term.PrintFileDiff(displayPath(snap.path), snap.old, string(data))
+}
+
+// displayPath shortens an absolute path to cwd-relative when possible.
+func displayPath(p string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return p
+	}
+	if rel, err := filepath.Rel(cwd, p); err == nil && !strings.HasPrefix(rel, "..") {
+		return rel
+	}
+	return p
+}

--- a/internal/agent/filediff_test.go
+++ b/internal/agent/filediff_test.go
@@ -83,7 +83,9 @@ func TestTakeFileSnapshotAndDiff(t *testing.T) {
 func TestTakeFileSnapshotRaw(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.txt")
-	os.WriteFile(path, []byte("x"), 0o644)
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if s := takeFileSnapshotRaw("opencode.edit", path); s.path == "" || s.old != "x" {
 		t.Fatalf("raw snapshot = %+v", s)
 	}

--- a/internal/agent/filediff_test.go
+++ b/internal/agent/filediff_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsFileEditTool(t *testing.T) {
+	cases := map[string]bool{
+		"edit_file":          true,
+		"write_file":         true,
+		"Edit":               true, // Claude Code
+		"Write":              true,
+		"NotebookEdit":       true,
+		"qmax__edit_file":    true, // mcp-prefixed
+		"opencode.edit":      true,
+		"applypatch":         true,
+		"read_file":          false,
+		"bash":               false,
+		"update_plan":        false,
+		"webfetch":           false,
+	}
+	for name, want := range cases {
+		if got := isFileEditTool(name); got != want {
+			t.Errorf("isFileEditTool(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestToolPathFieldVariants(t *testing.T) {
+	cases := []struct {
+		input map[string]interface{}
+		want  string
+	}{
+		{map[string]interface{}{"path": "a.go"}, "a.go"},
+		{map[string]interface{}{"file_path": "b.go"}, "b.go"},       // CC
+		{map[string]interface{}{"filePath": "c.go"}, "c.go"},        // OpenCode
+		{map[string]interface{}{"notebook_path": "n.ipynb"}, "n.ipynb"},
+		{map[string]interface{}{"files": map[string]interface{}{"path": "d.go"}}, "d.go"},
+		{map[string]interface{}{"command": "ls"}, ""},
+		{nil, ""},
+	}
+	for _, c := range cases {
+		if got := toolPath(c.input); got != c.want {
+			t.Errorf("toolPath(%v) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}
+
+func TestTakeFileSnapshotAndDiff(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "target.go")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := takeFileSnapshot("edit_file", map[string]interface{}{"path": path})
+	if snap.path == "" {
+		t.Fatal("expected snapshot for edit_file on existing file")
+	}
+	if snap.old != "old\n" {
+		t.Fatalf("snapshot content = %q", snap.old)
+	}
+
+	// No snapshot for non-edit tools or missing paths.
+	if s := takeFileSnapshot("bash", map[string]interface{}{"path": path}); s.path != "" {
+		t.Fatal("bash should not snapshot")
+	}
+	if s := takeFileSnapshot("edit_file", map[string]interface{}{"command": "x"}); s.path != "" {
+		t.Fatal("edit without a path should not snapshot")
+	}
+
+	// Identical content → zero snapshot path after edit (printFileDiff no-ops).
+	if err := os.WriteFile(path, []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTakeFileSnapshotRaw(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	os.WriteFile(path, []byte("x"), 0o644)
+	if s := takeFileSnapshotRaw("opencode.edit", path); s.path == "" || s.old != "x" {
+		t.Fatalf("raw snapshot = %+v", s)
+	}
+	if s := takeFileSnapshotRaw("opencode.bash", path); s.path != "" {
+		t.Fatal("non-edit tool must not snapshot")
+	}
+}

--- a/internal/agent/filediff_test.go
+++ b/internal/agent/filediff_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
 func TestIsFileEditTool(t *testing.T) {
@@ -92,4 +94,24 @@ func TestTakeFileSnapshotRaw(t *testing.T) {
 	if s := takeFileSnapshotRaw("opencode.bash", path); s.path != "" {
 		t.Fatal("non-edit tool must not snapshot")
 	}
+}
+
+func TestPrintFileDiffTargetDeletedAfterSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gone.go")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snap := takeFileSnapshot("edit_file", map[string]interface{}{"path": path})
+	if snap.path == "" {
+		t.Fatal("expected snapshot")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	// Zero-value Terminal is safe here: printFileDiff must return before any
+	// emit because the snapshot target no longer exists.
+	term := &tui.Terminal{}
+	printFileDiff(term, snap) // must not panic or print
+	printFileDiff(nil, snap)  // nil terminal tolerated
 }

--- a/internal/agent/opencode_agent.go
+++ b/internal/agent/opencode_agent.go
@@ -45,6 +45,7 @@ type OpenCodeAgent struct {
 	cfg            *api.Config
 	sctx           *api.SessionContext
 	lastToolName   string
+	fileSnaps      map[string]fileSnapshot // opencode tool part id → pre-edit snapshot
 	lastTurnIn     int  // token usage of the most recent turn (from opencode's stream)
 	lastTurnOut    int
 	lastTurnOK     bool      // true once a usage event carried tokens this turn
@@ -259,12 +260,14 @@ type ocEvent struct {
 }
 
 type ocPart struct {
-	ID     string    `json:"id"`
-	Type   string    `json:"type"`
-	Text   string    `json:"text"`
-	Tool   string    `json:"tool"`
-	Tokens *ocTokens `json:"tokens,omitempty"`
-	Usage  *ocTokens `json:"usage,omitempty"`
+	ID     string          `json:"id"`
+	Type   string          `json:"type"`
+	Text   string          `json:"text"`
+	Tool   string          `json:"tool"`
+	State  string          `json:"state,omitempty"`  // tool parts: pending|running|completed|error
+	Input  json.RawMessage `json:"input,omitempty"`  // tool parts: tool input (has file path)
+	Tokens *ocTokens       `json:"tokens,omitempty"`
+	Usage  *ocTokens       `json:"usage,omitempty"`
 }
 
 // ocTokens tolerates the common token-count field names emitted by opencode and
@@ -416,13 +419,34 @@ func (a *OpenCodeAgent) parseStream(stdout interface{ Read([]byte) (int, error) 
 			textByPart[id] = text
 
 		case ev.Part.Type == "tool" || ev.Type == "tool":
-			if ev.Part.Tool == "" || seenTool[ev.Part.ID] {
+			if ev.Part.Tool == "" {
+				continue
+			}
+			// A tool part reaching a terminal state may have changed a file —
+			// render the live diff before the next output block streams.
+			if ev.Part.State == "completed" || ev.Part.State == "error" {
+				a.mu.Lock()
+				snap, haveSnap := a.fileSnaps[ev.Part.ID]
+				delete(a.fileSnaps, ev.Part.ID)
+				a.mu.Unlock()
+				if haveSnap {
+					printFileDiff(term, snap)
+				}
+				continue
+			}
+			if seenTool[ev.Part.ID] {
 				continue
 			}
 			seenTool[ev.Part.ID] = true
 			displayName := stripMCPPrefix(ev.Part.Tool)
 			a.mu.Lock()
 			a.lastToolName = displayName
+			if snap := takeFileSnapshotRaw(ev.Part.Tool, toolPathFromRaw(ev.Part.Input)); snap.path != "" {
+				if a.fileSnaps == nil {
+					a.fileSnaps = map[string]fileSnapshot{}
+				}
+				a.fileSnaps[ev.Part.ID] = snap
+			}
 			a.mu.Unlock()
 			term.PrintToolIcon(displayName)
 			if !a.outputVerbose {

--- a/internal/agent/opencode_agent.go
+++ b/internal/agent/opencode_agent.go
@@ -432,7 +432,6 @@ func (a *OpenCodeAgent) parseStream(stdout interface{ Read([]byte) (int, error) 
 				if haveSnap {
 					printFileDiff(term, snap)
 				}
-				continue
 			}
 			if seenTool[ev.Part.ID] {
 				continue
@@ -441,11 +440,15 @@ func (a *OpenCodeAgent) parseStream(stdout interface{ Read([]byte) (int, error) 
 			displayName := stripMCPPrefix(ev.Part.Tool)
 			a.mu.Lock()
 			a.lastToolName = displayName
-			if snap := takeFileSnapshotRaw(ev.Part.Tool, toolPathFromRaw(ev.Part.Input)); snap.path != "" {
-				if a.fileSnaps == nil {
-					a.fileSnaps = map[string]fileSnapshot{}
+			// Snapshot only while the edit is still ahead of us; a part first
+			// seen in a terminal state has already run (nothing to diff).
+			if ev.Part.State != "completed" && ev.Part.State != "error" {
+				if snap := takeFileSnapshotRaw(ev.Part.Tool, toolPathFromRaw(ev.Part.Input)); snap.path != "" {
+					if a.fileSnaps == nil {
+						a.fileSnaps = map[string]fileSnapshot{}
+					}
+					a.fileSnaps[ev.Part.ID] = snap
 				}
-				a.fileSnaps[ev.Part.ID] = snap
 			}
 			a.mu.Unlock()
 			term.PrintToolIcon(displayName)

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -39,7 +39,7 @@ func ComputeDiff(oldContent, newContent string) []DiffLine {
 	newMid := newL[p : len(newL)-s]
 
 	var ops []DiffLine
-	ops = append(ops, ctxRun(oldL[:p])...)
+	ops = append(ops, prefixRun(oldL[:p])...)
 	if len(oldMid)*len(newMid) > lcsCellCap {
 		ops = append(ops, markRun(len(oldMid))...)
 		for _, l := range oldMid {
@@ -51,10 +51,59 @@ func ComputeDiff(oldContent, newContent string) []DiffLine {
 	} else {
 		ops = append(ops, lcsDiff(oldMid, newMid)...)
 	}
-	ops = append(ops, ctxRun(oldL[len(oldL)-s:])...)
-	return ops
+	ops = append(ops, suffixRun(oldL[len(oldL)-s:])...)
+	if added, removed := DiffStat(ops); added == 0 && removed == 0 && oldContent != newContent {
+		// Only a trailing-newline difference: represent it explicitly so the
+		// edit is visible instead of rendering as no change.
+		last := ""
+		if n := len(oldL); n > 0 {
+			last = oldL[n-1]
+		}
+		if last == "" && len(newL) > 0 {
+			last = newL[len(newL)-1]
+		}
+		marker := "trailing newline added"
+		if strings.HasSuffix(oldContent, "\n") && !strings.HasSuffix(newContent, "\n") {
+			marker = "trailing newline removed"
+		}
+		ops = append(ops,
+			DiffLine{T: "-", S: last},
+			DiffLine{T: "+", S: last},
+			DiffLine{T: "\\", S: marker},
+		)
+	}
+	return orderChanges(ops)
 }
 
+// orderChanges rewrites each contiguous +/- run so all removed lines precede
+// added lines, matching conventional unified-diff ordering.
+func orderChanges(ops []DiffLine) []DiffLine {
+	out := make([]DiffLine, 0, len(ops))
+	i := 0
+	for i < len(ops) {
+		if ops[i].T != "-" && ops[i].T != "+" {
+			out = append(out, ops[i])
+			i++
+			continue
+		}
+		j := i
+		for j < len(ops) && (ops[j].T == "-" || ops[j].T == "+") {
+			j++
+		}
+		for k := i; k < j; k++ {
+			if ops[k].T == "-" {
+				out = append(out, ops[k])
+			}
+		}
+		for k := i; k < j; k++ {
+			if ops[k].T == "+" {
+				out = append(out, ops[k])
+			}
+		}
+		i = j
+	}
+	return out
+}
 // lcsDiff diffs two slices via a standard LCS table with op reconstruction.
 func lcsDiff(a, b []string) []DiffLine {
 	n, m := len(a), len(b)
@@ -134,19 +183,36 @@ func collapseContext(ops []DiffLine) []DiffLine {
 	return out
 }
 
-// ctxRun renders a leading/trailing trimmed run: two context lines plus an
-// ellipsis when longer.
-func ctxRun(lines []string) []DiffLine {
+// prefixRun renders the trimmed common prefix, keeping the lines closest to
+// the change (the last ones) with the ellipsis before them.
+func prefixRun(lines []string) []DiffLine {
+	return edgeRun(lines, false)
+}
+
+// suffixRun renders the trimmed common suffix, keeping the lines closest to
+// the change (the first ones) with the ellipsis after them.
+func suffixRun(lines []string) []DiffLine {
+	return edgeRun(lines, true)
+}
+
+func edgeRun(lines []string, keepFirst bool) []DiffLine {
 	if len(lines) == 0 {
 		return nil
 	}
 	const keep = 2
 	var out []DiffLine
-	for i := 0; i < keep && i < len(lines); i++ {
-		out = append(out, DiffLine{T: " ", S: lines[i]})
-	}
-	if len(lines) > keep {
+	if keepFirst {
+		for i := 0; i < keep && i < len(lines); i++ {
+			out = append(out, DiffLine{T: " ", S: lines[i]})
+		}
 		out = append(out, markRun(len(lines)-keep)...)
+		return out
+	}
+	out = append(out, markRun(len(lines)-keep)...)
+	for i := len(lines) - keep; i < len(lines); i++ {
+		if i >= 0 {
+			out = append(out, DiffLine{T: " ", S: lines[i]})
+		}
 	}
 	return out
 }
@@ -238,6 +304,8 @@ func RenderFileDiff(path, oldContent, newContent string) string {
 			b.WriteString(styleError.Render("- " + line))
 		case "…":
 			b.WriteString(styleDim.Render("  ⋯ " + line))
+		case "\\":
+			b.WriteString(styleDim.Render("  \\ " + line))
 		default:
 			b.WriteString(styleDim.Render("  " + line))
 		}

--- a/internal/tui/diff.go
+++ b/internal/tui/diff.go
@@ -1,0 +1,251 @@
+package tui
+
+import "strings"
+
+// DiffLine is a single line of a file diff. T is "+", "-", or " " (context).
+type DiffLine struct {
+	T string
+	S string
+}
+
+// maxDiffLines caps how many diff lines RenderFileDiff prints so a full-file
+// rewrite cannot flood the transcript.
+const maxDiffLines = 40
+
+// lcsCellCap bounds the LCS table; larger middles degrade to a whole-block
+// replace (all old lines removed, all new lines added), keeping memory flat.
+const lcsCellCap = 4 << 20
+
+// ComputeDiff produces a line-level diff between old and new content.
+// Common prefix/suffix are trimmed first (most edits are local); the middle is
+// matched with an LCS when small enough. Runs of unchanged lines longer than
+// two collapse into an ellipsis marker line ("⋯ N unchanged") emitted as a
+// context DiffLine with T "…".
+func ComputeDiff(oldContent, newContent string) []DiffLine {
+	oldL := splitDiffLines(oldContent)
+	newL := splitDiffLines(newContent)
+
+	// Trim common prefix.
+	p := 0
+	for p < len(oldL) && p < len(newL) && oldL[p] == newL[p] {
+		p++
+	}
+	// Trim common suffix.
+	s := 0
+	for s < len(oldL)-p && s < len(newL)-p && oldL[len(oldL)-1-s] == newL[len(newL)-1-s] {
+		s++
+	}
+	oldMid := oldL[p : len(oldL)-s]
+	newMid := newL[p : len(newL)-s]
+
+	var ops []DiffLine
+	ops = append(ops, ctxRun(oldL[:p])...)
+	if len(oldMid)*len(newMid) > lcsCellCap {
+		ops = append(ops, markRun(len(oldMid))...)
+		for _, l := range oldMid {
+			ops = append(ops, DiffLine{T: "-", S: l})
+		}
+		for _, l := range newMid {
+			ops = append(ops, DiffLine{T: "+", S: l})
+		}
+	} else {
+		ops = append(ops, lcsDiff(oldMid, newMid)...)
+	}
+	ops = append(ops, ctxRun(oldL[len(oldL)-s:])...)
+	return ops
+}
+
+// lcsDiff diffs two slices via a standard LCS table with op reconstruction.
+func lcsDiff(a, b []string) []DiffLine {
+	n, m := len(a), len(b)
+	table := make([][]int, n+1)
+	for i := range table {
+		table[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				table[i][j] = table[i+1][j+1] + 1
+			} else if table[i+1][j] >= table[i][j+1] {
+				table[i][j] = table[i+1][j]
+			} else {
+				table[i][j] = table[i][j+1]
+			}
+		}
+	}
+	var ops []DiffLine
+	i, j := 0, 0
+	for i < n && j < m {
+		switch {
+		case a[i] == b[j]:
+			ops = append(ops, DiffLine{T: " ", S: a[i]})
+			i++
+			j++
+		case table[i+1][j] >= table[i][j+1]:
+			ops = append(ops, DiffLine{T: "-", S: a[i]})
+			i++
+		default:
+			ops = append(ops, DiffLine{T: "+", S: b[j]})
+			j++
+		}
+	}
+	for ; i < n; i++ {
+		ops = append(ops, DiffLine{T: "-", S: a[i]})
+	}
+	for ; j < m; j++ {
+		ops = append(ops, DiffLine{T: "+", S: b[j]})
+	}
+	return collapseContext(ops)
+}
+
+// collapseContext keeps at most two context lines around changes and replaces
+// longer unchanged runs with an ellipsis marker.
+func collapseContext(ops []DiffLine) []DiffLine {
+	const keepCtx = 2
+	keep := make([]bool, len(ops))
+	for idx, op := range ops {
+		if op.T == " " {
+			continue
+		}
+		for k := idx - keepCtx; k <= idx+keepCtx; k++ {
+			if k >= 0 && k < len(ops) {
+				keep[k] = true
+			}
+		}
+	}
+	var out []DiffLine
+	runStart := -1
+	for idx, op := range ops {
+		if op.T == " " && !keep[idx] {
+			if runStart < 0 {
+				runStart = idx
+			}
+			continue
+		}
+		if runStart >= 0 {
+			out = append(out, markRun(idx-runStart)...)
+			runStart = -1
+		}
+		out = append(out, op)
+	}
+	if runStart >= 0 {
+		out = append(out, markRun(len(ops)-runStart)...)
+	}
+	return out
+}
+
+// ctxRun renders a leading/trailing trimmed run: two context lines plus an
+// ellipsis when longer.
+func ctxRun(lines []string) []DiffLine {
+	if len(lines) == 0 {
+		return nil
+	}
+	const keep = 2
+	var out []DiffLine
+	for i := 0; i < keep && i < len(lines); i++ {
+		out = append(out, DiffLine{T: " ", S: lines[i]})
+	}
+	if len(lines) > keep {
+		out = append(out, markRun(len(lines)-keep)...)
+	}
+	return out
+}
+
+func markRun(n int) []DiffLine {
+	if n <= 0 {
+		return nil
+	}
+	return []DiffLine{{T: "…", S: itoa(n) + " unchanged"}}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}
+
+// splitDiffLines splits content into lines, dropping the trailing empty element
+// produced by a final newline so it does not pollute the diff.
+func splitDiffLines(content string) []string {
+	if content == "" {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
+}
+
+// DiffStat returns the added and removed line counts for a diff.
+func DiffStat(ops []DiffLine) (added, removed int) {
+	for _, op := range ops {
+		switch op.T {
+		case "+":
+			added++
+		case "-":
+			removed++
+		}
+	}
+	return added, removed
+}
+
+// RenderFileDiff renders a compact colored diff for the transcript:
+// a header line ("path +A −R") followed by capped +/-/context lines.
+// Returns "" when the contents are identical.
+func RenderFileDiff(path, oldContent, newContent string) string {
+	ops := ComputeDiff(oldContent, newContent)
+	added, removed := DiffStat(ops)
+	if added == 0 && removed == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	if removed == 0 {
+		b.WriteString(styleSuccess.Render("+ " + path))
+	} else {
+		b.WriteString(styleTool.Render("~ " + path))
+	}
+	b.WriteString(" ")
+	b.WriteString(styleSuccess.Render("+" + itoa(added)))
+	b.WriteString(" ")
+	b.WriteString(styleError.Render("-" + itoa(removed)))
+	b.WriteString("\n")
+
+	shown := ops
+	truncated := 0
+	if len(shown) > maxDiffLines {
+		truncated = len(shown) - maxDiffLines
+		shown = shown[:maxDiffLines]
+	}
+	for _, op := range shown {
+		line := op.S
+		if len(line) > 160 {
+			line = line[:160] + "…"
+		}
+		switch op.T {
+		case "+":
+			b.WriteString(styleSuccess.Render("+ " + line))
+		case "-":
+			b.WriteString(styleError.Render("- " + line))
+		case "…":
+			b.WriteString(styleDim.Render("  ⋯ " + line))
+		default:
+			b.WriteString(styleDim.Render("  " + line))
+		}
+		b.WriteString("\n")
+	}
+	if truncated > 0 {
+		b.WriteString(styleDim.Render("  ⋯ " + itoa(truncated) + " more diff lines"))
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/internal/tui/diff_test.go
+++ b/internal/tui/diff_test.go
@@ -1,0 +1,148 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeDiffModify(t *testing.T) {
+	old := "a\nb\nc\nd\ne\n"
+	new := "a\nB\nc\nd\ne\n"
+	ops := ComputeDiff(old, new)
+	added, removed := DiffStat(ops)
+	if added != 1 || removed != 1 {
+		t.Fatalf("stat = +%d −%d, want +1 −1; ops=%v", added, removed, ops)
+	}
+	var plus, minus string
+	for _, op := range ops {
+		if op.T == "+" {
+			plus = op.S
+		}
+		if op.T == "-" {
+			minus = op.S
+		}
+	}
+	if plus != "B" || minus != "b" {
+		t.Fatalf("changed lines = +%q −%q, want +B −b", plus, minus)
+	}
+}
+
+func TestComputeDiffNewFile(t *testing.T) {
+	ops := ComputeDiff("", "x\ny\n")
+	added, removed := DiffStat(ops)
+	if added != 2 || removed != 0 {
+		t.Fatalf("stat = +%d −%d, want +2 −0", added, removed)
+	}
+}
+
+func TestComputeDiffDeleteFile(t *testing.T) {
+	ops := ComputeDiff("x\ny\n", "")
+	added, removed := DiffStat(ops)
+	if added != 0 || removed != 2 {
+		t.Fatalf("stat = +%d −%d, want +0 −2", added, removed)
+	}
+}
+
+func TestComputeDiffIdentical(t *testing.T) {
+	ops := ComputeDiff("same\nsame\n", "same\nsame\n")
+	if out := RenderFileDiff("f", "same\nsame\n", "same\nsame\n"); out != "" {
+		t.Fatalf("identical content rendered %q, want empty", out)
+	}
+	if len(ops) == 0 {
+		t.Fatal("ops should include context/ellipsis lines, not panic")
+	}
+}
+
+func TestComputeDiffCollapsesLongContext(t *testing.T) {
+	var oldB, newB strings.Builder
+	for i := 0; i < 50; i++ {
+		oldB.WriteString("line\n")
+	}
+	newB.WriteString(oldB.String())
+	newB.WriteString("tail\n")
+	ops := ComputeDiff(oldB.String(), newB.String())
+	added, _ := DiffStat(ops)
+	if added != 1 {
+		t.Fatalf("added = %d, want 1", added)
+	}
+	sawEllipsis := false
+	for _, op := range ops {
+		if op.T == "…" {
+			sawEllipsis = true
+		}
+		if op.T == " " && op.S == "line" && !sawEllipsis {
+			// context before the ellipsis is fine; the point is the run collapses
+		}
+	}
+	if !sawEllipsis {
+		t.Fatalf("expected an ellipsis marker for the 50-line unchanged run, got %v", ops)
+	}
+}
+
+func TestComputeDiffLargeMiddleDegrades(t *testing.T) {
+	// 3k distinct lines on each side exceeds lcsCellCap → whole-block replace.
+	var oldB, newB strings.Builder
+	for i := 0; i < 3000; i++ {
+		oldB.WriteString("o")
+		oldB.WriteString(strings.Repeat("x", i%7))
+		oldB.WriteString("\n")
+		newB.WriteString("n")
+		newB.WriteString(strings.Repeat("y", i%7))
+		newB.WriteString("\n")
+	}
+	ops := ComputeDiff(oldB.String(), newB.String())
+	added, removed := DiffStat(ops)
+	if added != 3000 || removed != 3000 {
+		t.Fatalf("degraded stat = +%d −%d, want +3000 −3000", added, removed)
+	}
+}
+
+func TestRenderFileDiffNewFileHeader(t *testing.T) {
+	out := RenderFileDiff("new.go", "", "package main\nfunc f() {}\n")
+	if !strings.Contains(out, "new.go") || !strings.Contains(out, "+2") {
+		t.Fatalf("header missing path/added stat: %q", out)
+	}
+	if !strings.Contains(out, "+ package main") {
+		t.Fatalf("missing added line: %q", out)
+	}
+}
+
+func TestRenderFileDiffCapsOutput(t *testing.T) {
+	var oldB, newB strings.Builder
+	for i := 0; i < 500; i++ {
+		oldB.WriteString("old\n")
+		newB.WriteString("new\n")
+	}
+	out := RenderFileDiff("big.txt", oldB.String(), newB.String())
+	lines := strings.Count(out, "\n")
+	if lines > maxDiffLines+3 { // header + cap marker tolerance
+		t.Fatalf("rendered %d lines, want ≤ %d", lines, maxDiffLines+3)
+	}
+	if !strings.Contains(out, "more diff lines") {
+		t.Fatalf("missing truncation marker: %q", tail(out, 80))
+	}
+}
+
+func TestRenderFileDiffModifyHeader(t *testing.T) {
+	out := RenderFileDiff("main.go", "a\n", "b\n")
+	if !strings.Contains(out, "~ main.go") {
+		t.Fatalf("modify header missing: %q", head(out, 40))
+	}
+	if !strings.Contains(out, "+1") || !strings.Contains(out, "-1") {
+		t.Fatalf("stats missing: %q", head(out, 40))
+	}
+}
+
+func head(s string, n int) string { return s[:min(n, len(s))] }
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/tui/diff_test.go
+++ b/internal/tui/diff_test.go
@@ -143,3 +143,67 @@ func min(a, b int) int {
 	}
 	return b
 }
+
+func TestComputeDiffTrailingNewlineOnly(t *testing.T) {
+	out := RenderFileDiff("f.go", "a\nb\n", "a\nb")
+	if out == "" {
+		t.Fatal("trailing-newline-only change must render, got empty")
+	}
+	if !strings.Contains(out, "trailing newline removed") {
+		t.Fatalf("missing newline marker: %q", out)
+	}
+	ops := ComputeDiff("a\n", "a")
+	added, removed := DiffStat(ops)
+	if added != 1 || removed != 1 {
+		t.Fatalf("newline-only stat = +%d −%d, want +1 −1", added, removed)
+	}
+}
+
+func TestComputeDiffOrdersRemovesBeforeAdds(t *testing.T) {
+	// Interleavable middle; every contiguous change run must list − lines
+	// before + lines.
+	ops := ComputeDiff("a\nx\nb\nx\nc\n", "a\ny\nb\ny\nc\n")
+	runPlusFirst := false
+	sawPlus := false
+	for _, op := range ops {
+		switch op.T {
+		case "-":
+			if sawPlus {
+				runPlusFirst = true
+			}
+		case "+":
+			sawPlus = true
+		case " ", "…":
+			sawPlus = false
+		}
+	}
+	if runPlusFirst {
+		t.Fatalf("change run has + before −: %v", ops)
+	}
+}
+
+func TestComputeDiffContextAdjacentToChange(t *testing.T) {
+	// Change at the end: shown context must be the lines immediately above.
+	ops := ComputeDiff("l1\nl2\nl3\nl4\nend\n", "l1\nl2\nl3\nl4\nEND\n")
+	var ctx []string
+	for _, op := range ops {
+		if op.T == " " {
+			ctx = append(ctx, op.S)
+		}
+	}
+	if len(ctx) == 0 || ctx[len(ctx)-1] != "l4" {
+		t.Fatalf("context nearest the change should be l4, got %v", ctx)
+	}
+	// Change at the start: context nearest the change should be l2 (the line
+	// right after).
+	ops = ComputeDiff("start\nl1\nl2\nl3\nl4\n", "START\nl1\nl2\nl3\nl4\n")
+	ctx = nil
+	for _, op := range ops {
+		if op.T == " " {
+			ctx = append(ctx, op.S)
+		}
+	}
+	if len(ctx) == 0 || ctx[0] != "l1" {
+		t.Fatalf("context nearest the change should be l1, got %v", ctx)
+	}
+}

--- a/internal/tui/diff_test.go
+++ b/internal/tui/diff_test.go
@@ -70,9 +70,6 @@ func TestComputeDiffCollapsesLongContext(t *testing.T) {
 		if op.T == "…" {
 			sawEllipsis = true
 		}
-		if op.T == " " && op.S == "line" && !sawEllipsis {
-			// context before the ellipsis is fine; the point is the run collapses
-		}
 	}
 	if !sawEllipsis {
 		t.Fatalf("expected an ellipsis marker for the 50-line unchanged run, got %v", ops)

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -536,6 +536,22 @@ func (t *Terminal) PrintToolIcon(name string) {
 	t.emit(fmt.Sprintf("  %s %s", icon, styleTool.Render(displayName)))
 }
 
+// PrintFileDiff shows a live code change under the current tool line.
+// Renders nothing when the content is unchanged.
+func (t *Terminal) PrintFileDiff(path, oldContent, newContent string) {
+	out := RenderFileDiff(path, oldContent, newContent)
+	if out == "" {
+		return
+	}
+	t.StopThinking() // erase spinner before diff display
+	if t.streaming {
+		t.streaming = false
+		t.emit("\n")
+	}
+	t.toolStreak = false // diff block is its own visual group
+	t.emit(out)
+}
+
 // PrintToolStart shows a tool invocation with its input summary.
 func (t *Terminal) PrintToolStart(name string, input interface{}) {
 	summary := formatToolInput(input)


### PR DESCRIPTION
## What

Code changes now render **live in the TUI, consistently across all backends**. Previously `edit_file`/`write_file` printed only a one-line tool icon + input summary — no diff, no stats:

```
  ✏ edit file path=src/main.go
  ✓ {"success": true, ...}
```

Now every file-editing tool call renders a compact colored diff the moment the edit lands:

```
  ✏ edit file path=src/main.go
  ~ cmd/demo/main.go +4 -1
    package main

  + import "fmt"
  +
    func main() {
  -     fmt.Println("hi")
  +     fmt.Println("hello")
  +     fmt.Println("world")
    }
  ✓ {"success": true, ...}
```

New files render `+ path +N -0`; no-op/rejected edits render nothing.

## How — one mechanism, three wiring points

The diff is **display-only** (tool results sent back to the model are untouched → token cost per edit unchanged). Each backend snapshots the target file *before* the edit and diffs *after*, keyed so results can't cross:

| Backend | Snapshot | Render |
|---|---|---|
| Built-in (`agent.go`) | before `executeTool` in `executeToolCallsWithUI` | after execution, before the result line |
| Claude Code (`cc_agent.go`) | at `tool_use`, keyed by block ID | at matching `tool_result` (`ToolUseID`) |
| OpenCode (`opencode_agent.go`) | when a tool part first appears (`ocPart` gains `state`/`input` fields) | when the part reaches `completed`/`error` |

Tool-name matching is tolerant across namespaces (`edit_file`, CC `Edit`/`Write`/`NotebookEdit`, OpenCode `edit`/`write`, MCP-prefixed `qmax__edit_file`) and path extraction handles `path` / `file_path` / `filePath` / `notebook_path` / nested `files` maps.

## Diff engine (`internal/tui/diff.go`)

- Common prefix/suffix trim → LCS on the middle (most edits are local, so this is tiny)
- Oversized middles (>4M LCS cells) degrade to a whole-block replace — flat memory, no pathological slowdowns
- Context collapsed to 2 lines around changes; longer unchanged runs become `⋯ N unchanged`
- Render capped at 40 diff lines with an explicit truncation marker; lines truncated at 160 chars

## Validation

- `go build ./...` — clean; `go vet` clean
- `go test ./internal/tui/ ./internal/agent/` — all pass, including 8 new diff-engine tests (modify/new/delete/identical/collapse/degrade/cap/header) and 4 snapshot-helper tests
- Render demo run through `RenderFileDiff` directly (output above)

## Changes at a glance (9 files, +698 −7)

| Area | Files | Purpose |
|---|---|---|
| **Diff engine** | `tui/diff.go` +141 (new), `tui/terminal.go` +15 | LCS diff, capped colored render, `PrintFileDiff` |
| **Snapshot helpers** | `agent/filediff.go` +136 (new) | edit-tool detection, path extraction, snapshot/diff |
| **Backend wiring** | `agent.go` +4, `cc_agent.go` +14, `opencode_agent.go` +22 | snapshot-before / diff-after per backend |
| **Tests** | `tui/diff_test.go` +137 (new), `agent/filediff_test.go` +87 (new) | engine + helpers |
| **Docs** | `CHANGELOG.md` +9 | Unreleased entry |

```mermaid
flowchart LR
    subgraph backends["tool events (any backend)"]
        B1["built-in<br/>executeToolCallsWithUI"]
        B2["Claude Code<br/>tool_use → tool_result"]
        B3["OpenCode<br/>part state → completed"]
    end
    B1 & B2 & B3 --> S["filediff.go<br/>snapshot path pre-edit"]
    S --> T["terminal.PrintFileDiff"]
    T --> D["diff.go<br/>prefix/suffix trim → LCS<br/>cap 40 lines, ⋯ context"]
    D --> OUT["~ path +N −M<br/>colored ± lines"]
    S -.->|display-only| M["model context unchanged"]
```
