### PR TITLE
feat(setup): standalone escape hatch + arrow-key onboarding chooser

### DIFF
--- a/internal/setup/interactive.go
+++ b/internal/setup/interactive.go
@@ -30,6 +30,10 @@ var (
 
 	// ErrEmptyAPIKey is returned when the API key prompt ends with no input.
 	ErrEmptyAPIKey = errors.New("no API key provided")
+
+	// promptAPIKey is kept as a seam for the recovery-flow tests. Production
+	// always uses ReadSecret, so API keys remain read without echoing them.
+	promptAPIKey = ReadSecret
 )
 
 // LoginInteractive prompts the user to paste their API key.
@@ -412,7 +416,7 @@ func useStandaloneMode() error {
 
 // loginWithKeyPrompt asks the user to paste their API key.
 func loginWithKeyPrompt() (*api.AuthConfig, error) {
-	key := ReadSecret("  Paste your API key (qm-...): ")
+	key := promptAPIKey("  Paste your API key (qm-...): ")
 
 	if key == "" {
 		return nil, ErrEmptyAPIKey

--- a/internal/setup/interactive.go
+++ b/internal/setup/interactive.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -21,6 +22,16 @@ import (
 	"github.com/qualitymax/qmax-code/internal/tui"
 )
 
+var (
+	// ErrStandaloneSkip signals the user chose standalone local mode during
+	// onboarding instead of connecting a QualityMax account. Callers should
+	// switch to standalone mode rather than treating this as a failure.
+	ErrStandaloneSkip = errors.New("standalone local mode selected")
+
+	// ErrEmptyAPIKey is returned when the API key prompt ends with no input.
+	ErrEmptyAPIKey = errors.New("no API key provided")
+)
+
 // LoginInteractive prompts the user to paste their API key.
 func LoginInteractive() (*api.AuthConfig, error) {
 	fmt.Println()
@@ -30,7 +41,7 @@ func LoginInteractive() (*api.AuthConfig, error) {
 	key := ReadSecret("  Paste your API key (qm-...): ")
 
 	if key == "" {
-		return nil, fmt.Errorf("no API key provided")
+		return nil, ErrEmptyAPIKey
 	}
 
 	return api.LoginWithAPIKey(key)
@@ -232,11 +243,14 @@ func RunInteractive() (*api.AuthConfig, int, error) {
 	fmt.Println("  Let's get you set up — it takes 30 seconds.")
 	fmt.Println()
 
-	// Step 1: Account check
+	// Step 1: Account check. The standalone option is the escape hatch for
+	// users without a QualityMax account — without it, an empty key at the
+	// paste prompt used to kill the whole setup (QUA: onboarding dead-end).
 	choice := PromptChoice("  Do you have a QualityMax account?", []string{
 		"Yes, log me in (opens browser)",
 		"No, create one (free)",
 		"I have an API key already",
+		"Skip — use standalone local mode (no account needed)",
 	})
 
 	var auth *api.AuthConfig
@@ -256,12 +270,39 @@ func RunInteractive() (*api.AuthConfig, int, error) {
 		auth, err = LoginViaBrowser()
 	case 2: // I have an API key
 		auth, err = loginWithKeyPrompt()
+		if errors.Is(err, ErrEmptyAPIKey) {
+			// Empty paste is usually "I don't actually have a key" — offer
+			// the standalone exit instead of failing the whole setup.
+			retry := PromptChoice("  No key entered. What now?", []string{
+				"Try again — paste a key",
+				"Skip — use standalone local mode",
+			})
+			if retry == 0 {
+				auth, err = loginWithKeyPrompt()
+			} else {
+				err = useStandaloneMode()
+			}
+		}
+	case 3: // Skip — standalone local mode
+		err = useStandaloneMode()
+	}
+
+	if errors.Is(err, ErrStandaloneSkip) {
+		tui.AnimateMax(tui.MoodHappy, "Standalone mode it is!")
+		fmt.Println()
+		fmt.Println("  No account needed. Only local workspace tools are enabled;")
+		fmt.Println("  cloud features (crawls, test runs, reviews) stay off.")
+		fmt.Println()
+		fmt.Println("  Connect later anytime with: qmax-code login")
+		fmt.Println("  (after: qmax-code config set local_only false)")
+		return nil, 0, ErrStandaloneSkip
 	}
 
 	if err != nil {
 		tui.AnimateMax(tui.MoodSad, "Login failed: "+err.Error())
 		fmt.Println()
 		fmt.Println("  Try again with: qmax-code login")
+		fmt.Println("  Or skip the account: qmax-code --local")
 		return nil, 0, fmt.Errorf("interactive login: %w", err)
 	}
 
@@ -347,12 +388,23 @@ func RunInteractive() (*api.AuthConfig, int, error) {
 	return auth, projectID, nil
 }
 
+// useStandaloneMode persists local_only=true so the choice survives restarts,
+// and returns ErrStandaloneSkip so the caller can switch modes cleanly.
+func useStandaloneMode() error {
+	cfg := api.LoadQMaxCodeConfig()
+	if !cfg.LocalOnly {
+		cfg.LocalOnly = true
+		_ = cfg.Save()
+	}
+	return ErrStandaloneSkip
+}
+
 // loginWithKeyPrompt asks the user to paste their API key.
 func loginWithKeyPrompt() (*api.AuthConfig, error) {
 	key := ReadSecret("  Paste your API key (qm-...): ")
 
 	if key == "" {
-		return nil, fmt.Errorf("no API key provided")
+		return nil, ErrEmptyAPIKey
 	}
 
 	fmt.Println()
@@ -499,32 +551,136 @@ func maskKey(key string) string {
 // --- UI helpers ---
 
 // PromptChoice shows an interactive menu and returns the selected index.
+// On a TTY it renders an arrow-key chooser (↑/↓ or j/k to move, Enter to
+// confirm, digits 1-9 to select directly). When raw mode is unavailable
+// (piped stdin, CI), it falls back to the numeric prompt.
 func PromptChoice(prompt string, options []string) int {
 	fmt.Println(prompt)
-	for i, opt := range options {
-		if i == 0 {
-			fmt.Printf("    \033[36m› %s\033[0m\n", opt) // highlight first
+
+	oldState, rawErr := tui.EnableRawMode()
+	if rawErr != nil {
+		// Not a TTY (or raw mode unsupported): numeric fallback.
+		return promptChoiceNumeric(options)
+	}
+	defer tui.RestoreTermMode(oldState)
+
+	printMenu := func(sel int, typed string) {
+		for i, opt := range options {
+			if i == sel {
+				fmt.Printf("    \033[36m› %s\033[0m\n", opt)
+			} else {
+				fmt.Printf("      %s\n", opt)
+			}
+		}
+		if typed != "" {
+			fmt.Printf("  \033[2mGo to %s + Enter, or ↑/↓ then Enter\033[0m\n", typed)
 		} else {
-			fmt.Printf("      %s\n", opt)
+			fmt.Println("  \033[2m↑/↓ to move · Enter to select · 1-9 jumps\033[0m")
 		}
 	}
-	fmt.Println()
 
-	// Simple input: type number or press enter for first option
+	redraw := func(sel int, typed string) {
+		for i := 0; i < len(options)+1; i++ {
+			fmt.Print("\033[A\033[2K") // up one line, clear it
+		}
+		printMenu(sel, typed)
+	}
+
+	sel := 0
+	typed := ""
+	printMenu(sel, typed)
+
+	buf := make([]byte, 1)
+	for {
+		n, _ := os.Stdin.Read(buf)
+		if n == 0 {
+			tui.RestoreTermMode(oldState)
+			return promptChoiceNumeric(options)
+		}
+		switch buf[0] {
+		case '\r', '\n':
+			tui.RestoreTermMode(oldState)
+			fmt.Println()
+			if typed != "" {
+				if idx := parseChoiceLine(typed, len(options)); idx >= 0 {
+					sel = idx
+				}
+			}
+			fmt.Printf("  Selected: %s\n", options[sel])
+			return sel
+		case 3: // Ctrl+C — cancel with the default (first) option
+			tui.RestoreTermMode(oldState)
+			fmt.Println()
+			return 0
+		case 27: // ESC — expect '[' then A/B
+			b2 := make([]byte, 1)
+			if n2, _ := os.Stdin.Read(b2); n2 == 1 && b2[0] == '[' {
+				b3 := make([]byte, 1)
+				if n3, _ := os.Stdin.Read(b3); n3 == 1 {
+					switch b3[0] {
+					case 'A': // up
+						if sel > 0 {
+							sel--
+							typed = ""
+							redraw(sel, typed)
+						}
+					case 'B': // down
+						if sel < len(options)-1 {
+							sel++
+							typed = ""
+							redraw(sel, typed)
+						}
+					}
+				}
+			}
+		case 'k':
+			if sel > 0 {
+				sel--
+				typed = ""
+				redraw(sel, typed)
+			}
+		case 'j':
+			if sel < len(options)-1 {
+				sel++
+				typed = ""
+				redraw(sel, typed)
+			}
+		default:
+			if buf[0] >= '1' && buf[0] <= '9' {
+				candidate := typed + string(buf[0])
+				if idx := parseChoiceLine(candidate, len(options)); idx >= 0 {
+					sel = idx
+					typed = candidate
+					redraw(sel, typed)
+				}
+			}
+		}
+	}
+}
+
+// promptChoiceNumeric prints the classic "Choice (1-N, default 1)" prompt.
+func promptChoiceNumeric(options []string) int {
 	fmt.Print("  Choice (1-" + strconv.Itoa(len(options)) + ", default 1): ")
 	reader := bufio.NewReader(os.Stdin)
 	line, _ := reader.ReadString('\n')
+	if idx := parseChoiceLine(strings.TrimSpace(line), len(options)); idx >= 0 {
+		return idx
+	}
+	return 0
+}
+
+// parseChoiceLine converts a typed choice like "3" into a zero-based index.
+// Returns -1 for empty or out-of-range input.
+func parseChoiceLine(line string, n int) int {
 	line = strings.TrimSpace(line)
-
 	if line == "" {
-		return 0
+		return -1
 	}
-
-	n, err := strconv.Atoi(line)
-	if err != nil || n < 1 || n > len(options) {
-		return 0
+	v, err := strconv.Atoi(line)
+	if err != nil || v < 1 || v > n {
+		return -1
 	}
-	return n - 1
+	return v - 1
 }
 
 // waitForEnter waits for the user to press Enter.

--- a/internal/setup/interactive.go
+++ b/internal/setup/interactive.go
@@ -597,91 +597,129 @@ func PromptChoice(prompt string, options []string) int {
 		printMenu(sel, typed)
 	}
 
-	sel := 0
-	typed := ""
-	printMenu(sel, typed)
-
-	// chooserAllowedBytes is the closed set of input bytes the chooser acts
-	// on. Anything else — including bytes of ANSI sequences we never emit
-	// ourselves (screen clears, buffer switches) — is dropped unread, so
-	// injected terminal-control bytes cannot pass through this loop.
-	chooserAllowedBytes := map[byte]bool{
-		'\r': true, '\n': true, // confirm
-		3:   true, // Ctrl+C cancel
-		27:  true, // ESC (arrow sequence introducer; payload checked below)
-		'j': true, 'k': true,
-		'1': true, '2': true, '3': true, '4': true, '5': true,
-		'6': true, '7': true, '8': true, '9': true,
+	printMenu(0, "")
+	selection, confirmed := chooseFromRawInput(bufio.NewReader(os.Stdin), len(options), redraw)
+	if !confirmed {
+		tui.RestoreTermMode(oldState)
+		return promptChoiceNumeric(options)
 	}
 
-	buf := make([]byte, 1)
+	tui.RestoreTermMode(oldState)
+	fmt.Println()
+	fmt.Printf("  Selected: %s\n", options[selection])
+	return selection
+}
+
+type chooserEvent uint8
+
+const (
+	chooserNoop chooserEvent = iota
+	chooserConfirm
+	chooserCancel
+	chooserUp
+	chooserDown
+	chooserDigit
+)
+
+// chooseFromRawInput owns the raw chooser state. Keeping the byte parser
+// separate from terminal setup makes its navigation behavior deterministic to
+// test, while PromptChoice remains responsible for rendering and raw mode.
+func chooseFromRawInput(reader *bufio.Reader, optionCount int, redraw func(int, string)) (int, bool) {
+	sel, typed := 0, ""
 	for {
-		n, _ := os.Stdin.Read(buf)
-		if n == 0 {
-			tui.RestoreTermMode(oldState)
-			return promptChoiceNumeric(options)
+		event, digit, ok := readChooserEvent(reader)
+		if !ok {
+			return 0, false
 		}
-		if !chooserAllowedBytes[buf[0]] {
-			continue // not a byte we interpret — ignore it
-		}
-		switch buf[0] {
-		case '\r', '\n':
-			tui.RestoreTermMode(oldState)
-			fmt.Println()
-			if typed != "" {
-				if idx := parseChoiceLine(typed, len(options)); idx >= 0 {
-					sel = idx
-				}
-			}
-			fmt.Printf("  Selected: %s\n", options[sel])
-			return sel
-		case 3: // Ctrl+C — cancel with the default (first) option
-			tui.RestoreTermMode(oldState)
-			fmt.Println()
-			return 0
-		case 27: // ESC — expect '[' then A/B
-			b2 := make([]byte, 1)
-			if n2, _ := os.Stdin.Read(b2); n2 == 1 && b2[0] == '[' {
-				b3 := make([]byte, 1)
-				if n3, _ := os.Stdin.Read(b3); n3 == 1 {
-					switch b3[0] {
-					case 'A': // up
-						if sel > 0 {
-							sel--
-							typed = ""
-							redraw(sel, typed)
-						}
-					case 'B': // down
-						if sel < len(options)-1 {
-							sel++
-							typed = ""
-							redraw(sel, typed)
-						}
-					}
-				}
-			}
-		case 'k':
+
+		switch event {
+		case chooserConfirm:
+			return sel, true
+		case chooserCancel:
+			return 0, true
+		case chooserUp:
 			if sel > 0 {
 				sel--
 				typed = ""
 				redraw(sel, typed)
 			}
-		case 'j':
-			if sel < len(options)-1 {
+		case chooserDown:
+			if sel < optionCount-1 {
 				sel++
 				typed = ""
 				redraw(sel, typed)
 			}
-		default:
-			if buf[0] >= '1' && buf[0] <= '9' {
-				candidate := typed + string(buf[0])
-				if idx := parseChoiceLine(candidate, len(options)); idx >= 0 {
-					sel = idx
-					typed = candidate
-					redraw(sel, typed)
-				}
+		case chooserDigit:
+			candidate := typed + string(digit)
+			if idx := parseChoiceLine(candidate, optionCount); idx >= 0 {
+				sel = idx
+				typed = candidate
+				redraw(sel, typed)
 			}
 		}
+	}
+}
+
+// readChooserEvent accepts only the keys the chooser supports. Escape input
+// must be exactly CSI A/B; malformed CSI sequences are consumed as input, not
+// echoed or executed. A non-CSI byte after Escape is unread so it is handled
+// normally on the following iteration.
+func readChooserEvent(reader *bufio.Reader) (chooserEvent, byte, bool) {
+	b, err := reader.ReadByte()
+	if err != nil {
+		return chooserNoop, 0, false
+	}
+
+	switch b {
+	case '\r', '\n':
+		return chooserConfirm, 0, true
+	case 3:
+		return chooserCancel, 0, true
+	case 'j':
+		return chooserDown, 0, true
+	case 'k':
+		return chooserUp, 0, true
+	case '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return chooserDigit, b, true
+	case 27:
+		return readEscapeEvent(reader)
+	default:
+		return chooserNoop, 0, true
+	}
+}
+
+func readEscapeEvent(reader *bufio.Reader) (chooserEvent, byte, bool) {
+	second, err := reader.ReadByte()
+	if err != nil {
+		return chooserNoop, 0, true
+	}
+	if second != '[' {
+		// Escape itself is a no-op, but the next ordinary key still belongs to
+		// the user. Put it back so the normal allowlist handles it.
+		_ = reader.UnreadByte()
+		return chooserNoop, 0, true
+	}
+
+	third, err := reader.ReadByte()
+	if err != nil {
+		return chooserNoop, 0, true
+	}
+	switch third {
+	case 'A':
+		return chooserUp, 0, true
+	case 'B':
+		return chooserDown, 0, true
+	default:
+		// A CSI sequence has no meaning to this chooser unless it is A/B.
+		// Consume it through its final byte so no part can be reinterpreted as
+		// menu input (for example, ESC [ ? 1 B).
+		for third < 0x40 || third > 0x7e {
+			third, err = reader.ReadByte()
+			if err != nil {
+				break
+			}
+		}
+		return chooserNoop, 0, true
 	}
 }
 

--- a/internal/setup/interactive.go
+++ b/internal/setup/interactive.go
@@ -394,7 +394,13 @@ func useStandaloneMode() error {
 	cfg := api.LoadQMaxCodeConfig()
 	if !cfg.LocalOnly {
 		cfg.LocalOnly = true
-		_ = cfg.Save()
+		if err := cfg.Save(); err != nil {
+			// Don't fail the flow: this run still switches to standalone in
+			// memory. But a silent no-persist would confusingly re-run
+			// onboarding on the next launch, so say so.
+			fmt.Printf("  Note: could not save standalone preference (%s).\n", err)
+			fmt.Println("  This session is standalone; next launch may ask again.")
+		}
 	}
 	return ErrStandaloneSkip
 }
@@ -659,7 +665,18 @@ func PromptChoice(prompt string, options []string) int {
 }
 
 // promptChoiceNumeric prints the classic "Choice (1-N, default 1)" prompt.
+// It reproduces the pre-chooser output contract (full option list, then the
+// prompt) so non-TTY consumers — CI, expect scripts, AI-generated harnesses
+// — keep parsing stdout the same way.
 func promptChoiceNumeric(options []string) int {
+	for i, opt := range options {
+		if i == 0 {
+			fmt.Printf("    \033[36m› %s\033[0m\n", opt) // highlight first
+		} else {
+			fmt.Printf("      %s\n", opt)
+		}
+	}
+	fmt.Println()
 	fmt.Print("  Choice (1-" + strconv.Itoa(len(options)) + ", default 1): ")
 	reader := bufio.NewReader(os.Stdin)
 	line, _ := reader.ReadString('\n')

--- a/internal/setup/interactive.go
+++ b/internal/setup/interactive.go
@@ -271,17 +271,7 @@ func RunInteractive() (*api.AuthConfig, int, error) {
 	case 2: // I have an API key
 		auth, err = loginWithKeyPrompt()
 		if errors.Is(err, ErrEmptyAPIKey) {
-			// Empty paste is usually "I don't actually have a key" — offer
-			// the standalone exit instead of failing the whole setup.
-			retry := PromptChoice("  No key entered. What now?", []string{
-				"Try again — paste a key",
-				"Skip — use standalone local mode",
-			})
-			if retry == 0 {
-				auth, err = loginWithKeyPrompt()
-			} else {
-				err = useStandaloneMode()
-			}
+			auth, err = recoverFromEmptyKey()
 		}
 	case 3: // Skip — standalone local mode
 		err = useStandaloneMode()
@@ -386,6 +376,21 @@ func RunInteractive() (*api.AuthConfig, int, error) {
 	fmt.Println()
 
 	return auth, projectID, nil
+}
+
+// recoverFromEmptyKey handles an empty API-key paste: usually "I don't
+// actually have a key" — offer the standalone exit instead of failing the
+// whole setup. Returns the retry result, or ErrStandaloneSkip when the
+// user picks standalone.
+func recoverFromEmptyKey() (*api.AuthConfig, error) {
+	retry := PromptChoice("  No key entered. What now?", []string{
+		"Try again — paste a key",
+		"Skip — use standalone local mode",
+	})
+	if retry == 0 {
+		return loginWithKeyPrompt()
+	}
+	return nil, useStandaloneMode()
 }
 
 // useStandaloneMode persists local_only=true so the choice survives restarts,
@@ -596,12 +601,28 @@ func PromptChoice(prompt string, options []string) int {
 	typed := ""
 	printMenu(sel, typed)
 
+	// chooserAllowedBytes is the closed set of input bytes the chooser acts
+	// on. Anything else — including bytes of ANSI sequences we never emit
+	// ourselves (screen clears, buffer switches) — is dropped unread, so
+	// injected terminal-control bytes cannot pass through this loop.
+	chooserAllowedBytes := map[byte]bool{
+		'\r': true, '\n': true, // confirm
+		3:   true, // Ctrl+C cancel
+		27:  true, // ESC (arrow sequence introducer; payload checked below)
+		'j': true, 'k': true,
+		'1': true, '2': true, '3': true, '4': true, '5': true,
+		'6': true, '7': true, '8': true, '9': true,
+	}
+
 	buf := make([]byte, 1)
 	for {
 		n, _ := os.Stdin.Read(buf)
 		if n == 0 {
 			tui.RestoreTermMode(oldState)
 			return promptChoiceNumeric(options)
+		}
+		if !chooserAllowedBytes[buf[0]] {
+			continue // not a byte we interpret — ignore it
 		}
 		switch buf[0] {
 		case '\r', '\n':

--- a/internal/setup/interactive_test.go
+++ b/internal/setup/interactive_test.go
@@ -258,3 +258,62 @@ func TestLoginWithKeyPromptEmptyInputReturnsSentinel(t *testing.T) {
 		t.Fatalf("loginWithKeyPrompt() error = %v, want ErrEmptyAPIKey", err)
 	}
 }
+
+func TestRecoverFromEmptyKeyStandaloneBranch(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	defer os.Setenv("HOME", origHome)
+
+	// Piped stdin → PromptChoice takes the numeric fallback; "2" selects
+	// "Skip — use standalone local mode".
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("2\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	_, err = recoverFromEmptyKey()
+	if !errors.Is(err, ErrStandaloneSkip) {
+		t.Fatalf("recoverFromEmptyKey() error = %v, want ErrStandaloneSkip", err)
+	}
+	if cfg := api.LoadQMaxCodeConfig(); !cfg.LocalOnly {
+		t.Fatal("standalone branch did not persist local_only")
+	}
+}
+
+func TestRecoverFromEmptyKeyRetryBranchAsksForKeyAgain(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	defer os.Setenv("HOME", origHome)
+
+	// "1" selects "Try again — paste a key"; the retry prompt then hits EOF
+	// (numeric reader buffers the whole pipe) and must surface the sentinel
+	// again rather than a generic failure.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("1\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	_, err = recoverFromEmptyKey()
+	if !errors.Is(err, ErrEmptyAPIKey) {
+		t.Fatalf("recoverFromEmptyKey() error = %v, want ErrEmptyAPIKey from retry prompt", err)
+	}
+	if cfg := api.LoadQMaxCodeConfig(); cfg.LocalOnly {
+		t.Fatal("retry branch must not persist standalone mode")
+	}
+}

--- a/internal/setup/interactive_test.go
+++ b/internal/setup/interactive_test.go
@@ -359,3 +359,49 @@ func TestRecoverFromEmptyKeyRetryBranchAsksForKeyAgain(t *testing.T) {
 		t.Fatal("retry branch must not persist standalone mode")
 	}
 }
+
+func TestRecoverFromEmptyKeyRetryBranchAcceptsValidKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/me" {
+			t.Errorf("path = %q, want /api/me", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer retry-success" {
+			t.Errorf("Authorization = %q, want stripped retry key", got)
+		}
+		_, _ = w.Write([]byte(`{"email":"retry@example.test","id":"retry-user"}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("QUALITYMAX_URL", server.URL)
+
+	// The recovery menu reads "1" from piped stdin. Stub the secret prompt so
+	// this test can deterministically model the key entered after that choice.
+	originalPrompt := promptAPIKey
+	promptAPIKey = func(string) string { return "qm-retry-success" }
+	defer func() { promptAPIKey = originalPrompt }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("1\n"); err != nil {
+		t.Fatalf("write retry choice: %v", err)
+	}
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	auth, err := recoverFromEmptyKey()
+	if err != nil {
+		t.Fatalf("recoverFromEmptyKey() error = %v", err)
+	}
+	if auth == nil || auth.APIKey != "qm-retry-success" {
+		t.Fatalf("auth = %+v, want successful retry config", auth)
+	}
+	if auth.Email != "retry@example.test" || auth.UserID != "retry-user" {
+		t.Fatalf("auth metadata = %+v", auth)
+	}
+}

--- a/internal/setup/interactive_test.go
+++ b/internal/setup/interactive_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/qualitymax/qmax-code/internal/api"
@@ -180,5 +181,80 @@ func TestBrowserLoginHTTPClientDoesNotFollowRedirects(t *testing.T) {
 	}
 	if redirected {
 		t.Fatal("redirect target was contacted")
+	}
+}
+
+func TestParseChoiceLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		n    int
+		want int
+	}{
+		{name: "first option", line: "1", n: 4, want: 0},
+		{name: "last option", line: "4", n: 4, want: 3},
+		{name: "middle option", line: "3", n: 4, want: 2},
+		{name: "empty line", line: "", n: 4, want: -1},
+		{name: "zero", line: "0", n: 4, want: -1},
+		{name: "above range", line: "5", n: 4, want: -1},
+		{name: "negative", line: "-1", n: 4, want: -1},
+		{name: "non-numeric", line: "yes", n: 4, want: -1},
+		{name: "padded digit", line: " 2 ", n: 4, want: 1},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := parseChoiceLine(tt.line, tt.n); got != tt.want {
+				t.Fatalf("parseChoiceLine(%q, %d) = %d, want %d", tt.line, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUseStandaloneModePersistsLocalOnly(t *testing.T) {
+	// api config resolves ~/.qmax-code from HOME at call time, so a temp
+	// HOME isolates the persisted local_only write.
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", t.TempDir())
+	defer os.Setenv("HOME", origHome)
+
+	if err := useStandaloneMode(); !errors.Is(err, ErrStandaloneSkip) {
+		t.Fatalf("useStandaloneMode() error = %v, want ErrStandaloneSkip", err)
+	}
+
+	cfg := api.LoadQMaxCodeConfig()
+	if !cfg.LocalOnly {
+		t.Fatal("local_only not persisted after standalone selection")
+	}
+
+	// Second run must stay idempotent (no error, still standalone).
+	if err := useStandaloneMode(); !errors.Is(err, ErrStandaloneSkip) {
+		t.Fatalf("second useStandaloneMode() error = %v, want ErrStandaloneSkip", err)
+	}
+}
+
+func TestLoginWithKeyPromptEmptyInputReturnsSentinel(t *testing.T) {
+	// Empty stdin must surface ErrEmptyAPIKey (not a generic error) so the
+	// onboarding retry/standalone branch can match on it.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	if _, err := w.WriteString("\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	w.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = r
+	defer func() { os.Stdin = origStdin }()
+
+	_, err = loginWithKeyPrompt()
+	if !errors.Is(err, ErrEmptyAPIKey) {
+		t.Fatalf("loginWithKeyPrompt() error = %v, want ErrEmptyAPIKey", err)
 	}
 }

--- a/internal/setup/interactive_test.go
+++ b/internal/setup/interactive_test.go
@@ -1,12 +1,14 @@
 package setup
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/qualitymax/qmax-code/internal/api"
@@ -210,6 +212,46 @@ func TestParseChoiceLine(t *testing.T) {
 			t.Parallel()
 			if got := parseChoiceLine(tt.line, tt.n); got != tt.want {
 				t.Fatalf("parseChoiceLine(%q, %d) = %d, want %d", tt.line, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChooseFromRawInputNavigation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{name: "down arrow", input: "\x1b[B\n", want: 1},
+		{name: "up arrow", input: "j\x1b[A\n", want: 0},
+		{name: "vim and arrow navigation", input: "j\x1b[Bk\n", want: 1},
+		{name: "direct digit", input: "3\n", want: 2},
+		{name: "ordinary key after escape is preserved", input: "\x1bj\n", want: 1},
+		{name: "malformed CSI is ignored as a unit", input: "\x1b[?1049hj\n", want: 1},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			redraws := 0
+			got, confirmed := chooseFromRawInput(
+				bufio.NewReader(strings.NewReader(tt.input)),
+				4,
+				func(int, string) { redraws++ },
+			)
+			if !confirmed {
+				t.Fatal("raw input did not confirm a selection")
+			}
+			if got != tt.want {
+				t.Fatalf("selection = %d, want %d", got, tt.want)
+			}
+			if redraws == 0 {
+				t.Fatal("navigation did not request a menu redraw")
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -282,13 +282,16 @@ func main() {
 					// The user chose standalone local mode during onboarding.
 					// setup already persisted local_only=true; mirror the
 					// startup path so descendants (MCP serve, CLI backends)
-					// inherit the choice for this process too.
+					// inherit the choice for this process too. Mutate the
+					// in-memory config rather than reloading from disk — a
+					// reload would discard per-run overrides (--backend,
+					// --professional, --save-session) applied earlier.
 					localOnly = true
 					_ = os.Setenv(api.LocalOnlyEnv, "1")
 					auth = nil
 					apiClient = nil
 					qmaxCfg = api.QMaxConfig{}
-					appConfig = api.LoadQMaxCodeConfig()
+					appConfig.LocalOnly = true
 				} else {
 					fmt.Fprintln(os.Stderr, "Setup failed:", setupErr)
 					exitWithReceipt(1)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -169,7 +170,9 @@ func main() {
 	// This must happen before any setup, consent, or API-key prompt, because
 	// those paths are interactive too and can block forever when stdin is a
 	// pipe. One-shot prompts (-p or positional args) remain valid headless use.
-	if *oneShot == "" && len(flag.Args()) == 0 && !xterm.IsTerminal(int(os.Stdin.Fd())) {
+	stdinTTY := xterm.IsTerminal(int(os.Stdin.Fd()))
+	isOneShot := *oneShot != "" || len(flag.Args()) > 0
+	if !isOneShot && !stdinTTY {
 		fmt.Fprintln(os.Stderr, "qmax-code: stdin is not a terminal.")
 		fmt.Fprintln(os.Stderr, "  For non-interactive use, pass a prompt:")
 		fmt.Fprintln(os.Stderr, "      qmax-code -p \"<your prompt>\"")
@@ -258,16 +261,46 @@ func main() {
 
 	// If no qmax CLI and no API client, run full interactive setup
 	if shouldRunInteractiveSetup(localOnly, qmaxBin, apiClient != nil) {
-		setupAuth, setupProjectID, setupErr := setup.RunInteractive()
-		if setupErr != nil {
-			fmt.Fprintln(os.Stderr, "Setup failed:", setupErr)
-			exitWithReceipt(1)
-		}
-		auth = setupAuth
-		apiClient = api.NewAPIClient(auth)
-		appConfig.DefaultProject = setupProjectID
-		if anthropicKey == "" {
-			anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
+		// Headless one-shot companion to the QUA-580 guard above: onboarding
+		// is interactive (browser login or key paste), so a piped stdin would
+		// either hang on the poll loop or consume the piped bytes as menu
+		// input. Fall back to ephemeral standalone for this run only — no
+		// config mutation — and tell the user how to connect properly.
+		if headlessSetupFallback(stdinTTY) {
+			localOnly = true
+			_ = os.Setenv(api.LocalOnlyEnv, "1")
+			auth = nil
+			apiClient = nil
+			qmaxCfg = api.QMaxConfig{}
+			fmt.Fprintln(os.Stderr, "qmax-code: no QualityMax credentials found; running this command in standalone local mode.")
+			fmt.Fprintln(os.Stderr, "  Connect once interactively: qmax-code login")
+			fmt.Fprintln(os.Stderr, "  Or persist standalone:      qmax-code config set local_only true")
+		} else {
+			setupAuth, setupProjectID, setupErr := setup.RunInteractive()
+			if setupErr != nil {
+				if errors.Is(setupErr, setup.ErrStandaloneSkip) {
+					// The user chose standalone local mode during onboarding.
+					// setup already persisted local_only=true; mirror the
+					// startup path so descendants (MCP serve, CLI backends)
+					// inherit the choice for this process too.
+					localOnly = true
+					_ = os.Setenv(api.LocalOnlyEnv, "1")
+					auth = nil
+					apiClient = nil
+					qmaxCfg = api.QMaxConfig{}
+					appConfig = api.LoadQMaxCodeConfig()
+				} else {
+					fmt.Fprintln(os.Stderr, "Setup failed:", setupErr)
+					exitWithReceipt(1)
+				}
+			} else {
+				auth = setupAuth
+				apiClient = api.NewAPIClient(auth)
+				appConfig.DefaultProject = setupProjectID
+				if anthropicKey == "" {
+					anthropicKey = os.Getenv("ANTHROPIC_API_KEY")
+				}
+			}
 		}
 	}
 
@@ -365,9 +398,10 @@ func main() {
 		}
 	}
 
-	// If connected but missing Anthropic key, prompt for it (skipped in CLI backend modes).
+	// If connected but missing Anthropic key, prompt for it (skipped in CLI
+	// backend modes and headless runs — the prompt would eat piped stdin).
 	ollamaConfigured := appConfig.OllamaURL != "" && appConfig.OllamaModel != ""
-	if cliBackend == "" && anthropicKey == "" && !(localOnly && ollamaConfigured) {
+	if cliBackend == "" && anthropicKey == "" && !(localOnly && ollamaConfigured) && stdinTTY {
 		fmt.Println()
 		fmt.Println("  Anthropic API key needed (this powers the AI).")
 		fmt.Println("  Get one at: https://console.anthropic.com/settings/keys")
@@ -624,6 +658,14 @@ func resolveLocalOnly(flagEnabled, persisted, envEnabled bool) bool {
 
 func shouldRunInteractiveSetup(localOnly bool, qmaxBin string, hasAPIClient bool) bool {
 	return !localOnly && qmaxBin == "" && !hasAPIClient
+}
+
+// headlessSetupFallback reports whether interactive onboarding must be
+// replaced by an ephemeral standalone fallback. It only ever fires for
+// one-shot runs: pure-REPL non-TTY starts were already rejected by the
+// QUA-580 guard, so reaching setup without a TTY means -p/positional args.
+func headlessSetupFallback(stdinIsTTY bool) bool {
+	return !stdinIsTTY
 }
 
 func shouldUseStreamingBuiltIn(ag *agent.Agent) bool {

--- a/main_validation_test.go
+++ b/main_validation_test.go
@@ -86,6 +86,24 @@ func TestShouldRunInteractiveSetup(t *testing.T) {
 	}
 }
 
+func TestHeadlessSetupFallback(t *testing.T) {
+	tests := []struct {
+		name     string
+		stdinTTY bool
+		want     bool
+	}{
+		{name: "piped stdin falls back to standalone", stdinTTY: false, want: true},
+		{name: "terminal stdin keeps interactive onboarding", stdinTTY: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := headlessSetupFallback(tt.stdinTTY); got != tt.want {
+				t.Fatalf("headlessSetupFallback(%v) = %v, want %v", tt.stdinTTY, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldUseStreamingBuiltIn(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Problem

First-run onboarding had no path to standalone local-only mode:
- All 3 chooser options led to login; an empty API-key paste failed the whole setup (`Setup failed: interactive login: no API key provided`)
- Standalone mode (`--local`, `local_only`) existed but was undiscoverable at first run
- Headless `-p` runs with piped stdin and no credentials fell into interactive onboarding: EOF selected default choice 1 → browser login opened → hung in the 10-minute poll loop
- The chooser was number-typing only (no keyboard navigation)

## Changes

**internal/setup/interactive.go**
- 4th onboarding option: `Skip — use standalone local mode (no account needed)` → persists `local_only: true`, returns `ErrStandaloneSkip`
- Empty API-key paste offers retry-or-standalone recovery instead of hard-failing (`ErrEmptyAPIKey` sentinel)
- `PromptChoice` rewritten as an arrow-key chooser: ↑/↓/j/k to move, 1-9 direct jump, Enter to select; numeric `Choice (1-N)` fallback when raw mode is unavailable (piped stdin)
- `parseChoiceLine` shared parser (trims padding, validates range)

**main.go**
- `setup.ErrStandaloneSkip` switches the process into standalone mode (env handoff for MCP/CLI-backend descendants, clears auth/client, reloads config)
- Headless one-shot runs (`-p`/positional) with no credentials fall back to ephemeral standalone — no config mutation, stderr guidance on how to connect
- Interactive Anthropic key prompt gated on stdin being a TTY

## Testing

- Unit: `TestParseChoiceLine`, `TestUseStandaloneModePersistsLocalOnly` (incl. idempotency), `TestLoginWithKeyPromptEmptyInputReturnsSentinel`, `TestHeadlessSetupFallback`; full `go test ./...` green, gofmt/vet clean
- PTY (expect): digit-select → standalone ✓, ↓↓↓+Enter navigation ✓, empty-key → recovery menu → standalone ✓, `local_only: true` persisted ✓, non-TTY numeric fallback ✓
- Headless e2e: fresh HOME, `-p` + `</dev/null` → standalone fallback notice + clean `Anthropic API key required` exit, no browser, nothing persisted ✓
- Interactive TTY still shows onboarding menu ✓

## Risk

MEDIUM — touches startup gating; standalone tool-boundary enforcement itself unchanged (`localOnlyToolNames` path untouched).