### PR TITLE
docs: show release download count

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 # qmax-code
 
 [![Latest release](https://img.shields.io/github/v/release/Quality-Max/qmax-code?label=release&color=217a45)](https://github.com/Quality-Max/qmax-code/releases/latest)
+[![GitHub downloads](https://img.shields.io/github/downloads/Quality-Max/qmax-code/total?label=downloads)](https://github.com/Quality-Max/qmax-code/releases)
 [![License: FSL-1.1-ALv2](https://img.shields.io/badge/license-FSL--1.1--ALv2-2ea44f.svg)](LICENSE)
 [![Future License: Apache 2.0](https://img.shields.io/badge/future%20license-Apache%202.0-blue.svg)](LICENSE)
 [![Made with Go](https://img.shields.io/badge/made%20with-Go%201.24+-00ADD8.svg)](https://go.dev/)


### PR DESCRIPTION
## What

Add a live cumulative GitHub release-download badge to the qmax-code README.

## Acceptance criteria

- [x] The README displays downloads across all qmax-code release assets and releases.
- [x] The badge links to the qmax-code releases page.

## Validation

- `go build -o /tmp/qmax-code-download-badge-check .` — passed.
- `go vet ./...` — passed.
- `go test ./...` — all packages passed.
- `git diff --check` — passed.
- Shields endpoint — HTTP 200 SVG; currently reports 44 downloads.
- Independent adversarial review — no findings.

## Deployment verification

README-only change. After merge, verify the badge renders on the repository homepage and links to the releases page.

## Known unrelated/non-blocking failures

- `golangci-lint` is not installed in the local environment; the repository CI lint job is authoritative.
- `pre-commit run --all-files` is not applicable because this repository has no `.pre-commit-config.yaml`.
