### PR TITLE
release: v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.26.0] - 2026-08-21
+
+### Added
+- First-run onboarding now has a standalone local-mode escape hatch, so you
+  can skip account login entirely (`Skip — use standalone local mode`). The
+  chooser is arrow-key navigable (↑/↓/j/k, or 1–9 to jump). An empty API-key
+  paste offers retry-or-standalone instead of failing the whole setup, and
+  headless `-p` runs with no credentials fall back to ephemeral standalone
+  instead of hanging on a browser login (#169).
+- Live-turn assistant text is glamour-rendered (bold, headers, inline code)
+  instead of showing raw markdown syntax. Multi-part streams insert a
+  paragraph break so consecutive parts no longer run together. Alt+↑/↓ jumps
+  between live code-change diffs, landing on each diff's header (#170).
+
+### Fixed
+- Subprocess progress redraws that use bare `\r` (git clone, npm/pip install,
+  docker, curl) no longer garble the live pane. The sanitizer is stateful
+  across output chunks, so a progress frame split across `emit()` calls still
+  collapses to its final line (#170).
+
 ## [1.25.0] - 2026-08-21
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.25.0"
+var Version = "1.26.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Version bump to 1.26.0 + changelog promotion.

## What's in v1.26.0
- **Standalone onboarding escape hatch** (#169, merged `a9948d8`): skip-login local mode as a first-run chooser option, arrow-key navigation, empty API-key recovery, headless `-p` fallback so piped runs no longer hang on browser login.
- **Live-turn readability + diff-jump nav** (#170, merged `cc2fefa`): glamour-rendered markdown in the live pane, paragraph breaks between stream parts, stateful `\r` progress-redraw sanitizer, Alt+↑/↓ between live code-change diffs.

## Release checklist (post-merge)
- [ ] Tag `v1.26.0` → workflow builds 6 platforms, creates release, publishes to qmax-code-releases
- [ ] Verify assets on both repos
- [ ] Verify `Check("1.25.0")` finds 1.26.0


Made with [Cursor](https://cursor.com)