### PR TITLE
release: v1.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.26.1] - 2026-08-22
+
+### Fixed
+- First-run onboarding no longer skips when a leftover `qmax` CLI is on PATH.
+  A fresh qmax-code install with no credentials now always shows the chooser
+  (browser login / signup / API key / standalone).
+- Startup restores terminal newline handling if a previous session died in
+  raw mode, so Max and the setup menu no longer staircase across the screen.
+  The arrow-key chooser prints `\r\n` so the menu stays left-aligned.
+
 ## [1.26.0] - 2026-08-21
 
 ### Added

--- a/internal/setup/interactive.go
+++ b/internal/setup/interactive.go
@@ -582,21 +582,21 @@ func PromptChoice(prompt string, options []string) int {
 	printMenu := func(sel int, typed string) {
 		for i, opt := range options {
 			if i == sel {
-				fmt.Printf("    \033[36m› %s\033[0m\n", opt)
+				fmt.Printf("    \033[36m› %s\033[0m\r\n", opt)
 			} else {
-				fmt.Printf("      %s\n", opt)
+				fmt.Printf("      %s\r\n", opt)
 			}
 		}
 		if typed != "" {
-			fmt.Printf("  \033[2mGo to %s + Enter, or ↑/↓ then Enter\033[0m\n", typed)
+			fmt.Printf("  \033[2mGo to %s + Enter, or ↑/↓ then Enter\033[0m\r\n", typed)
 		} else {
-			fmt.Println("  \033[2m↑/↓ to move · Enter to select · 1-9 jumps\033[0m")
+			fmt.Print("  \033[2m↑/↓ to move · Enter to select · 1-9 jumps\033[0m\r\n")
 		}
 	}
 
 	redraw := func(sel int, typed string) {
 		for i := 0; i < len(options)+1; i++ {
-			fmt.Print("\033[A\033[2K") // up one line, clear it
+			fmt.Print("\033[A\r\033[2K") // up, column 0, clear line
 		}
 		printMenu(sel, typed)
 	}

--- a/internal/tui/term_raw.go
+++ b/internal/tui/term_raw.go
@@ -20,6 +20,7 @@ func EnableRawMode() (*TermState, error) {
 	}
 	raw := *old
 	raw.Lflag &^= unix.ECHO | unix.ICANON
+	raw.Oflag |= unix.OPOST | unix.ONLCR
 	raw.Cc[unix.VMIN] = 1
 	raw.Cc[unix.VTIME] = 0
 	if err := unix.IoctlSetTermios(fd, unix.TIOCSETA, &raw); err != nil {
@@ -30,6 +31,30 @@ func EnableRawMode() (*TermState, error) {
 
 func RestoreTermMode(state *TermState) {
 	if state != nil {
-		_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TIOCSETA, &state.old)
+		restored := state.old
+		restored.Oflag |= unix.OPOST | unix.ONLCR
+		_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TIOCSETA, &restored)
+	}
+}
+
+// EnsureTTYNewlines turns output-postprocessing back on so '\n' returns the
+// cursor to column 0. A previous process that died in full raw mode (Bubble
+// Tea) can leave OPOST/ONLCR off, which makes every later line staircase.
+func EnsureTTYNewlines() {
+	seen := map[int]struct{}{}
+	for _, fd := range []int{int(os.Stdin.Fd()), int(os.Stdout.Fd())} {
+		if _, dup := seen[fd]; dup {
+			continue
+		}
+		seen[fd] = struct{}{}
+		t, err := unix.IoctlGetTermios(fd, unix.TIOCGETA)
+		if err != nil {
+			continue
+		}
+		if t.Oflag&unix.OPOST != 0 && t.Oflag&unix.ONLCR != 0 {
+			continue
+		}
+		t.Oflag |= unix.OPOST | unix.ONLCR
+		_ = unix.IoctlSetTermios(fd, unix.TIOCSETA, t)
 	}
 }

--- a/internal/tui/term_raw_linux.go
+++ b/internal/tui/term_raw_linux.go
@@ -20,6 +20,7 @@ func EnableRawMode() (*TermState, error) {
 	}
 	raw := *old
 	raw.Lflag &^= unix.ECHO | unix.ICANON
+	raw.Oflag |= unix.OPOST | unix.ONLCR
 	raw.Cc[unix.VMIN] = 1
 	raw.Cc[unix.VTIME] = 0
 	if err := unix.IoctlSetTermios(fd, unix.TCSETS, &raw); err != nil {
@@ -30,6 +31,30 @@ func EnableRawMode() (*TermState, error) {
 
 func RestoreTermMode(state *TermState) {
 	if state != nil {
-		_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, &state.old)
+		restored := state.old
+		restored.Oflag |= unix.OPOST | unix.ONLCR
+		_ = unix.IoctlSetTermios(int(os.Stdin.Fd()), unix.TCSETS, &restored)
+	}
+}
+
+// EnsureTTYNewlines turns output-postprocessing back on so '\n' returns the
+// cursor to column 0. A previous process that died in full raw mode (Bubble
+// Tea) can leave OPOST/ONLCR off, which makes every later line staircase.
+func EnsureTTYNewlines() {
+	seen := map[int]struct{}{}
+	for _, fd := range []int{int(os.Stdin.Fd()), int(os.Stdout.Fd())} {
+		if _, dup := seen[fd]; dup {
+			continue
+		}
+		seen[fd] = struct{}{}
+		t, err := unix.IoctlGetTermios(fd, unix.TCGETS)
+		if err != nil {
+			continue
+		}
+		if t.Oflag&unix.OPOST != 0 && t.Oflag&unix.ONLCR != 0 {
+			continue
+		}
+		t.Oflag |= unix.OPOST | unix.ONLCR
+		_ = unix.IoctlSetTermios(fd, unix.TCSETS, t)
 	}
 }

--- a/internal/tui/term_raw_windows.go
+++ b/internal/tui/term_raw_windows.go
@@ -11,3 +11,5 @@ func EnableRawMode() (*TermState, error) {
 }
 
 func RestoreTermMode(state *TermState) {}
+
+func EnsureTTYNewlines() {}

--- a/main.go
+++ b/main.go
@@ -21,11 +21,13 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.26.0"
+var Version = "1.26.1"
 
 const Name = "qmax-code"
 
 func main() {
+	tui.EnsureTTYNewlines()
+
 	// Flags
 	projectID := flag.Int("project-id", 0, "Default project ID for this session")
 	model := flag.String("model", "", "Claude model: auto (haiku+sonnet), sonnet, opus, haiku, or full ID")
@@ -259,8 +261,11 @@ func main() {
 		}
 	}
 
-	// If no qmax CLI and no API client, run full interactive setup
-	if shouldRunInteractiveSetup(localOnly, qmaxBin, apiClient != nil) {
+	// First-run onboarding when qmax-code itself has no credentials.
+	// A leftover `qmax` CLI on PATH must not skip this: the chooser
+	// (browser login / signup / API key / standalone) is how this
+	// binary gets configured, independent of the legacy CLI.
+	if shouldRunInteractiveSetup(localOnly, apiClient != nil) {
 		// Headless one-shot companion to the QUA-580 guard above: onboarding
 		// is interactive (browser login or key paste), so a piped stdin would
 		// either hang on the poll loop or consume the piped bytes as menu
@@ -659,8 +664,8 @@ func resolveLocalOnly(flagEnabled, persisted, envEnabled bool) bool {
 	return flagEnabled || persisted || envEnabled
 }
 
-func shouldRunInteractiveSetup(localOnly bool, qmaxBin string, hasAPIClient bool) bool {
-	return !localOnly && qmaxBin == "" && !hasAPIClient
+func shouldRunInteractiveSetup(localOnly bool, hasAPIClient bool) bool {
+	return !localOnly && !hasAPIClient
 }
 
 // headlessSetupFallback reports whether interactive onboarding must be

--- a/main_validation_test.go
+++ b/main_validation_test.go
@@ -67,20 +67,19 @@ func TestShouldRunInteractiveSetup(t *testing.T) {
 	tests := []struct {
 		name         string
 		localOnly    bool
-		qmaxBin      string
 		hasAPIClient bool
 		want         bool
 	}{
 		{name: "standalone skips setup", localOnly: true, want: false},
 		{name: "unconfigured connected mode runs setup", want: true},
-		{name: "legacy CLI available", qmaxBin: "/usr/local/bin/qmax", want: false},
 		{name: "direct API available", hasAPIClient: true, want: false},
+		{name: "standalone with credentials still skips", localOnly: true, hasAPIClient: true, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldRunInteractiveSetup(tt.localOnly, tt.qmaxBin, tt.hasAPIClient); got != tt.want {
-				t.Fatalf("shouldRunInteractiveSetup(%v, %q, %v) = %v, want %v",
-					tt.localOnly, tt.qmaxBin, tt.hasAPIClient, got, tt.want)
+			if got := shouldRunInteractiveSetup(tt.localOnly, tt.hasAPIClient); got != tt.want {
+				t.Fatalf("shouldRunInteractiveSetup(%v, %v) = %v, want %v",
+					tt.localOnly, tt.hasAPIClient, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Patch release so a fresh install actually shows the new setup dialogs.

## What's in v1.26.1
- First-run chooser no longer skips just because a leftover `qmax` CLI is on PATH.
- Startup restores `OPOST`/`ONLCR` if a previous session died in raw mode; the chooser prints `\r\n` so the menu stays left-aligned.

## Release checklist (post-merge)
- [ ] Tag `v1.26.1` → workflow builds 6 platforms, publishes to qmax-code-releases
- [ ] Verify assets on both repos
- [ ] Reinstall: `curl -sL https://qualitymax.io/static/install-qmax-code.txt | bash`


Made with [Cursor](https://cursor.com)