### PR TITLE
docs: position qmax-code as the QA terminal, not a faster Claude

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,31 @@ Instructions for coding agents working on qmax-code.
 
 ## What this is
 
-qmax-code is a terminal QA and coding agent. It can run standalone on a local
-repository or connected to QualityMax, and it can host Claude Code, Codex, or
-OpenCode through `/orch` while keeping qmax tools and terminal UX.
+qmax-code is a terminal **QA** agent that can also host coding CLIs. It runs
+standalone on a local repository or connected to QualityMax. Through `/orch`
+it can launch Claude Code, Codex, or OpenCode while keeping qmax tools and
+terminal UX — or run the built-in loop on Anthropic, Cerebras, or Ollama.
 
 This repository is **Go 1.24+**, not TypeScript. The thing users install is one
 compiled binary.
+
+## Positioning (do not oversell)
+
+qmax-code is **not** a faster Claude and **not** an IDE. Cursor owns the
+editor. Claude Code and Codex own general coding in a terminal. qmax-code owns
+QA on the repo (crawl, generate/run tests, review, heal, receipts) and borrows
+those other agents when the job is coding.
+
+- **Go** = one-file install and instant TUI. It does not make tokens faster.
+- **Cerebras** = fast inference (~1000–2000+ tok/s). Models today: GPT-OSS
+  120B, GLM 4.7, Gemma 4. **Qwen 3.8 is coming soon** on Cerebras; do not
+  wire it into `/orch` until the model ID is live on the Cerebras API.
+- **Claude Code / Codex** = judgment for hard design and tricky refactors.
+- **OpenCode** = opt-in providers (Z.AI GLM, Groq, OpenRouter) via
+  `/providers`.
+
+When writing copy or comments, say “the QA terminal that can switch
+inference,” not “faster than Claude.”
 
 ## Why Go
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ terminal UX — or run the built-in loop on Anthropic, Cerebras, or Ollama.
 This repository is **Go 1.24+**, not TypeScript. The thing users install is one
 compiled binary.
 
-## Positioning (do not oversell)
+## Positioning
 
 qmax-code is **not** a faster Claude and **not** an IDE. Cursor owns the
 editor. Claude Code and Codex own general coding in a terminal. qmax-code owns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,20 @@
 # CLAUDE.md
 
-qmax-code is a **Go** terminal agent (Go 1.24+). It ships as one compiled
-binary: `curl | bash` installs a file, not a Node or Python runtime. Claude
-Code, Codex, and OpenCode are separate subprocesses that `/orch` can host;
-they are not this repository's runtime.
+qmax-code is a **Go** terminal **QA** agent (Go 1.24+). It ships as one
+compiled binary: `curl | bash` installs a file, not a Node or Python runtime.
+Claude Code, Codex, and OpenCode are separate subprocesses that `/orch` can
+host; they are not this repository's runtime.
 
-**Why Go (not a smarter model):** one-file install, six OS/arch binaries from
-the same source, instant TUI startup, goroutines for the agent turn / live
-feed / MCP / signals. Do not add npm, pip, or another language runtime as a
-dependency of the CLI itself.
+**Positioning:** not an IDE, not a faster Claude. Cursor owns the editor.
+Claude Code / Codex own hard coding. qmax-code owns QA (tests, crawls, review,
+receipts) and switches inference in `/orch`. **Cerebras** is the fast path
+(~1000–2000+ tok/s: GPT-OSS 120B, GLM 4.7, Gemma 4; **Qwen 3.8 coming soon**).
+Do not add Qwen to the picker until Cerebras publishes the live model ID.
+
+**Why Go (not a smarter or faster model):** one-file install, six OS/arch
+binaries from the same source, instant TUI startup, goroutines for the agent
+turn / live feed / MCP / signals. Do not add npm, pip, or another language
+runtime as a dependency of the CLI itself.
 
 Build and test: `go build -o qmax-code .` then `go test ./...`. Project-wide
 agent instructions: [AGENTS.md](AGENTS.md). Contribution map:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,31 @@ cloud reach a private network). Only hosted QualityMax needs an account.
 > internal use, modification, contribution, education, research, and
 > professional services. Each release converts to Apache 2.0 after two years.
 
+## Where it sits
+
+qmax-code is the **QA terminal next to the repo**, not an editor and not a
+faster Claude. Cursor owns the file buffer. Claude Code and Codex own general
+coding in a terminal. qmax-code owns crawls, tests, review, healing, and
+receipts — and can **host** those other agents through `/orch` when the job is
+coding.
+
+Go makes the binary install once. **Cerebras** makes tokens fast (today:
+GPT-OSS 120B, GLM 4.7, Gemma 4 at ~1000–2000+ tok/s; **Qwen 3.8 coming
+soon**). Claude Code and Codex are the careful path for hard design. Switch
+in `/orch`; do not run two CLIs and two configs.
+
+| Job | Pick |
+| --- | --- |
+| Tests, crawls, coverage, QualityMax projects | qmax-code connected (or `--local` for workspace-only) |
+| Fast loops, bulk generation, cheap iteration | `/orch` → Cerebras |
+| Hard design, tricky refactors | `/orch` → Claude Code or Codex |
+| GLM on a coding plan | `/providers` → Z.AI, then OpenCode in `/orch` |
+| Air-gapped / local weights | Ollama |
+
+Day-to-day: the editor for typing, qmax-code for the agent. Default `/orch`
+to Cerebras or Claude Code depending on whether the next hour is “generate
+and run a lot” or “think hard.”
+
 ## What qmax-code can do
 
 ![Plan, generate, execute, review, and ship, over a local repository lane](docs/img/lifecycle.svg)
@@ -155,9 +180,11 @@ installs like a Unix tool.
 - **Concurrent without extra machinery.** The agent turn, live browser feed,
   signals, and MCP server run as goroutines in one process.
 
-Go does not make the model smarter. Claude Code, Codex, and OpenCode remain
-separate tools that qmax-code can host through `/orch`. Go makes qmax-code
-itself install once and run like `curl`, `git`, or `rg`.
+Go does not make the model smarter, and qmax-code is not faster than Claude
+at thinking. Token speed is the inference backend (Cerebras today; Qwen 3.8
+on Cerebras soon). Claude Code, Codex, and OpenCode remain separate tools
+that qmax-code can host through `/orch`. Go makes qmax-code itself install
+once and run like `curl`, `git`, or `rg`.
 
 ## Quick start
 
@@ -276,7 +303,7 @@ troubleshooting.
 | Anthropic API | `/api` or `/orch` | `ANTHROPIC_API_KEY` or OS keychain | Built-in agent loop; tool set follows connected vs. standalone mode. |
 | Claude Code | `/cc` or `/orch` | Local Claude Code login | CLI subprocess; qmax tools arrive through MCP. Agent SDK usage may be separately metered by Anthropic. |
 | Codex | `/codex` or `/orch` | Local Codex login | CLI subprocess using the user's OpenAI access; qmax tools arrive through MCP. |
-| Cerebras | `/gemma`, `/orch`, or `--backend cerebras` | `CEREBRAS_API_KEY` or OS keychain | Built-in native function calling. Gemma 4 supports images and reasoning effort. |
+| Cerebras | `/gemma`, `/orch`, or `--backend cerebras` | `CEREBRAS_API_KEY` or OS keychain | Built-in native function calling. Fast inference (~1000–2000+ tok/s): GPT-OSS 120B, GLM 4.7, Gemma 4 (vision + effort). **Qwen 3.8 coming soon.** |
 | OpenCode | `/opencode` or `/orch` | Per-provider key in OS keychain | CLI subprocess for opt-in Z.AI, Groq, and OpenRouter providers. |
 | Ollama | `/ollama` or `/orch` | Configured Ollama endpoint | Self-hosted inference; configure the URL and model first. |
 


### PR DESCRIPTION
## Summary
- README, AGENTS.md, and CLAUDE.md now say qmax-code is the QA terminal next to the repo — not an IDE and not a faster Claude.
- Usage table: Cerebras for fast loops, Claude Code/Codex for hard design, OpenCode/Z.AI for GLM plans, Ollama for local weights.
- Cerebras notes current models (GPT-OSS 120B, GLM 4.7, Gemma 4) and **Qwen 3.8 coming soon**. Agents are told not to add Qwen to `/orch` until Cerebras publishes a live model ID.

## Test plan
- [ ] Skim README “Where it sits” + backend guide Cerebras row
- [ ] Skim AGENTS.md positioning and CLAUDE.md intro
- [ ] Confirm no picker/code changes (docs only)


Made with [Cursor](https://cursor.com)