### PR TITLE
release: v1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.24.0] - 2026-08-21
+
 ### Added
 - Live code-change diffs in the TUI while the agent works. Every file-editing
   tool call — built-in `edit_file`/`write_file`, Claude Code's `Edit`/`Write`,

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.23.0"
+var Version = "1.24.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Version bump to 1.24.0 + changelog promotion.

## What's in v1.24.0
- **Live TUI file diffs** (#165, merged `e207259`): every file-editing tool call renders a compact colored diff (`path +N −M`, capped, context-hugging) as the edit lands — consistently across built-in, Claude Code, and OpenCode backends. Display-only; model-facing tool results unchanged.

## Release checklist (post-merge)
- [ ] Tag `v1.24.0` on the merge commit → release workflow builds 6 platforms, runs full tests, creates the GitHub release, publishes archives to Quality-Max/qmax-code-releases
- [ ] Verify release assets + public repo publish