### PR TITLE
release: v1.27.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+Instructions for coding agents working on qmax-code.
+
+## What this is
+
+qmax-code is a terminal QA and coding agent. It can run standalone on a local
+repository or connected to QualityMax, and it can host Claude Code, Codex, or
+OpenCode through `/orch` while keeping qmax tools and terminal UX.
+
+This repository is **Go 1.24+**, not TypeScript. The thing users install is one
+compiled binary.
+
+## Why Go
+
+qmax-code is written in Go so it behaves like a Unix tool, not like a Node app.
+
+- **One file.** `curl | bash` drops a single binary (`~/.qmax-code/qmax-code`).
+  There is no Node, npm, Python, or version manager for qmax-code itself.
+- **Every OS from one source tree.** A tagged release builds macOS, Linux, and
+  Windows (Intel and ARM) from the same commit.
+- **Starts immediately.** A TUI people open all day cannot wait on an
+  interpreter.
+- **Concurrent without extra machinery.** The agent turn, live browser feed,
+  signals, and embedded MCP server run as goroutines in one process.
+
+Go does not make the model smarter. Claude Code, Codex, and OpenCode stay
+separate CLIs that this binary can launch. Do not add npm, pip, or another
+language runtime as a dependency of qmax-code.
+
+## Git
+
+Never commit or push directly to `main`. Create a branch and open a PR.
+Claude-specific merge notes live in [CLAUDE.md](CLAUDE.md).
+
+## Build and test
+
+```bash
+go build -o qmax-code .
+go test ./...
+go vet ./...
+```
+
+Match a release build with:
+
+```bash
+go build -ldflags="-s -w -X main.Version=dev" -o qmax-code .
+```
+
+Architecture, slash-command and tool patterns, and PR expectations:
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.27.0] - 2026-08-22
+
+### Added
+- `/providers` is an interactive picker: ↑/↓ highlights Z.AI, Groq, or
+  OpenRouter; Enter enables and saves (then the existing key prompt if needed).
+- When no OpenCode provider is opted in, `/orch` still shows the OpenCode
+  section with enable rows, so GLM/Groq/OpenRouter can be turned on from the
+  model picker.
+- README, AGENTS.md, and CLAUDE.md explain why qmax-code is written in Go:
+  one-file install, cross-platform releases, instant startup, and cheap
+  concurrency — not a smarter model.
+
+### Fixed
+- `/orch` Enter confirms the highlighted model even when Tab has focused the
+  effort bar. Previously that Enter quit with no selection.
+
 ## [1.26.1] - 2026-08-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # CLAUDE.md
 
+qmax-code is a **Go** terminal agent (Go 1.24+). It ships as one compiled
+binary: `curl | bash` installs a file, not a Node or Python runtime. Claude
+Code, Codex, and OpenCode are separate subprocesses that `/orch` can host;
+they are not this repository's runtime.
+
+**Why Go (not a smarter model):** one-file install, six OS/arch binaries from
+the same source, instant TUI startup, goroutines for the agent turn / live
+feed / MCP / signals. Do not add npm, pip, or another language runtime as a
+dependency of the CLI itself.
+
+Build and test: `go build -o qmax-code .` then `go test ./...`. Project-wide
+agent instructions: [AGENTS.md](AGENTS.md). Contribution map:
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Git workflow
 
 - Never commit or push directly to `main`. Always create a branch and open a PR.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ background-job health—remain experimental and are only exposed when
 
 ## What is new
 
+### v1.27
+
+- **Selectable providers:** `/providers` is an arrow-key picker (Enter
+  enables and saves). `/orch` Enter always confirms, including when the
+  effort bar is focused, and can opt in OpenCode providers (Z.AI GLM, Groq,
+  OpenRouter) when none are enabled yet.
+- **Why Go:** this README, `AGENTS.md`, and `CLAUDE.md` now explain the
+  product choice: one-file install, cross-platform releases, instant
+  startup — not a smarter model.
+
 ### v1.22
 
 - **Cloud-routed MCP tool calls (v1.22.1):** `serve --mcp` now routes
@@ -130,6 +140,24 @@ go build -o qmax-code .
 ```
 
 Go 1.24 or newer is required for source builds.
+
+## Why Go
+
+qmax-code is a compiled Go program, not a Node or Python app. That is why it
+installs like a Unix tool.
+
+- **One file.** `curl | bash` drops a single binary. There is no Node, npm,
+  Python, or version manager to keep in sync.
+- **Every OS from one source tree.** A release is six binaries — macOS, Linux,
+  and Windows, Intel and ARM — from the same code.
+- **Starts immediately.** A terminal agent you open all day cannot wait on an
+  interpreter.
+- **Concurrent without extra machinery.** The agent turn, live browser feed,
+  signals, and MCP server run as goroutines in one process.
+
+Go does not make the model smarter. Claude Code, Codex, and OpenCode remain
+separate tools that qmax-code can host through `/orch`. Go makes qmax-code
+itself install once and run like `curl`, `git`, or `rg`.
 
 ## Quick start
 

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -497,6 +497,10 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 			if len(cfg.ActiveProviders()) > 0 && agent.FindOpenCode() != "" {
 				term.PrintSystem("Querying opencode models for your enabled providers…")
 			}
+			ocModels := buildOpenCodeModelEntries(cfg, ag.Cfg.Context)
+			if len(ocModels) == 0 {
+				ocModels = openCodeSetupEntries()
+			}
 			result := tui.ShowModelPicker(tui.ModelPickerOpts{
 				CurrentBackend:    currentBackend,
 				CurrentModelID:    currentModelID,
@@ -507,9 +511,14 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				CodexInstalled:    agent.FindCodex() != "",
 				CerebrasKeySet:    cfg.CerebrasKey != "",
 				OpenCodeInstalled: agent.FindOpenCode() != "",
-				OpenCodeModels:    buildOpenCodeModelEntries(cfg, ag.Cfg.Context),
+				OpenCodeModels:    ocModels,
 			})
 			if !result.Confirmed {
+				continue
+			}
+
+			if result.Backend == "opencode-enable" {
+				enableProvider(cfg, result.ModelID, ag, term)
 				continue
 			}
 
@@ -1581,7 +1590,7 @@ Commands:
   /gemma [none|low|medium|high|off]
                     Activate Gemma 4 on Cerebras, or return to API
   /ollama           Toggle the configured Ollama backend
-  /providers        List opt-in OpenCode providers
+  /providers        Pick and enable an OpenCode provider
   /providers enable|disable <id>
                     Manage Z.AI, Groq, or OpenRouter
   /reconnect        Restore the active CC/Codex MCP transport
@@ -2145,10 +2154,27 @@ func resolveOpenCodeModelOverride(cfg *api.Config, sctx *api.SessionContext) (st
 	return entries[0].ModelID, true
 }
 
-// handleProviders implements the /providers command: list opt-in opencode
-// providers, or enable/disable one for this user. Enabling prompts for the key
-// (stored in the OS keychain) and regenerates the managed opencode config so
-// the provider's models appear in /orch.
+// openCodeSetupEntries are /orch rows shown when no provider is opted in yet.
+// Selecting one runs enableProvider so GLM/Groq/OpenRouter can be chosen
+// from the picker instead of requiring a typed /providers enable command.
+func openCodeSetupEntries() []tui.OpenCodeModelEntry {
+	providers := api.BuiltinProviders()
+	out := make([]tui.OpenCodeModelEntry, 0, len(providers))
+	for _, p := range providers {
+		out = append(out, tui.OpenCodeModelEntry{
+			ProviderID:   p.ID,
+			ProviderName: "Enter to enable",
+			ModelID:      "enable:" + p.ID,
+			Label:        p.DisplayName,
+		})
+	}
+	return out
+}
+
+// handleProviders implements the /providers command: an arrow-key picker to
+// enable an opt-in opencode provider, or typed enable/disable. Enabling
+// prompts for the key (stored in the OS keychain) and regenerates the managed
+// opencode config so the provider's models appear in /orch.
 func handleProviders(input string, ag *agent.Agent, term *tui.Terminal) {
 	cfg := ag.AppConfig
 	if cfg == nil {
@@ -2157,7 +2183,7 @@ func handleProviders(input string, ag *agent.Agent, term *tui.Terminal) {
 	}
 	fields := strings.Fields(strings.TrimSpace(strings.TrimPrefix(input, "/providers")))
 	if len(fields) == 0 {
-		printProvidersList(cfg, term)
+		pickAndEnableProvider(cfg, ag, term)
 		return
 	}
 	switch fields[0] {
@@ -2178,23 +2204,33 @@ func handleProviders(input string, ag *agent.Agent, term *tui.Terminal) {
 	}
 }
 
-func printProvidersList(cfg *api.Config, term *tui.Terminal) {
-	term.PrintSystem("Opt-in providers (opencode backend). Enable one, then pick a model in /orch:")
-	for _, p := range api.BuiltinProviders() {
-		status := "○ available"
-		switch {
-		case !api.ProviderAllowed(p.ID):
-			status = "🔒 not entitled"
-		case cfg.IsProviderEnabled(p.ID) && api.ProviderKeySet(p.ID):
-			status = "● enabled (key set)"
-		case cfg.IsProviderEnabled(p.ID):
-			status = "● enabled (no key — re-enable)"
+func pickAndEnableProvider(cfg *api.Config, ag *agent.Agent, term *tui.Terminal) {
+	providers := api.BuiltinProviders()
+	items := make([]tui.ProviderPickerItem, 0, len(providers))
+	for _, p := range providers {
+		item := tui.ProviderPickerItem{
+			ID:          p.ID,
+			DisplayName: p.DisplayName,
+			Allowed:     api.ProviderAllowed(p.ID),
+			Enabled:     cfg.IsProviderEnabled(p.ID),
 		}
-		term.PrintSystem(fmt.Sprintf("  %-16s %-30s %s", p.ID, status, p.DisplayName))
+		switch {
+		case !item.Allowed:
+			item.Status = "not entitled"
+		case item.Enabled && api.ProviderKeySet(p.ID):
+			item.Status = "enabled"
+		case item.Enabled:
+			item.Status = "enabled (no key)"
+		default:
+			item.Status = "available"
+		}
+		items = append(items, item)
 	}
-	term.PrintSystem("")
-	term.PrintSystem("  /providers enable <id>   ·   /providers disable <id>")
-	term.PrintSystem("  Cerebras is available natively — select it directly in /orch.")
+	result := tui.ShowProviderPicker(items)
+	if !result.Confirmed {
+		return
+	}
+	enableProvider(cfg, result.ID, ag, term)
 }
 
 func enableProvider(cfg *api.Config, id string, ag *agent.Agent, term *tui.Terminal) {

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -56,7 +56,7 @@ var slashMenuItems = []SlashMenuItem{
 	{"/codex", "Switch to Codex CLI backend"},
 	{"/opencode", "Switch to opencode backend (Z.AI / Groq / OpenRouter)"},
 	{"/api", "Switch to direct Anthropic API"},
-	{"/providers", "Enable/disable opencode providers (per-user opt-in)"},
+	{"/providers", "Pick and enable an opencode provider (arrows + Enter)"},
 	{"/connect", "Log in to QualityMax (browser)"},
 	{"/disconnect", "Log out"},
 	{"/reconnect", "Restore active MCP transport"},

--- a/internal/tui/tui_backend.go
+++ b/internal/tui/tui_backend.go
@@ -249,11 +249,18 @@ func newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, olla
 	entries = append(entries, apiModels...)
 	entries = append(entries, cerebrasModels...)
 
-	// Append opencode entries (one per enabled-provider model) after Cerebras.
+	// Append opencode entries after Cerebras. A ModelID of "enable:<id>" is a
+	// setup row: the user has not opted into that provider yet, so Enter
+	// should enable it rather than launching opencode on a missing model.
 	for _, m := range openCodeModels {
+		backend, modelID := "opencode", m.ModelID
+		if strings.HasPrefix(m.ModelID, "enable:") {
+			backend = "opencode-enable"
+			modelID = strings.TrimPrefix(m.ModelID, "enable:")
+		}
 		entries = append(entries, pickerEntry{
-			backend:  "opencode",
-			modelID:  m.ModelID,
+			backend:  backend,
+			modelID:  modelID,
 			label:    m.Label,
 			subLabel: m.ProviderName,
 			external: true,
@@ -355,10 +362,15 @@ func (m modelPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 		case msg.String() == "enter", msg.String() == " ":
-			if !m.effortFocus {
-				e := m.allEntries[m.cursor]
-				m.chosen = &e
+			// Enter always confirms the highlighted model plus the current
+			// effort. Tab only switches which keys move (list vs effort bar);
+			// leaving effort focused used to quit with no selection.
+			if len(m.allEntries) == 0 {
+				m.cancelled = true
+				return m, tea.Quit
 			}
+			e := m.allEntries[m.cursor]
+			m.chosen = &e
 			return m, tea.Quit
 
 		default:
@@ -468,16 +480,26 @@ func (m modelPickerModel) View() string {
 		b.WriteByte('\n')
 		ocDot := pickerDotGreen.Render("●")
 		ocStatus := "enabled providers"
+		hasReal := false
+		for _, e := range m.allEntries {
+			if e.backend == "opencode" {
+				hasReal = true
+				break
+			}
+		}
 		if !m.openCodeInstalled {
 			ocDot = pickerDotRed.Render("●")
 			ocStatus = "opencode not installed"
+		} else if !hasReal {
+			ocDot = pickerDotRed.Render("●")
+			ocStatus = "not enabled — Enter to opt in"
 		}
 		sectionLabelOC := fmt.Sprintf("%s  opencode  %s %s",
 			pickerIconOpenCode.Render("◈"), ocDot, pickerBadgeExt.Render(ocStatus))
 		b.WriteString(pickerSectionHeader.Render(sectionLabelOC))
 		b.WriteByte('\n')
 		for i, e := range m.allEntries {
-			if e.backend != "opencode" {
+			if e.backend != "opencode" && e.backend != "opencode-enable" {
 				continue
 			}
 			b.WriteString(m.renderRow(i, e, "opencode"))
@@ -1008,6 +1030,156 @@ func ShowSessionPicker(sessions []SessionPickerItem, activeID string) (string, b
 		return "", false
 	}
 	return final.sessions[final.cursor].ID, true
+}
+
+// ─── Provider picker ──────────────────────────────────────────────────────────
+
+// ProviderPickerItem is one opt-in opencode provider shown by /providers.
+type ProviderPickerItem struct {
+	ID          string
+	DisplayName string
+	Status      string // "available", "enabled", "enabled (no key)", "not entitled"
+	Enabled     bool
+	Allowed     bool
+}
+
+// ProviderPickerResult is returned after the /providers TUI closes.
+type ProviderPickerResult struct {
+	ID        string
+	Confirmed bool
+}
+
+type providerPickerModel struct {
+	items     []ProviderPickerItem
+	cursor    int
+	confirmed bool
+	cancelled bool
+}
+
+func newProviderPickerModel(items []ProviderPickerItem) providerPickerModel {
+	cursor := 0
+	for i, it := range items {
+		if it.Allowed && !it.Enabled {
+			cursor = i
+			break
+		}
+	}
+	return providerPickerModel{items: items, cursor: cursor}
+}
+
+func (m providerPickerModel) Init() tea.Cmd { return nil }
+
+func (m providerPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "esc", "q":
+			m.cancelled = true
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.items)-1 {
+				m.cursor++
+			}
+		case "enter", " ":
+			if len(m.items) == 0 {
+				m.cancelled = true
+				return m, tea.Quit
+			}
+			if !m.items[m.cursor].Allowed {
+				return m, nil
+			}
+			m.confirmed = true
+			return m, tea.Quit
+		default:
+			k := msg.String()
+			if len(k) == 1 && k[0] >= '1' && k[0] <= '9' {
+				n := int(k[0] - '1')
+				if n < len(m.items) {
+					m.cursor = n
+				}
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m providerPickerModel) View() string {
+	var b strings.Builder
+
+	b.WriteString(pickerSectionHeader.Render(
+		fmt.Sprintf("%s  opencode providers", pickerIconOpenCode.Render("◈"))))
+	b.WriteByte('\n')
+	b.WriteString(pickerFooter.Render("  Enable one, then pick a model in /orch"))
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+
+	for i, it := range m.items {
+		isCursor := i == m.cursor
+		arrow := "  "
+		if isCursor {
+			arrow = pickerBadgeStar.Render("▶ ")
+		}
+
+		mark := "○"
+		markStyle := pickerBadgeExt
+		switch {
+		case !it.Allowed:
+			mark = "🔒"
+			markStyle = pickerDotRed
+		case it.Enabled:
+			mark = "●"
+			markStyle = pickerDotGreen
+		}
+
+		name := pickerLabel.Render(it.DisplayName)
+		status := pickerBadgeExt.Render(it.Status)
+		id := pickerFooter.Render(it.ID)
+		if isCursor {
+			name = pickerLabelSel.Render(it.DisplayName)
+			status = menuDescSelSty.Render(it.Status)
+			id = menuDescSelSty.Render(it.ID)
+		}
+
+		row := fmt.Sprintf("%s%s  %s  %s  %s", arrow, markStyle.Render(mark), name, status, id)
+		if isCursor {
+			b.WriteString(pickerRowSelected.Render(row))
+		} else {
+			b.WriteString(pickerRowNormal.Render(row))
+		}
+		b.WriteByte('\n')
+	}
+
+	b.WriteByte('\n')
+	b.WriteString(pickerFooter.Render("  Cerebras is native — select it in /orch"))
+	b.WriteByte('\n')
+	b.WriteString(pickerDivider.Render(strings.Repeat("─", 52)))
+	b.WriteByte('\n')
+	b.WriteString(pickerFooter.Render("↑↓ navigate  ·  1-9 jump  ·  Enter enable  ·  Esc cancel"))
+	b.WriteByte('\n')
+
+	return pickerBox.Render(b.String())
+}
+
+// ShowProviderPicker opens the /providers TUI. Confirmed=false means cancel.
+func ShowProviderPicker(items []ProviderPickerItem) ProviderPickerResult {
+	if len(items) == 0 {
+		return ProviderPickerResult{}
+	}
+	m := newProviderPickerModel(items)
+	p := tea.NewProgram(m)
+	result, err := p.Run()
+	if err != nil {
+		return ProviderPickerResult{}
+	}
+	final := result.(providerPickerModel)
+	if final.cancelled || !final.confirmed {
+		return ProviderPickerResult{}
+	}
+	return ProviderPickerResult{ID: final.items[final.cursor].ID, Confirmed: true}
 }
 
 // ─── Cloud-sync toggle ────────────────────────────────────────────────────────

--- a/internal/tui/tui_backend_cerebras_test.go
+++ b/internal/tui/tui_backend_cerebras_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestPickerIncludesCerebrasEntries(t *testing.T) {
@@ -46,5 +48,108 @@ func TestPickerCerebrasCursorOnCurrent(t *testing.T) {
 	cur := m.allEntries[m.cursor]
 	if cur.backend != "cerebras" || cur.modelID != "zai-glm-4.7" {
 		t.Errorf("cursor on %s/%s, want cerebras/zai-glm-4.7", cur.backend, cur.modelID)
+	}
+}
+
+func TestPickerEnterConfirmsWhileEffortFocused(t *testing.T) {
+	m := newModelPickerModel("cerebras", "gemma-4-31b", "high", "", "", true, true, true, false, nil)
+	m.effortFocus = true
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next, ok := updated.(modelPickerModel)
+	if !ok {
+		t.Fatalf("Update returned %T", updated)
+	}
+	if cmd == nil {
+		t.Fatal("Enter should quit the picker")
+	}
+	if next.chosen == nil {
+		t.Fatal("Enter with effort focused discarded the selection")
+	}
+	if next.chosen.backend != "cerebras" || next.chosen.modelID != "gemma-4-31b" {
+		t.Errorf("chose %s/%s, want cerebras/gemma-4-31b", next.chosen.backend, next.chosen.modelID)
+	}
+	if next.effort != "high" {
+		t.Errorf("effort = %q, want high", next.effort)
+	}
+}
+
+func TestPickerOpenCodeSetupRowsAreEnableActions(t *testing.T) {
+	models := []OpenCodeModelEntry{
+		{ProviderID: "zai-coding-plan", ProviderName: "Enter to enable", ModelID: "enable:zai-coding-plan", Label: "Z.AI Coding Plan"},
+	}
+	m := newModelPickerModel("", "", "high", "", "", true, true, false, true, models)
+	view := m.View()
+	if !strings.Contains(view, "opencode") {
+		t.Fatal("picker missing opencode section for setup rows")
+	}
+	if !strings.Contains(view, "Z.AI Coding Plan") {
+		t.Fatal("picker missing Z.AI setup row")
+	}
+	if !strings.Contains(view, "not enabled") {
+		t.Fatal("picker should say the provider is not enabled yet")
+	}
+	var enable []pickerEntry
+	for _, e := range m.allEntries {
+		if e.backend == "opencode-enable" {
+			enable = append(enable, e)
+		}
+	}
+	if len(enable) != 1 || enable[0].modelID != "zai-coding-plan" {
+		t.Fatalf("setup rows = %#v, want one opencode-enable/zai-coding-plan", enable)
+	}
+}
+
+func TestProviderPickerEnterEnablesHighlighted(t *testing.T) {
+	m := newProviderPickerModel([]ProviderPickerItem{
+		{ID: "zai-coding-plan", DisplayName: "Z.AI Coding Plan", Status: "available", Allowed: true},
+		{ID: "groq", DisplayName: "Groq", Status: "available", Allowed: true},
+		{ID: "openrouter", DisplayName: "OpenRouter", Status: "available", Allowed: true},
+	})
+	if m.cursor != 0 {
+		t.Fatalf("cursor = %d, want first available provider", m.cursor)
+	}
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	next := updated.(providerPickerModel)
+	if next.cursor != 1 {
+		t.Fatalf("after ↓ cursor = %d, want 1 (groq)", next.cursor)
+	}
+	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next = updated.(providerPickerModel)
+	if cmd == nil {
+		t.Fatal("Enter should quit the picker")
+	}
+	if !next.confirmed || next.cancelled {
+		t.Fatal("Enter should confirm the highlighted provider")
+	}
+	if next.items[next.cursor].ID != "groq" {
+		t.Errorf("confirmed %q, want groq", next.items[next.cursor].ID)
+	}
+}
+
+func TestProviderPickerEnterSkipsLocked(t *testing.T) {
+	m := newProviderPickerModel([]ProviderPickerItem{
+		{ID: "groq", DisplayName: "Groq", Status: "not entitled", Allowed: false},
+	})
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	next := updated.(providerPickerModel)
+	if cmd != nil {
+		t.Fatal("Enter on a locked provider should stay in the picker")
+	}
+	if next.confirmed {
+		t.Fatal("locked provider must not confirm")
+	}
+}
+
+func TestProviderPickerViewShowsRows(t *testing.T) {
+	m := newProviderPickerModel([]ProviderPickerItem{
+		{ID: "zai-coding-plan", DisplayName: "Z.AI Coding Plan", Status: "available", Allowed: true},
+		{ID: "groq", DisplayName: "Groq", Status: "enabled", Enabled: true, Allowed: true},
+	})
+	view := m.View()
+	if !strings.Contains(view, "Z.AI Coding Plan") || !strings.Contains(view, "Groq") {
+		t.Fatal("picker missing provider names")
+	}
+	if !strings.Contains(view, "Enter enable") {
+		t.Fatal("picker missing Enter enable hint")
 	}
 }

--- a/internal/tui/tui_backend_cerebras_test.go
+++ b/internal/tui/tui_backend_cerebras_test.go
@@ -108,12 +108,12 @@ func TestProviderPickerEnterEnablesHighlighted(t *testing.T) {
 	if m.cursor != 0 {
 		t.Fatalf("cursor = %d, want first available provider", m.cursor)
 	}
-	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	next := updated.(providerPickerModel)
 	if next.cursor != 1 {
 		t.Fatalf("after ↓ cursor = %d, want 1 (groq)", next.cursor)
 	}
-	updated, cmd = next.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	next = updated.(providerPickerModel)
 	if cmd == nil {
 		t.Fatal("Enter should quit the picker")

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.26.1"
+var Version = "1.27.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
## Summary
- `/providers` is an arrow-key picker (Enter enables and saves). `/orch` Enter always confirms, including when effort is focused, and can opt in OpenCode providers when none are enabled yet.
- README, `AGENTS.md`, and `CLAUDE.md` explain why qmax-code is written in Go: one-file install, six OS/arch binaries, instant startup — not a smarter model.
- Version bump to 1.27.0.

## Test plan
- [ ] `/providers`: ↑/↓ then Enter enables Z.AI / Groq / OpenRouter (key prompt if needed); Esc cancels
- [ ] `/orch` with Tab on High effort: Enter confirms the highlighted model
- [ ] `/orch` with no OpenCode provider enabled: OpenCode section shows enable rows; Enter on Z.AI starts enable flow
- [ ] `go test ./internal/tui/ ./internal/repl/`
- [ ] After merge: tag `v1.27.0` → 6-platform build + public qmax-code-releases publish


Made with [Cursor](https://cursor.com)