### PR TITLE
fix(tui): render markdown in live pane, fix run-on/garbled text, add diff-jump nav

### DIFF
--- a/internal/agent/opencode_agent.go
+++ b/internal/agent/opencode_agent.go
@@ -405,6 +405,13 @@ func (a *OpenCodeAgent) parseStream(stdout interface{ Read([]byte) (int, error) 
 			}
 			prev, seen := textByPart[id]
 			if !seen {
+				if len(order) > 0 {
+					// A new part starting after another already streamed (e.g. GLM's
+					// separate reasoning/commentary steps) has no separator of its
+					// own; without one its first word runs directly into the
+					// previous part's last word on screen.
+					term.StreamText("\n\n")
+				}
 				order = append(order, id)
 			}
 			// opencode may re-emit a growing snapshot for the same part id;
@@ -459,7 +466,12 @@ func (a *OpenCodeAgent) parseStream(stdout interface{ Read([]byte) (int, error) 
 	}
 
 	var sb strings.Builder
-	for _, id := range order {
+	for i, id := range order {
+		if i > 0 {
+			// Match the separator streamed live between parts above so the
+			// returned/rendered result doesn't run parts together either.
+			sb.WriteString("\n\n")
+		}
 		sb.WriteString(textByPart[id])
 	}
 	finalResult := sb.String()

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -461,43 +461,56 @@ func (t *Terminal) StreamText(text string) {
 }
 
 // FinishMarkdown is called when a text block is complete.
-// Re-renders the streamed text with glamour for syntax highlighting.
+// Re-renders the streamed text with glamour so headers, bold/italic, lists,
+// inline code, and fenced code blocks display formatted instead of as raw
+// markdown syntax. Previously this only happened when the text contained a
+// fenced code block; now every finished block gets the same treatment,
+// since raw "**bold**"/backtick syntax is just as unreadable without one.
 func (t *Terminal) FinishMarkdown(fullText string) {
 	t.toolStreak = false
-	if t.streaming {
-		t.streaming = false
-		if t.activeTurnProgram() != nil {
-			t.streamBuf.Reset()
-			if !strings.HasSuffix(fullText, "\n") {
-				t.emit("\n")
-			}
+	if !t.streaming {
+		return
+	}
+	t.streaming = false
+
+	var rendered string
+	var renderErr error
+	if t.renderer != nil {
+		rendered, renderErr = t.renderer.Render(fullText)
+	}
+	renderedOK := t.renderer != nil && renderErr == nil
+
+	if p := t.activeTurnProgram(); p != nil {
+		raw := t.streamBuf.String()
+		t.streamBuf.Reset()
+		if renderedOK {
+			// Swap the raw streamed text already in the live buffer for the
+			// rendered version instead of appending both.
+			p.Send(turnReplaceTailMsg{rawLen: len(raw), rendered: rendered})
 			return
 		}
-
-		// If the text contains code blocks, re-render with glamour for highlighting
-		if t.renderer != nil && strings.Contains(fullText, "```") {
-			// Move cursor up to overwrite raw output, then print rendered version
-			rawLines := strings.Count(t.streamBuf.String(), "\n") + 1
-			// Clear the raw streamed output
-			for i := 0; i < rawLines; i++ {
-				fmt.Print("\033[1A\033[2K") // move up + clear line
-			}
-			rendered, err := t.renderer.Render(fullText)
-			if err == nil {
-				fmt.Print(rendered)
-				t.streamBuf.Reset()
-				return
-			}
-		}
-
-		t.streamBuf.Reset()
 		if !strings.HasSuffix(fullText, "\n") {
-			fmt.Println()
+			t.emit("\n")
 		}
-		// Restore readline prompt after streaming completes
-		if t.rl != nil && t.currentPrompt != "" {
-			t.rl.SetPrompt(t.currentPrompt)
+		return
+	}
+
+	if renderedOK {
+		// Move cursor up to overwrite the raw streamed output, then print
+		// the rendered version in its place.
+		rawLines := strings.Count(t.streamBuf.String(), "\n") + 1
+		for i := 0; i < rawLines; i++ {
+			fmt.Print("\033[1A\033[2K") // move up + clear line
 		}
+		fmt.Print(rendered)
+	} else if !strings.HasSuffix(fullText, "\n") {
+		fmt.Println()
+	}
+	t.streamBuf.Reset()
+
+	// Restore readline prompt after streaming completes
+	if t.rl != nil && t.currentPrompt != "" {
+		t.rl.SetPrompt(t.currentPrompt)
 	}
 }
 
@@ -549,6 +562,11 @@ func (t *Terminal) PrintFileDiff(path, oldContent, newContent string) {
 		t.emit("\n")
 	}
 	t.toolStreak = false // diff block is its own visual group
+	if p := t.activeTurnProgram(); p != nil {
+		// Mark where this diff starts so the live pane can jump straight to
+		// it later (Alt+↓/Alt+↑) instead of only ever showing the tail.
+		p.Send(turnMarkMsg{})
+	}
 	t.emit(out)
 }
 

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -485,8 +485,11 @@ func (t *Terminal) FinishMarkdown(fullText string) {
 		t.streamBuf.Reset()
 		if renderedOK {
 			// Swap the raw streamed text already in the live buffer for the
-			// rendered version instead of appending both.
-			p.Send(turnReplaceTailMsg{rawLen: len(raw), rendered: rendered})
+			// rendered version instead of appending both. The live buffer
+			// stores stripCROverwrites(raw), which is shorter than raw when
+			// the stream contained '\r' progress redraws — using the
+			// stripped length keeps replaceTail from eating preceding output.
+			p.Send(turnReplaceTailMsg{rawLen: len(stripCROverwrites(raw)), rendered: rendered})
 			return
 		}
 		if !strings.HasSuffix(fullText, "\n") {

--- a/internal/tui/turn_viewport.go
+++ b/internal/tui/turn_viewport.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 	"unicode"
@@ -25,6 +26,18 @@ type turnActivityMsg string
 type turnDoneMsg struct{}
 type turnTickMsg time.Time
 
+// turnReplaceTailMsg swaps the most recently appended rawLen bytes of the
+// output/live buffers for rendered — used to upgrade raw streamed markdown
+// to its glamour-rendered form once a text block finishes.
+type turnReplaceTailMsg struct {
+	rawLen   int
+	rendered string
+}
+
+// turnMarkMsg records the current position in the live buffer as a
+// diff-hunk landmark, letting Alt+↓/Alt+↑ jump straight to it later.
+type turnMarkMsg struct{}
+
 const (
 	maxLiveOutput       = 64 * 1024
 	keptLiveOutput      = 48 * 1024
@@ -43,22 +56,24 @@ type turnViewportCache struct {
 }
 
 type turnViewportModel struct {
-	prompt   string
-	status   *StatusInfo
-	output   *strings.Builder
-	live     *strings.Builder
-	revision uint64
-	cache    *turnViewportCache
-	text     []rune
-	cursor   int
-	width    int
-	height   int
-	thinking bool
-	activity string
-	frame    int
-	done     bool
-	result   TurnInputResult
-	cancelFn func()
+	prompt       string
+	status       *StatusInfo
+	output       *strings.Builder
+	live         *strings.Builder
+	revision     uint64
+	cache        *turnViewportCache
+	text         []rune
+	cursor       int
+	width        int
+	height       int
+	thinking     bool
+	activity     string
+	frame        int
+	done         bool
+	result       TurnInputResult
+	cancelFn     func()
+	scrollOffset int   // wrapped-display-lines back from the live tail; 0 = following it
+	diffMarks    []int // raw-line indices into m.live where a diff block starts
 }
 
 func newTurnViewportModel(prompt string, status *StatusInfo, cancelFn func()) turnViewportModel {
@@ -87,6 +102,14 @@ func (m turnViewportModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case turnOutputMsg:
 		m.appendOutput(string(msg))
+		return m, nil
+	case turnReplaceTailMsg:
+		m.replaceTail(msg.rawLen, msg.rendered)
+		return m, nil
+	case turnMarkMsg:
+		if m.live != nil {
+			m.diffMarks = append(m.diffMarks, strings.Count(m.live.String(), "\n"))
+		}
 		return m, nil
 	case turnThinkingMsg:
 		m.thinking = bool(msg)
@@ -119,6 +142,7 @@ func (m *turnViewportModel) appendOutput(text string) {
 	if m.live == nil {
 		m.live = &strings.Builder{}
 	}
+	text = stripCROverwrites(text)
 	m.output.WriteString(text)
 	m.live.WriteString(text)
 	m.revision++
@@ -139,12 +163,88 @@ func (m *turnViewportModel) appendOutput(text string) {
 	// this as a separate buffer bounds wrapping work even for a huge line with
 	// no newline, where a byte offset into the full ANSI stream would be unsafe.
 	if m.live.Len() > maxLiveOutput {
-		kept := safeOutputSuffix(m.live.String(), keptLiveOutput)
+		old := m.live.String()
+		kept := safeOutputSuffix(old, keptLiveOutput)
 		next := &strings.Builder{}
 		next.Grow(len(kept))
 		next.WriteString(kept)
 		m.live = next
+		// diffMarks are line indices into m.live; re-anchor them to the
+		// trimmed buffer so a jump doesn't land on the wrong line.
+		m.diffMarks = rebaseLineMarks(m.diffMarks, old, kept)
 	}
+}
+
+// stripCROverwrites collapses text carrying a real terminal's raw '\r'
+// in-place progress redraws (git clone, npm install, pip, docker, curl -#,
+// etc., piped through a tool call) down to the final state of each line —
+// the way a real terminal would display it. Left as literal bytes, a bare
+// '\r' in this append-only buffer doesn't erase anything; it just makes the
+// real terminal overwrite part of a later, unrelated line once the buffer is
+// finally printed, producing garbled/overlapping text.
+func stripCROverwrites(s string) string {
+	if !strings.ContainsRune(s, '\r') {
+		return s
+	}
+	// Normalize CRLF line endings first so they're left untouched below —
+	// only a bare '\r' (not immediately followed by '\n') is a redraw marker.
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	if !strings.ContainsRune(s, '\r') {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if idx := strings.LastIndexByte(line, '\r'); idx >= 0 {
+			lines[i] = line[idx+1:]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// replaceTail swaps the most recently appended rawLen bytes of both the
+// scrollback and live buffers for rendered. Used to upgrade raw streamed
+// markdown to its glamour-rendered form once a text block completes,
+// without disturbing anything emitted before it. rawLen is clamped to each
+// buffer's length so a concurrent trim (above) can't underflow the slice.
+func (m *turnViewportModel) replaceTail(rawLen int, rendered string) {
+	trim := func(b *strings.Builder) {
+		if b == nil {
+			return
+		}
+		s := b.String()
+		n := rawLen
+		if n > len(s) {
+			n = len(s)
+		}
+		b.Reset()
+		b.WriteString(s[:len(s)-n])
+	}
+	trim(m.output)
+	trim(m.live)
+	m.appendOutput(rendered)
+}
+
+// rebaseLineMarks re-anchors raw-line-index marks after a buffer's front has
+// been trimmed. Marks that fell within the dropped prefix are discarded; the
+// rest are shifted down by the number of complete lines removed. When kept
+// isn't an exact byte suffix of old (the ANSI-stripping fallback in
+// safeOutputSuffix for one huge unbroken line), the marks can't be rebased
+// safely, so all of them are dropped rather than risk a dangling index.
+func rebaseLineMarks(marks []int, old, kept string) []int {
+	if len(marks) == 0 {
+		return marks
+	}
+	if !strings.HasSuffix(old, kept) {
+		return nil
+	}
+	droppedLines := strings.Count(old[:len(old)-len(kept)], "\n")
+	out := make([]int, 0, len(marks))
+	for _, ln := range marks {
+		if ln >= droppedLines {
+			out = append(out, ln-droppedLines)
+		}
+	}
+	return out
 }
 
 func safeOutputSuffix(out string, keep int) string {
@@ -171,6 +271,29 @@ func safeOutputSuffix(out string, keep int) string {
 
 func (m turnViewportModel) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
+	case tea.KeyUp:
+		if msg.Alt {
+			m.jumpToMark(-1) // previous diff/code-change block
+		} else {
+			m.scrollOffset++ // clamped against actual content in visibleOutput
+		}
+		return m, nil
+	case tea.KeyDown:
+		if msg.Alt {
+			m.jumpToMark(1) // next diff/code-change block
+		} else if m.scrollOffset > 0 {
+			m.scrollOffset--
+		}
+		return m, nil
+	case tea.KeyPgUp:
+		m.scrollOffset += m.outputMaxLines()
+		return m, nil
+	case tea.KeyPgDown:
+		m.scrollOffset -= m.outputMaxLines()
+		if m.scrollOffset < 0 {
+			m.scrollOffset = 0
+		}
+		return m, nil
 	case tea.KeyEnter:
 		text := strings.TrimSpace(string(m.text))
 		if text == "" {
@@ -285,7 +408,9 @@ func (m turnViewportModel) View() string {
 	if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
 		b.WriteString("\n")
 	}
-	if m.activity != "" {
+	if m.scrollOffset > 0 {
+		b.WriteString(fmt.Sprintf("  %s↑ scrolled back • ↓ or Alt+↓ toward live%s\n", ColorDim, ColorReset))
+	} else if m.activity != "" {
 		b.WriteString(fmt.Sprintf("  %s%s%s\n", ColorDim, m.activity, ColorReset))
 	} else if m.thinking {
 		frame := spinnerFrames[m.frame%len(spinnerFrames)]
@@ -293,7 +418,7 @@ func (m turnViewportModel) View() string {
 	}
 	b.WriteString(input.renderInputBox(string(display), w))
 	b.WriteString("\n")
-	b.WriteString(menuHintStyle.Render("  Enter queue + interrupt • Ctrl+C cancel turn • type while the agent works"))
+	b.WriteString(menuHintStyle.Render("  ↑↓ scroll • PgUp/PgDn page • Alt+↑/↓ prev/next change • Enter queue + interrupt • Ctrl+C cancel"))
 	if status := input.renderStatus(w); status != "" {
 		b.WriteString("\n")
 		b.WriteString(status)
@@ -333,18 +458,95 @@ func (m turnViewportModel) visibleOutput() string {
 	if m.height <= 0 {
 		return strings.Join(lines, "\n")
 	}
-	// Reserve the bordered input, hint, metrics, bottom bar, and spinner.
-	maxLines := m.height - 8
-	if maxLines < 3 {
-		maxLines = 3
-	}
+	maxLines := m.outputMaxLines()
 	if len(lines) <= maxLines {
 		if m.cache != nil && m.cache.lines != nil {
 			return m.cache.wrapped
 		}
 		return strings.Join(lines, "\n")
 	}
-	return strings.Join(lines[len(lines)-maxLines:], "\n")
+
+	// scrollOffset counts wrapped lines back from the live tail; 0 (the
+	// default) reproduces the old always-show-the-tail behavior exactly.
+	maxOffset := len(lines) - maxLines
+	offset := m.scrollOffset
+	if offset < 0 {
+		offset = 0
+	} else if offset > maxOffset {
+		offset = maxOffset
+	}
+	end := len(lines) - offset
+	return strings.Join(lines[end-maxLines:end], "\n")
+}
+
+// outputMaxLines is how many wrapped output lines fit above the persistent
+// input panel: height minus the bordered input, hint, metrics, bottom bar,
+// and spinner/activity line.
+func (m turnViewportModel) outputMaxLines() int {
+	h := m.height - 8
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+// jumpToMark scrolls to the next (dir > 0) or previous (dir < 0) recorded
+// diff block relative to the current scroll position, landing with that
+// diff's header line at the top of the visible window. Wraps at either end.
+func (m *turnViewportModel) jumpToMark(dir int) {
+	if len(m.diffMarks) == 0 || m.live == nil {
+		return
+	}
+	width := m.width
+	if width <= 0 {
+		width = 80
+	}
+	rawLines := strings.Split(m.live.String(), "\n")
+
+	// wrappedStart[i] is how many wrapped display rows precede raw line i.
+	// Wrapping decisions reset at every '\n' (see ansi.Wrap), so wrapping
+	// each raw line in isolation reproduces exactly what wrapping the whole
+	// buffer would have produced for that line.
+	wrappedStart := make([]int, len(rawLines)+1)
+	total := 0
+	for i, line := range rawLines {
+		wrappedStart[i] = total
+		total += strings.Count(ansi.Wrap(line, width, ""), "\n") + 1
+	}
+	wrappedStart[len(rawLines)] = total
+
+	targets := make([]int, 0, len(m.diffMarks))
+	for _, ln := range m.diffMarks {
+		if ln < 0 || ln >= len(wrappedStart) {
+			continue
+		}
+		// Convert the mark's forward position to "lines back from the
+		// bottom", matching scrollOffset's convention.
+		targets = append(targets, total-wrappedStart[ln])
+	}
+	if len(targets) == 0 {
+		return
+	}
+	sort.Ints(targets)
+
+	cur := m.scrollOffset
+	if dir < 0 { // older content = larger offset
+		for _, t := range targets {
+			if t > cur {
+				m.scrollOffset = t
+				return
+			}
+		}
+		m.scrollOffset = targets[len(targets)-1] // wrap to the oldest
+		return
+	}
+	for i := len(targets) - 1; i >= 0; i-- { // newer content = smaller offset
+		if targets[i] < cur {
+			m.scrollOffset = targets[i]
+			return
+		}
+	}
+	m.scrollOffset = targets[0] // wrap to the newest
 }
 
 // RunTurnViewport keeps a Bubble Tea-owned input/status region active while

--- a/internal/tui/turn_viewport.go
+++ b/internal/tui/turn_viewport.go
@@ -74,6 +74,12 @@ type turnViewportModel struct {
 	cancelFn     func()
 	scrollOffset int   // wrapped-display-lines back from the live tail; 0 = following it
 	diffMarks    []int // raw-line indices into m.live where a diff block starts
+	// crPending is the unsanitized incomplete last line (no trailing '\n'),
+	// which may still contain bare '\r' redraw markers. The displayed live
+	// buffer holds only the collapsed form; keeping the raw pending line lets
+	// a '\r' in a later chunk overwrite this one, matching a real terminal
+	// across emit boundaries.
+	crPending string
 }
 
 func newTurnViewportModel(prompt string, status *StatusInfo, cancelFn func()) turnViewportModel {
@@ -142,9 +148,7 @@ func (m *turnViewportModel) appendOutput(text string) {
 	if m.live == nil {
 		m.live = &strings.Builder{}
 	}
-	text = stripCROverwrites(text)
-	m.output.WriteString(text)
-	m.live.WriteString(text)
+	m.writeSanitized(text)
 	m.revision++
 
 	// Retain enough output to restore useful scrollback after the viewport
@@ -172,7 +176,70 @@ func (m *turnViewportModel) appendOutput(text string) {
 		// diffMarks are line indices into m.live; re-anchor them to the
 		// trimmed buffer so a jump doesn't land on the wrong line.
 		m.diffMarks = rebaseLineMarks(m.diffMarks, old, kept)
+		// The pending incomplete line lives at the tail; reconstruct it
+		// from the kept (already-collapsed) suffix so a later '\r' can
+		// still overwrite that last displayed line.
+		m.crPending = incompleteLine(kept)
 	}
+}
+
+func (m *turnViewportModel) writeSanitized(text string) {
+	write := func(s string) {
+		if s == "" {
+			return
+		}
+		m.output.WriteString(s)
+		m.live.WriteString(s)
+	}
+
+	// Fast path: no carriage returns in flight, so each chunk can append
+	// directly. Still track the incomplete last line so a later '\r' can
+	// overwrite it.
+	if !strings.ContainsRune(m.crPending, '\r') && !strings.ContainsRune(text, '\r') {
+		write(text)
+		if i := strings.LastIndexByte(text, '\n'); i >= 0 {
+			m.crPending = text[i+1:]
+		} else {
+			m.crPending += text
+		}
+		return
+	}
+
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	if m.crPending != "" {
+		dropExactSuffix(m.output, stripCROverwrites(m.crPending))
+		dropExactSuffix(m.live, stripCROverwrites(m.crPending))
+	}
+	combined := m.crPending + text
+	if i := strings.LastIndexByte(combined, '\n'); i >= 0 {
+		write(stripCROverwrites(combined[:i+1]))
+		m.crPending = combined[i+1:]
+	} else {
+		m.crPending = combined
+	}
+	write(stripCROverwrites(m.crPending))
+}
+
+func dropExactSuffix(b *strings.Builder, suffix string) {
+	if b == nil || suffix == "" {
+		return
+	}
+	s := b.String()
+	if !strings.HasSuffix(s, suffix) {
+		return
+	}
+	b.Reset()
+	b.WriteString(s[:len(s)-len(suffix)])
+}
+
+func incompleteLine(s string) string {
+	if s == "" || strings.HasSuffix(s, "\n") {
+		return ""
+	}
+	if i := strings.LastIndexByte(s, '\n'); i >= 0 {
+		return s[i+1:]
+	}
+	return s
 }
 
 // stripCROverwrites collapses text carrying a real terminal's raw '\r'
@@ -194,9 +261,23 @@ func stripCROverwrites(s string) string {
 	}
 	lines := strings.Split(s, "\n")
 	for i, line := range lines {
-		if idx := strings.LastIndexByte(line, '\r'); idx >= 0 {
-			lines[i] = line[idx+1:]
+		if !strings.ContainsRune(line, '\r') {
+			continue
 		}
+		// Last non-empty CR-delimited frame. A trailing '\r' (cursor
+		// returned, nothing written yet) still shows the previous frame
+		// instead of going blank until the next chunk arrives.
+		parts := strings.Split(line, "\r")
+		chosen := parts[len(parts)-1]
+		if chosen == "" {
+			for j := len(parts) - 2; j >= 0; j-- {
+				if parts[j] != "" {
+					chosen = parts[j]
+					break
+				}
+			}
+		}
+		lines[i] = chosen
 	}
 	return strings.Join(lines, "\n")
 }
@@ -207,6 +288,8 @@ func stripCROverwrites(s string) string {
 // without disturbing anything emitted before it. rawLen is clamped to each
 // buffer's length so a concurrent trim (above) can't underflow the slice.
 func (m *turnViewportModel) replaceTail(rawLen int, rendered string) {
+	// The tail being replaced includes any unsanitized pending line.
+	m.crPending = ""
 	trim := func(b *strings.Builder) {
 		if b == nil {
 			return
@@ -515,14 +598,21 @@ func (m *turnViewportModel) jumpToMark(dir int) {
 	}
 	wrappedStart[len(rawLines)] = total
 
+	maxLines := m.outputMaxLines()
 	targets := make([]int, 0, len(m.diffMarks))
 	for _, ln := range m.diffMarks {
 		if ln < 0 || ln >= len(wrappedStart) {
 			continue
 		}
-		// Convert the mark's forward position to "lines back from the
-		// bottom", matching scrollOffset's convention.
-		targets = append(targets, total-wrappedStart[ln])
+		// visibleOutput shows lines[end-maxLines:end] with
+		// end = total - offset. To put raw line ln at the top,
+		// end-maxLines == wrappedStart[ln], so
+		// offset = total - wrappedStart[ln] - maxLines.
+		target := total - wrappedStart[ln] - maxLines
+		if target < 0 {
+			target = 0
+		}
+		targets = append(targets, target)
 	}
 	if len(targets) == 0 {
 		return

--- a/internal/tui/turn_viewport_test.go
+++ b/internal/tui/turn_viewport_test.go
@@ -232,6 +232,39 @@ func TestTurnViewportCollapsesCarriageReturnProgressRedraws(t *testing.T) {
 	}
 }
 
+func TestTurnViewportCollapsesCRLFMixedWithBareCarriageReturns(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	// Windows-style line endings must survive as '\n' while a later bare
+	// '\r' progress redraw still collapses to its final frame. line2 is a
+	// complete line (not a redraw frame) so it is kept.
+	m.appendOutput("line1\r\nline2\nprogress\rfinal\n")
+
+	got := m.output.String()
+	if strings.ContainsRune(got, '\r') {
+		t.Fatalf("output retained a raw carriage return: %q", got)
+	}
+	if got != "line1\nline2\nfinal\n" {
+		t.Fatalf("output = %q, want %q", got, "line1\nline2\nfinal\n")
+	}
+}
+
+func TestTurnViewportCollapsesCarriageReturnsAcrossChunks(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	// Progress frames often split across emit() calls, with '\r' at the end
+	// of one chunk and the replacement frame in the next. The pending line
+	// has to carry the raw '\r' across that boundary or the frames concatenate.
+	m.appendOutput("Cloning into repo...\rReceiving objects:  40%")
+	m.appendOutput("\rReceiving objects: 100%, done.\n")
+
+	got := m.output.String()
+	if strings.Contains(got, "Cloning") || strings.Contains(got, "40%") {
+		t.Fatalf("earlier overwritten progress frames should not survive: %q", got)
+	}
+	if got != "Receiving objects: 100%, done.\n" {
+		t.Fatalf("output = %q, want %q", got, "Receiving objects: 100%, done.\n")
+	}
+}
+
 func TestTurnViewportReplaceTailSwapsRawForRendered(t *testing.T) {
 	m := newTurnViewportModel("qmax > ", nil, nil)
 	m, _ = updateTurnViewport(t, m, turnOutputMsg("**bold**"))
@@ -253,6 +286,25 @@ func TestTurnViewportReplaceTailClampsOversizedRawLen(t *testing.T) {
 	m, _ = updateTurnViewport(t, m, turnReplaceTailMsg{rawLen: 999, rendered: "X"})
 
 	if got, want := m.output.String(), "X"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestTurnViewportReplaceTailUsesStrippedRawLen(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("keep\n"))
+	raw := "foo\rbar"
+	m, _ = updateTurnViewport(t, m, turnOutputMsg(raw))
+
+	// FinishMarkdown must pass the stripped length: live holds stripCROverwrites(raw),
+	// which is shorter than raw. Using len(raw) would eat into "keep\n".
+	strippedLen := len(stripCROverwrites(raw))
+	if strippedLen >= len(raw) {
+		t.Fatalf("fixture no longer contains a '\\r' that shrinks the live tail")
+	}
+	m, _ = updateTurnViewport(t, m, turnReplaceTailMsg{rawLen: strippedLen, rendered: "BAZ"})
+
+	if got, want := m.output.String(), "keep\nBAZ"; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
 }
@@ -302,38 +354,57 @@ func TestTurnViewportScrollOffsetWindowsVisibleOutput(t *testing.T) {
 
 func TestTurnViewportAltArrowsJumpBetweenDiffMarks(t *testing.T) {
 	m := newTurnViewportModel("qmax > ", nil, nil)
-	m.height = 30
-	m.width = 80
+	m.height = 12 // outputMaxLines = 4; content below must exceed that
+	m.width = 80  // short lines, so one raw line == one wrapped row
 
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("pre0\npre1\npre2\npre3\npre4\npre5\n"))
 	m, _ = updateTurnViewport(t, m, turnMarkMsg{})
-	m, _ = updateTurnViewport(t, m, turnOutputMsg("+ file_a.go +1 -0\n+ hello\n"))
-	m, _ = updateTurnViewport(t, m, turnOutputMsg("some commentary\nmore commentary\n"))
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("DIFF_A\n+ a1\n+ a2\n"))
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("mid0\nmid1\nmid2\nmid3\nmid4\nmid5\n"))
 	m, _ = updateTurnViewport(t, m, turnMarkMsg{})
-	m, _ = updateTurnViewport(t, m, turnOutputMsg("+ file_b.go +1 -0\n+ world\n"))
-	m, _ = updateTurnViewport(t, m, turnOutputMsg("trailing chatter\n"))
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("DIFF_B\n+ b1\n+ b2\n"))
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("tail0\ntail1\ntail2\ntail3\ntail4\ntail5\n"))
 
 	if len(m.diffMarks) != 2 {
 		t.Fatalf("diffMarks = %v, want 2 marks", m.diffMarks)
 	}
 
-	// Alt+Up from the live tail lands on the most recent (second) mark first.
+	firstVisible := func() string {
+		visible := m.visibleOutput()
+		if i := strings.IndexByte(visible, '\n'); i >= 0 {
+			return visible[:i]
+		}
+		return visible
+	}
+
+	// Alt+Up from the live tail lands on the most recent mark, with its
+	// header at the top of the window (not the bottom).
 	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyUp, Alt: true})
 	firstStop := m.scrollOffset
 	if firstStop <= 0 {
 		t.Fatalf("Alt+Up did not scroll back to a mark, offset = %d", firstStop)
 	}
+	if got, want := firstVisible(), "DIFF_B"; got != want {
+		t.Fatalf("after Alt+Up, top line = %q, want %q (header should be at the top)", got, want)
+	}
 
-	// A second Alt+Up moves further back to the older, first mark.
+	// A second Alt+Up moves further back to the older mark.
 	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyUp, Alt: true})
 	secondStop := m.scrollOffset
 	if secondStop <= firstStop {
 		t.Fatalf("second Alt+Up should reach an older mark: first=%d second=%d", firstStop, secondStop)
+	}
+	if got, want := firstVisible(), "DIFF_A"; got != want {
+		t.Fatalf("after second Alt+Up, top line = %q, want %q", got, want)
 	}
 
 	// Alt+Down walks back toward the live tail, retracing the same marks.
 	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyDown, Alt: true})
 	if m.scrollOffset != firstStop {
 		t.Fatalf("Alt+Down = %d, want back to %d", m.scrollOffset, firstStop)
+	}
+	if got, want := firstVisible(), "DIFF_B"; got != want {
+		t.Fatalf("after Alt+Down, top line = %q, want %q", got, want)
 	}
 }
 

--- a/internal/tui/turn_viewport_test.go
+++ b/internal/tui/turn_viewport_test.go
@@ -208,3 +208,159 @@ func TestTurnViewportBoundsStoredAndLiveOutput(t *testing.T) {
 		t.Fatal("long-line live suffix retained a partial or active ANSI sequence")
 	}
 }
+
+func TestTurnViewportCollapsesCarriageReturnProgressRedraws(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	// A subprocess (git clone, npm install, pip, docker, curl -#, ...) piped
+	// through a tool call redraws its own progress line with bare '\r'. In
+	// this append-only buffer that byte doesn't erase anything — left as-is
+	// it would make the real terminal overwrite part of a later line once
+	// printed, which is exactly the garbled/overlapping text this collapses.
+	m.appendOutput("Cloning into repo...\rReceiving objects:  40%\rReceiving objects: 100%, done.\n")
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("next line\r\n"))
+
+	got := m.output.String()
+	if strings.ContainsRune(got, '\r') {
+		t.Fatalf("output retained a raw carriage return: %q", got)
+	}
+	if strings.Contains(got, "Cloning") || strings.Contains(got, "40%") {
+		t.Fatalf("earlier overwritten progress frames should not survive: %q", got)
+	}
+	want := "Receiving objects: 100%, done.\nnext line\n"
+	if got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestTurnViewportReplaceTailSwapsRawForRendered(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("**bold**"))
+	m, _ = updateTurnViewport(t, m, turnReplaceTailMsg{rawLen: len("**bold**"), rendered: "BOLD"})
+
+	if got, want := m.output.String(), "BOLD"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+	if strings.Contains(m.live.String(), "**") {
+		t.Fatalf("raw markdown survived the replace: %q", m.live.String())
+	}
+}
+
+func TestTurnViewportReplaceTailClampsOversizedRawLen(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("hi"))
+
+	// rawLen larger than the buffer must clamp instead of underflowing the slice.
+	m, _ = updateTurnViewport(t, m, turnReplaceTailMsg{rawLen: 999, rendered: "X"})
+
+	if got, want := m.output.String(), "X"; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+}
+
+func TestTurnViewportScrollKeysMoveOffsetAndClamp(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m.height = 20
+
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyUp})
+	if m.scrollOffset != 1 {
+		t.Fatalf("scrollOffset after Up = %d, want 1", m.scrollOffset)
+	}
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.scrollOffset != 0 {
+		t.Fatalf("scrollOffset after Down = %d, want 0", m.scrollOffset)
+	}
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	if m.scrollOffset != 0 {
+		t.Fatalf("Down at the live tail should clamp at 0, got %d", m.scrollOffset)
+	}
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyPgUp})
+	if want := m.outputMaxLines(); m.scrollOffset != want {
+		t.Fatalf("scrollOffset after PgUp = %d, want %d", m.scrollOffset, want)
+	}
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyPgDown})
+	if m.scrollOffset != 0 {
+		t.Fatalf("scrollOffset after PgDown = %d, want 0", m.scrollOffset)
+	}
+}
+
+func TestTurnViewportScrollOffsetWindowsVisibleOutput(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m.height = 12 // outputMaxLines = 4
+	m.appendOutput("line0\nline1\nline2\nline3\nline4\nline5\nline6\nline7\nline8\nline9")
+
+	m.scrollOffset = 2
+	visible := m.visibleOutput()
+	for _, want := range []string{"line4", "line5", "line6", "line7"} {
+		if !strings.Contains(visible, want) {
+			t.Fatalf("scrolled view missing %q: %q", want, visible)
+		}
+	}
+	if strings.Contains(visible, "line8") || strings.Contains(visible, "line9") {
+		t.Fatalf("scrolled view should not show the live tail: %q", visible)
+	}
+}
+
+func TestTurnViewportAltArrowsJumpBetweenDiffMarks(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m.height = 30
+	m.width = 80
+
+	m, _ = updateTurnViewport(t, m, turnMarkMsg{})
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("+ file_a.go +1 -0\n+ hello\n"))
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("some commentary\nmore commentary\n"))
+	m, _ = updateTurnViewport(t, m, turnMarkMsg{})
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("+ file_b.go +1 -0\n+ world\n"))
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("trailing chatter\n"))
+
+	if len(m.diffMarks) != 2 {
+		t.Fatalf("diffMarks = %v, want 2 marks", m.diffMarks)
+	}
+
+	// Alt+Up from the live tail lands on the most recent (second) mark first.
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyUp, Alt: true})
+	firstStop := m.scrollOffset
+	if firstStop <= 0 {
+		t.Fatalf("Alt+Up did not scroll back to a mark, offset = %d", firstStop)
+	}
+
+	// A second Alt+Up moves further back to the older, first mark.
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyUp, Alt: true})
+	secondStop := m.scrollOffset
+	if secondStop <= firstStop {
+		t.Fatalf("second Alt+Up should reach an older mark: first=%d second=%d", firstStop, secondStop)
+	}
+
+	// Alt+Down walks back toward the live tail, retracing the same marks.
+	m, _ = updateTurnViewport(t, m, tea.KeyMsg{Type: tea.KeyDown, Alt: true})
+	if m.scrollOffset != firstStop {
+		t.Fatalf("Alt+Down = %d, want back to %d", m.scrollOffset, firstStop)
+	}
+}
+
+func TestTurnViewportPrunesDiffMarksWhenLiveOutputTrims(t *testing.T) {
+	m := newTurnViewportModel("qmax > ", nil, nil)
+	m, _ = updateTurnViewport(t, m, turnMarkMsg{})
+	m, _ = updateTurnViewport(t, m, turnOutputMsg("old diff block\n"))
+
+	// Push enough newline-delimited content through to exceed maxLiveOutput
+	// and trigger the front-trim in appendOutput.
+	const fillerLine = "filler line\n"
+	filler := strings.Repeat(fillerLine, maxLiveOutput/len(fillerLine)+10)
+	m, _ = updateTurnViewport(t, m, turnOutputMsg(filler))
+
+	if m.live.Len() > maxLiveOutput {
+		t.Fatalf("live output = %d bytes, want <= %d", m.live.Len(), maxLiveOutput)
+	}
+	liveLines := strings.Count(m.live.String(), "\n")
+	for _, ln := range m.diffMarks {
+		if ln < 0 || ln > liveLines {
+			t.Fatalf("stale diff mark %d out of range after trim (live has %d lines)", ln, liveLines)
+		}
+	}
+	// The mark predating the flood of filler no longer has a valid home in
+	// the retained suffix and must be dropped rather than pointing at the
+	// wrong line.
+	if len(m.diffMarks) != 0 {
+		t.Fatalf("expected the stale mark to be pruned by the trim, got %v", m.diffMarks)
+	}
+}


### PR DESCRIPTION
## Problem

Reported via screenshots: the live "agent working" pane rendered assistant
text as one dense, run-on wall of characters — literal `**bold**`/`` `code` ``
markdown syntax unrendered, some text visibly garbled/overlapping — and there
was no way to scroll to or jump between the file diffs the agent renders
mid-turn.

## Root causes & fixes

1. **Markdown never rendered in the live pane.** `Terminal.FinishMarkdown`
   skipped glamour rendering entirely whenever the live turn viewport owned
   the terminal, and even off that path only rendered when a fenced code
   block was present. Every finished text block is now rendered through
   glamour and swapped into the live buffer in place of the raw text via a
   new `turnReplaceTailMsg`.

2. **Run-on text between opencode's streamed parts.** opencode streams
   separate text parts (e.g. GLM's distinct reasoning/commentary steps) with
   no separator between them, so one part's last word ran directly into the
   next part's first word (`flow.Now`, `path.Let`). A paragraph break is now
   inserted between parts, both live and in the persisted result text.

3. **Garbled/overlapping text from subprocess `\r` bytes.** Tool calls that
   shell out (git clone, npm/pip install, docker, curl progress bars, ...)
   can emit raw `\r` progress-redraw bytes. The live pane's buffer is
   append-only, so a bare `\r` doesn't erase anything there — it just sits
   until the *real* terminal prints and interprets it, overwriting part of a
   later, unrelated line. `appendOutput` now normalizes CRLF and collapses
   any remaining redraw sequences down to their final frame.

4. **No keyboard navigation to diffs.** `turnViewportModel` had no scroll
   state — the live pane always showed only the tail, and every arrow/paging
   key only edited the input line. Added `scrollOffset` + `diffMarks`;
   `PrintFileDiff` now records a mark before each diff block.
   - `↑`/`↓` scroll by line
   - `PgUp`/`PgDn` scroll by page
   - `Alt+↑`/`Alt+↓` jump directly between diff blocks (wraps at either end)
   - A dim indicator shows when scrolled off the live tail

Linear: [QUA-1888](https://linear.app/quality-max/issue/QUA-1888/tui-live-turn-text-is-unreadable-add-keyboard-nav-to-code-change-diffs)

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` — full repo, all
  packages green
- 8 new tests in `turn_viewport_test.go`: markdown replace-tail (+ clamping
  on oversized rawLen), scroll/page key handling, diff-mark jump navigation,
  mark pruning under buffer trim, CR-overwrite collapse
- No live terminal available in the environment this was built in, so this
  hasn't been eyeballed in a real TTY yet — worth a manual smoke test
  (stream a markdown-heavy response, run a tool that shells out with a
  progress bar, try the new scroll/jump keys) before merging.