### PR TITLE
release: v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.25.0] - 2026-08-21
+
 ### Added
 - Self-update with a startup proposal. When a newer release exists in the
   public releases repo, qmax-code offers to install it at startup

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.24.0"
+var Version = "1.25.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Version bump to 1.25.0 + changelog promotion.

## What's in v1.25.0
- **Self-update proposal** (#167, merged `284aaaf`): startup offer to install newer releases (`Update now? [y/N]`), atomic binary swap, `/update` command, 24h check cache, skip memory, `QMAX_NO_UPDATE_CHECK=1` opt-out.

First release that can update to its successor — 1.24.0 installs get their first prompt once this is published.

## Release checklist (post-merge)
- [ ] Tag `v1.25.0` → workflow builds 6 platforms, creates release, publishes to qmax-code-releases
- [ ] Verify assets on both repos
- [ ] Verify `Check("1.24.0")` finds 1.25.0