### PR TITLE
feat: add terminal-neutral Codex runner (QUA-1913)

### DIFF
--- a/codexrunner/continuity.go
+++ b/codexrunner/continuity.go
@@ -1,0 +1,85 @@
+package codexrunner
+
+import (
+	"context"
+	"sync"
+)
+
+// Continuity serializes turns and remembers only the exact validated thread
+// checkpoint. It stores no prompts, responses, source, or provider payloads.
+// Durable callers should also provide Hooks.Checkpoints on every turn.
+type Continuity struct {
+	runner *Runner
+	runMu  sync.Mutex
+	mu     sync.RWMutex
+	state  Checkpoint
+}
+
+// NewContinuity creates an empty continuity adapter for runner.
+func NewContinuity(runner *Runner) *Continuity {
+	return &Continuity{runner: runner}
+}
+
+// Run executes a turn using the current checkpoint and atomically adopts the
+// validated checkpoint emitted by the runner, even if the turn later fails.
+func (continuity *Continuity) Run(ctx Cancellation, prompt string, hooks Hooks) (Result, error) {
+	continuity.runMu.Lock()
+	defer continuity.runMu.Unlock()
+	if continuity.runner == nil {
+		return Result{}, ErrRunnerUnavailable
+	}
+
+	checkpoint := continuity.Checkpoint()
+	externalSink := hooks.Checkpoints
+	hooks.Checkpoints = CheckpointSinkFunc(func(ctx context.Context, next Checkpoint) error {
+		continuity.mu.Lock()
+		continuity.state = next
+		continuity.mu.Unlock()
+		if externalSink != nil {
+			return externalSink.OnCheckpoint(ctx, next)
+		}
+		return nil
+	})
+
+	result, err := continuity.runner.Run(ctx, Turn{
+		Prompt:   prompt,
+		ThreadID: checkpoint.ThreadID,
+		Hooks:    hooks,
+	})
+	if result.ThreadID != "" {
+		continuity.mu.Lock()
+		continuity.state = Checkpoint{ThreadID: result.ThreadID}
+		continuity.mu.Unlock()
+	}
+	return result, err
+}
+
+// Checkpoint returns the current exact continuity state.
+func (continuity *Continuity) Checkpoint() Checkpoint {
+	continuity.mu.RLock()
+	defer continuity.mu.RUnlock()
+	return continuity.state
+}
+
+// Restore validates and installs a durable checkpoint. An empty checkpoint is
+// equivalent to Reset.
+func (continuity *Continuity) Restore(checkpoint Checkpoint) error {
+	continuity.runMu.Lock()
+	defer continuity.runMu.Unlock()
+	if checkpoint.ThreadID != "" && !validThreadID(checkpoint.ThreadID) {
+		return ErrInvalidThreadID
+	}
+	continuity.mu.Lock()
+	continuity.state = checkpoint
+	continuity.mu.Unlock()
+	return nil
+}
+
+// Reset forgets the current thread so the next Run starts a new one.
+func (continuity *Continuity) Reset() {
+	continuity.runMu.Lock()
+	defer continuity.runMu.Unlock()
+	continuity.mu.Lock()
+	continuity.state = Checkpoint{}
+	continuity.mu.Unlock()
+}

--- a/codexrunner/continuity_test.go
+++ b/codexrunner/continuity_test.go
@@ -1,0 +1,54 @@
+package codexrunner
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+)
+
+func TestContinuityStartsResumesAndResetsExactThread(t *testing.T) {
+	executor := &scriptedExecutor{streams: []string{
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID}),
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID}),
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": secondThreadID}),
+	}}
+	continuity := NewContinuity(New(Options{Executor: executor}))
+
+	first, err := continuity.Run(context.Background(), generatedSensitiveValue(t), Hooks{})
+	if err != nil || first.ThreadID != firstThreadID {
+		t.Fatal("continuity did not capture the initial thread")
+	}
+	second, err := continuity.Run(context.Background(), generatedSensitiveValue(t), Hooks{})
+	if err != nil || second.ThreadID != firstThreadID {
+		t.Fatal("continuity did not retain the exact thread")
+	}
+	if !slices.Equal(executor.command(t, 0).args, []string{"exec", "--json", "-"}) {
+		t.Fatal("continuity did not start with the initial command")
+	}
+	if !slices.Equal(executor.command(t, 1).args, []string{"exec", "resume", "--json", firstThreadID, "-"}) {
+		t.Fatal("continuity did not use the exact resume command")
+	}
+
+	continuity.Reset()
+	third, err := continuity.Run(context.Background(), generatedSensitiveValue(t), Hooks{})
+	if err != nil || third.ThreadID != secondThreadID {
+		t.Fatal("reset did not start a fresh thread")
+	}
+	if !slices.Equal(executor.command(t, 2).args, []string{"exec", "--json", "-"}) {
+		t.Fatal("reset reused prior continuity")
+	}
+}
+
+func TestContinuityCheckpointRestoreIsValidated(t *testing.T) {
+	continuity := NewContinuity(New(Options{Executor: &scriptedExecutor{}}))
+	if err := continuity.Restore(Checkpoint{ThreadID: "--last"}); !errors.Is(err, ErrInvalidThreadID) {
+		t.Fatal("restore accepted implicit continuity")
+	}
+	if err := continuity.Restore(Checkpoint{ThreadID: firstThreadID}); err != nil {
+		t.Fatal("restore rejected a canonical checkpoint")
+	}
+	if continuity.Checkpoint().ThreadID != firstThreadID {
+		t.Fatal("restore changed the exact thread ID")
+	}
+}

--- a/codexrunner/doc.go
+++ b/codexrunner/doc.go
@@ -1,0 +1,8 @@
+// Package codexrunner executes Codex CLI turns without depending on qmax-code's
+// terminal or on any private cloud implementation.
+//
+// A first turn always invokes "codex exec --json -". A continued turn always
+// invokes "codex exec resume --json <thread_id> -" with a validated, explicit
+// thread ID. Prompts are supplied only through stdin. Raw provider events and
+// diagnostics are never exposed through the structural event interfaces.
+package codexrunner

--- a/codexrunner/runner.go
+++ b/codexrunner/runner.go
@@ -1,0 +1,462 @@
+package codexrunner
+
+// qmax:allow=os/exec, exec.Command
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+const maxEventBytes = 4 << 20
+
+var (
+	// ErrInvalidThreadID means a caller or stream supplied a non-canonical UUID.
+	ErrInvalidThreadID = errors.New("codex runner: invalid thread ID")
+	// ErrThreadMismatch means a resumed stream identified a different thread.
+	ErrThreadMismatch = errors.New("codex runner: resumed thread does not match checkpoint")
+	// ErrMissingThreadID means the stream ended without a thread.started event.
+	ErrMissingThreadID = errors.New("codex runner: thread ID missing from stream")
+	// ErrMalformedStream means stdout was not a valid Codex JSONL event stream.
+	ErrMalformedStream = errors.New("codex runner: malformed event stream")
+	// ErrStart means the Codex process could not be started.
+	ErrStart = errors.New("codex runner: process start failed")
+	// ErrProcess means Codex exited unsuccessfully.
+	ErrProcess = errors.New("codex runner: process failed")
+	// ErrEventSink means a structural event consumer rejected an event.
+	ErrEventSink = errors.New("codex runner: event sink failed")
+	// ErrCheckpointSink means a checkpoint consumer rejected a checkpoint.
+	ErrCheckpointSink = errors.New("codex runner: checkpoint sink failed")
+	// ErrPresenter means the response presenter rejected an update.
+	ErrPresenter = errors.New("codex runner: presenter failed")
+	// ErrRunnerUnavailable means a Continuity was created without a Runner.
+	ErrRunnerUnavailable = errors.New("codex runner: runner unavailable")
+)
+
+// EventKind identifies a safe structural lifecycle event. Events intentionally
+// contain no prompt, response, source, tool arguments, provider message, or raw
+// JSON payload.
+type EventKind uint8
+
+const (
+	EventThreadStarted EventKind = iota + 1
+	EventTurnStarted
+	EventAssistantMessage
+	EventTurnCompleted
+	EventProviderError
+	EventPlanLimit
+)
+
+// Usage is aggregate token accounting reported by Codex for one turn.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
+// Event is safe for lifecycle observation and metrics. It never contains raw
+// provider content.
+type Event struct {
+	Kind  EventKind
+	Usage Usage
+}
+
+// EventSink consumes structural runner events.
+type EventSink interface {
+	OnEvent(context.Context, Event) error
+}
+
+// EventSinkFunc adapts a function to EventSink.
+type EventSinkFunc func(context.Context, Event) error
+
+// OnEvent implements EventSink.
+func (f EventSinkFunc) OnEvent(ctx context.Context, event Event) error {
+	return f(ctx, event)
+}
+
+// Checkpoint is the minimum durable state required to continue a Codex thread.
+type Checkpoint struct {
+	ThreadID string
+}
+
+// CheckpointSink persists a validated checkpoint as soon as thread.started is
+// observed, including when the turn later fails or is canceled.
+type CheckpointSink interface {
+	OnCheckpoint(context.Context, Checkpoint) error
+}
+
+// CheckpointSinkFunc adapts a function to CheckpointSink.
+type CheckpointSinkFunc func(context.Context, Checkpoint) error
+
+// OnCheckpoint implements CheckpointSink.
+func (f CheckpointSinkFunc) OnCheckpoint(ctx context.Context, checkpoint Checkpoint) error {
+	return f(ctx, checkpoint)
+}
+
+// PresentationKind distinguishes response text from a sanitized provider
+// notice. PresentationText contains model output and must be rendered directly,
+// not logged or copied into metrics.
+type PresentationKind uint8
+
+const (
+	PresentationText PresentationKind = iota + 1
+	PresentationPlanLimit
+)
+
+// Presentation is the only callback value that may contain response text.
+type Presentation struct {
+	Kind PresentationKind
+	Text string
+}
+
+// Presenter is the terminal-neutral rendering boundary. Cloud callers may omit
+// it and consume Result.Response through their protected artifact boundary.
+type Presenter interface {
+	Present(context.Context, Presentation) error
+}
+
+// PresenterFunc adapts a function to Presenter.
+type PresenterFunc func(context.Context, Presentation) error
+
+// Present implements Presenter.
+func (f PresenterFunc) Present(ctx context.Context, presentation Presentation) error {
+	return f(ctx, presentation)
+}
+
+// Cancellation is the runner's cancellation boundary. A standard
+// context.Context satisfies it, preserving deadlines and process teardown
+// without coupling callers to a terminal implementation.
+type Cancellation interface {
+	context.Context
+}
+
+// Command describes one direct process invocation. Stdin carries the prompt;
+// Args is always one of the two fixed command shapes documented by this
+// package. Stderr is deliberately absent so raw diagnostics cannot be logged.
+type Command struct {
+	Executable       string
+	Args             []string
+	Stdin            io.Reader
+	WorkingDirectory string
+}
+
+// ToolProcess is the minimal process boundary required by Runner.
+type ToolProcess interface {
+	Stdout() io.Reader
+	Wait() error
+}
+
+// ToolExecutor starts Codex without coupling the runner to a terminal or a
+// particular process host.
+type ToolExecutor interface {
+	Start(context.Context, Command) (ToolProcess, error)
+}
+
+// Options configures an immutable Runner.
+type Options struct {
+	Executable       string
+	WorkingDirectory string
+	Executor         ToolExecutor
+}
+
+// Hooks are optional per-turn observation and presentation boundaries.
+type Hooks struct {
+	Events      EventSink
+	Checkpoints CheckpointSink
+	Presenter   Presenter
+}
+
+// Turn contains the sensitive prompt and an optional exact continuity ID.
+// Callers must not log this value.
+type Turn struct {
+	Prompt   string
+	ThreadID string
+	Hooks    Hooks
+}
+
+// Result contains the exact validated Codex thread ID and response. Response is
+// transcript data and must not be logged or placed in workflow history.
+type Result struct {
+	ThreadID  string
+	Response  string
+	Usage     Usage
+	Canceled  bool
+	PlanLimit bool
+}
+
+// Runner executes terminal-neutral Codex turns.
+type Runner struct {
+	executable       string
+	workingDirectory string
+	executor         ToolExecutor
+}
+
+// New returns a runner. An empty executable uses "codex" and a nil executor
+// uses the local OS process implementation.
+func New(options Options) *Runner {
+	executable := options.Executable
+	if executable == "" {
+		executable = "codex"
+	}
+	executor := options.Executor
+	if executor == nil {
+		executor = OSExecutor{}
+	}
+	return &Runner{
+		executable:       executable,
+		workingDirectory: options.WorkingDirectory,
+		executor:         executor,
+	}
+}
+
+// Run executes one turn. Cancellation is controlled exclusively by ctx.
+func (r *Runner) Run(ctx Cancellation, turn Turn) (Result, error) {
+	var result Result
+	if r == nil || r.executor == nil {
+		return result, ErrRunnerUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		result.Canceled = true
+		return result, err
+	}
+	if turn.ThreadID != "" && !validThreadID(turn.ThreadID) {
+		return result, ErrInvalidThreadID
+	}
+
+	args := []string{"exec", "--json", "-"}
+	if turn.ThreadID != "" {
+		args = []string{"exec", "resume", "--json", turn.ThreadID, "-"}
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	process, err := r.executor.Start(runCtx, Command{
+		Executable:       r.executable,
+		Args:             append([]string(nil), args...),
+		Stdin:            strings.NewReader(turn.Prompt),
+		WorkingDirectory: r.workingDirectory,
+	})
+	if err != nil {
+		if ctx.Err() != nil {
+			result.Canceled = true
+			return result, ctx.Err()
+		}
+		return result, ErrStart
+	}
+
+	var response strings.Builder
+	var streamErr error
+	scanner := bufio.NewScanner(process.Stdout())
+	scanner.Buffer(make([]byte, 64<<10), maxEventBytes)
+	for scanner.Scan() {
+		var event wireEvent
+		if json.Unmarshal(scanner.Bytes(), &event) != nil {
+			streamErr = ErrMalformedStream
+			break
+		}
+		if err := r.handleEvent(runCtx, turn, event, &result, &response); err != nil {
+			streamErr = err
+			break
+		}
+	}
+	if streamErr == nil && scanner.Err() != nil {
+		streamErr = ErrMalformedStream
+	}
+	if streamErr != nil {
+		cancel()
+	}
+	waitErr := process.Wait()
+
+	result.Response = strings.TrimSpace(response.String())
+	if ctx.Err() != nil {
+		result.Canceled = true
+		return result, ctx.Err()
+	}
+	if streamErr != nil {
+		return result, streamErr
+	}
+	if waitErr != nil {
+		return result, ErrProcess
+	}
+	if result.ThreadID == "" {
+		return result, ErrMissingThreadID
+	}
+	return result, nil
+}
+
+func (r *Runner) handleEvent(ctx context.Context, turn Turn, event wireEvent, result *Result, response *strings.Builder) error {
+	switch event.Type {
+	case "thread.started":
+		if !validThreadID(event.ThreadID) {
+			return ErrInvalidThreadID
+		}
+		if turn.ThreadID != "" && event.ThreadID != turn.ThreadID {
+			return ErrThreadMismatch
+		}
+		if result.ThreadID != "" && event.ThreadID != result.ThreadID {
+			return ErrThreadMismatch
+		}
+		if result.ThreadID == "" {
+			result.ThreadID = event.ThreadID
+			if turn.Hooks.Checkpoints != nil {
+				if err := turn.Hooks.Checkpoints.OnCheckpoint(ctx, Checkpoint{ThreadID: event.ThreadID}); err != nil {
+					return ErrCheckpointSink
+				}
+			}
+		}
+		return emitEvent(ctx, turn.Hooks.Events, Event{Kind: EventThreadStarted})
+	case "turn.started":
+		return emitEvent(ctx, turn.Hooks.Events, Event{Kind: EventTurnStarted})
+	case "item.completed":
+		if event.Item.Type != "agent_message" {
+			return nil
+		}
+		if turn.Hooks.Presenter != nil {
+			if err := turn.Hooks.Presenter.Present(ctx, Presentation{Kind: PresentationText, Text: event.Item.Text}); err != nil {
+				return ErrPresenter
+			}
+		}
+		response.WriteString(event.Item.Text)
+		response.WriteByte('\n')
+		return emitEvent(ctx, turn.Hooks.Events, Event{Kind: EventAssistantMessage})
+	case "turn.completed":
+		result.Usage = event.tokenUsage()
+		return emitEvent(ctx, turn.Hooks.Events, Event{Kind: EventTurnCompleted, Usage: result.Usage})
+	default:
+		if !event.isError() {
+			return nil
+		}
+		if err := emitEvent(ctx, turn.Hooks.Events, Event{Kind: EventProviderError}); err != nil {
+			return err
+		}
+		if !event.isPlanLimit() || result.PlanLimit {
+			return nil
+		}
+		result.PlanLimit = true
+		if err := emitEvent(ctx, turn.Hooks.Events, Event{Kind: EventPlanLimit}); err != nil {
+			return err
+		}
+		if turn.Hooks.Presenter != nil {
+			if err := turn.Hooks.Presenter.Present(ctx, Presentation{Kind: PresentationPlanLimit}); err != nil {
+				return ErrPresenter
+			}
+		}
+		return nil
+	}
+}
+
+func emitEvent(ctx context.Context, sink EventSink, event Event) error {
+	if sink == nil {
+		return nil
+	}
+	if err := sink.OnEvent(ctx, event); err != nil {
+		return ErrEventSink
+	}
+	return nil
+}
+
+type wireEvent struct {
+	Type     string          `json:"type"`
+	ThreadID string          `json:"thread_id"`
+	Message  string          `json:"message"`
+	Error    json.RawMessage `json:"error"`
+	Item     struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"item"`
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+	Usage        *struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+		Input        int `json:"input"`
+		Output       int `json:"output"`
+	} `json:"usage"`
+}
+
+func (event wireEvent) tokenUsage() Usage {
+	usage := Usage{InputTokens: event.InputTokens, OutputTokens: event.OutputTokens}
+	if event.Usage == nil {
+		return usage
+	}
+	if event.Usage.InputTokens > 0 || event.Usage.OutputTokens > 0 {
+		return Usage{InputTokens: event.Usage.InputTokens, OutputTokens: event.Usage.OutputTokens}
+	}
+	return Usage{InputTokens: event.Usage.Input, OutputTokens: event.Usage.Output}
+}
+
+func (event wireEvent) isError() bool {
+	return strings.Contains(strings.ToLower(event.Type), "error") || len(event.Error) > 0
+}
+
+func (event wireEvent) isPlanLimit() bool {
+	message := event.Message
+	if len(event.Error) > 0 {
+		var text string
+		if json.Unmarshal(event.Error, &text) == nil {
+			message += " " + text
+		} else {
+			var detail struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			}
+			if json.Unmarshal(event.Error, &detail) == nil {
+				message += " " + detail.Message + " " + detail.Code
+			}
+		}
+	}
+	message = strings.ToLower(message)
+	for _, marker := range []string{"plan limit", "usage limit", "rate limit", "quota", "too many requests"} {
+		if strings.Contains(message, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func validThreadID(id string) bool {
+	if len(id) != 36 || id[8] != '-' || id[13] != '-' || id[18] != '-' || id[23] != '-' {
+		return false
+	}
+	for index := range id {
+		if index == 8 || index == 13 || index == 18 || index == 23 {
+			continue
+		}
+		character := id[index]
+		if !((character >= '0' && character <= '9') || (character >= 'a' && character <= 'f') || (character >= 'A' && character <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+// OSExecutor starts the local Codex executable directly, without a shell.
+// Stderr is discarded because provider diagnostics may contain sensitive data.
+type OSExecutor struct{}
+
+// Start implements ToolExecutor.
+func (OSExecutor) Start(ctx context.Context, command Command) (ToolProcess, error) {
+	cmd := exec.CommandContext(ctx, command.Executable, command.Args...)
+	cmd.Dir = command.WorkingDirectory
+	cmd.Stdin = command.Stdin
+	cmd.Stderr = io.Discard
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &osProcess{cmd: cmd, stdout: stdout}, nil
+}
+
+type osProcess struct {
+	cmd    *exec.Cmd
+	stdout io.Reader
+}
+
+func (process *osProcess) Stdout() io.Reader { return process.stdout }
+func (process *osProcess) Wait() error       { return process.cmd.Wait() }

--- a/codexrunner/runner_test.go
+++ b/codexrunner/runner_test.go
@@ -1,0 +1,408 @@
+package codexrunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const (
+	firstThreadID  = "abcdef12-3456-4abc-8def-1234567890ab"
+	secondThreadID = "12345678-90ab-4cde-8fab-1234567890ab"
+)
+
+func TestRunnerInitialTurnCapturesExactThreadID(t *testing.T) {
+	prompt := generatedSensitiveValue(t)
+	response := strings.ToUpper(t.Name())
+	executor := &scriptedExecutor{streams: []string{eventStream(t,
+		map[string]any{"type": "thread.started", "thread_id": firstThreadID},
+		map[string]any{"type": "turn.started"},
+		map[string]any{"type": "item.completed", "item": map[string]any{"type": "agent_message", "text": response}},
+		map[string]any{"type": "turn.completed", "usage": map[string]any{"input_tokens": 7, "output_tokens": 3}},
+	)}}
+
+	result, err := New(Options{Executable: "codex-test", WorkingDirectory: t.TempDir(), Executor: executor}).Run(context.Background(), Turn{Prompt: prompt})
+	if err != nil {
+		t.Fatal("initial turn failed")
+	}
+	if result.ThreadID != firstThreadID {
+		t.Fatal("runner did not return the exact thread ID")
+	}
+	if result.Response != response {
+		t.Fatal("runner did not return the assistant response")
+	}
+	if result.Usage != (Usage{InputTokens: 7, OutputTokens: 3}) {
+		t.Fatal("runner did not capture turn usage")
+	}
+	command := executor.command(t, 0)
+	if command.executable != "codex-test" || !slices.Equal(command.args, []string{"exec", "--json", "-"}) {
+		t.Fatal("initial command shape changed")
+	}
+	if command.stdin != prompt {
+		t.Fatal("prompt was not sent exactly through stdin")
+	}
+	assertPromptAbsent(t, prompt, command.args, err)
+}
+
+func TestRunnerResumeUsesExactThreadID(t *testing.T) {
+	prompt := generatedSensitiveValue(t)
+	executor := &scriptedExecutor{streams: []string{eventStream(t,
+		map[string]any{"type": "thread.started", "thread_id": firstThreadID},
+	)}}
+
+	result, err := New(Options{Executor: executor}).Run(context.Background(), Turn{Prompt: prompt, ThreadID: firstThreadID})
+	if err != nil {
+		t.Fatal("resume turn failed")
+	}
+	if result.ThreadID != firstThreadID {
+		t.Fatal("resume changed the thread ID")
+	}
+	command := executor.command(t, 0)
+	want := []string{"exec", "resume", "--json", firstThreadID, "-"}
+	if !slices.Equal(command.args, want) {
+		t.Fatal("resume command shape changed")
+	}
+	if slices.Contains(command.args, "--last") {
+		t.Fatal("resume command used forbidden implicit continuity")
+	}
+	if command.stdin != prompt {
+		t.Fatal("resume prompt was not sent exactly through stdin")
+	}
+	assertPromptAbsent(t, prompt, command.args, err)
+}
+
+func TestRunnerRejectsImplicitOrMismatchedContinuity(t *testing.T) {
+	t.Run("option-like ID", func(t *testing.T) {
+		executor := &scriptedExecutor{}
+		_, err := New(Options{Executor: executor}).Run(context.Background(), Turn{ThreadID: "--last"})
+		if !errors.Is(err, ErrInvalidThreadID) {
+			t.Fatal("option-like thread ID was not rejected")
+		}
+		if executor.commandCount() != 0 {
+			t.Fatal("invalid thread ID reached the process boundary")
+		}
+	})
+
+	t.Run("stream mismatch", func(t *testing.T) {
+		executor := &scriptedExecutor{streams: []string{eventStream(t,
+			map[string]any{"type": "thread.started", "thread_id": secondThreadID},
+		)}}
+		_, err := New(Options{Executor: executor}).Run(context.Background(), Turn{ThreadID: firstThreadID})
+		if !errors.Is(err, ErrThreadMismatch) {
+			t.Fatal("mismatched resumed thread was not rejected")
+		}
+	})
+}
+
+func TestRunnerFailsClosedOnMalformedStreams(t *testing.T) {
+	prompt := generatedSensitiveValue(t)
+	malformed := strings.Repeat("{", 3)
+	executor := &scriptedExecutor{streams: []string{
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID}) + malformed + "\n",
+	}}
+
+	result, err := New(Options{Executor: executor}).Run(context.Background(), Turn{Prompt: prompt})
+	if !errors.Is(err, ErrMalformedStream) {
+		t.Fatal("malformed JSONL was not rejected")
+	}
+	if result.ThreadID != firstThreadID {
+		t.Fatal("validated checkpoint was not retained before stream failure")
+	}
+	assertPromptAbsent(t, prompt, executor.command(t, 0).args, err)
+	if strings.Contains(err.Error(), malformed) {
+		t.Fatal("malformed provider payload escaped through the error boundary")
+	}
+}
+
+func TestRunnerSanitizesProcessFailures(t *testing.T) {
+	prompt := generatedSensitiveValue(t)
+	t.Run("start", func(t *testing.T) {
+		executor := &scriptedExecutor{startErr: errors.New(prompt)}
+
+		_, err := New(Options{Executor: executor}).Run(context.Background(), Turn{Prompt: prompt})
+		if !errors.Is(err, ErrStart) {
+			t.Fatal("start failure did not use the public sentinel")
+		}
+		assertPromptAbsent(t, prompt, executor.command(t, 0).args, err)
+	})
+
+	t.Run("wait", func(t *testing.T) {
+		executor := &scriptedExecutor{
+			streams:    []string{eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID})},
+			waitErrors: []error{errors.New(prompt)},
+		}
+
+		result, err := New(Options{Executor: executor}).Run(context.Background(), Turn{Prompt: prompt})
+		if !errors.Is(err, ErrProcess) {
+			t.Fatal("process failure did not use the public sentinel")
+		}
+		if result.ThreadID != firstThreadID {
+			t.Fatal("process failure lost the validated checkpoint")
+		}
+		assertPromptAbsent(t, prompt, executor.command(t, 0).args, err)
+	})
+}
+
+func TestRunnerRequiresAThreadCheckpoint(t *testing.T) {
+	executor := &scriptedExecutor{streams: []string{eventStream(t,
+		map[string]any{"type": "turn.started"},
+		map[string]any{"type": "turn.completed"},
+	)}}
+
+	_, err := New(Options{Executor: executor}).Run(context.Background(), Turn{})
+	if !errors.Is(err, ErrMissingThreadID) {
+		t.Fatal("stream without a thread checkpoint was accepted")
+	}
+}
+
+func TestRunnerCancellationReapsTheTurn(t *testing.T) {
+	prompt := generatedSensitiveValue(t)
+	executor := newCancelExecutor(t, firstThreadID)
+	ctx, cancel := context.WithCancel(context.Background())
+	type outcome struct {
+		result Result
+		err    error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result, err := New(Options{Executor: executor}).Run(ctx, Turn{Prompt: prompt})
+		done <- outcome{result: result, err: err}
+	}()
+
+	<-executor.started
+	cancel()
+	got := <-done
+	if !errors.Is(got.err, context.Canceled) || !got.result.Canceled {
+		t.Fatal("context cancellation was not returned as a canceled result")
+	}
+	if got.result.ThreadID != firstThreadID {
+		t.Fatal("cancellation lost the checkpoint captured before interruption")
+	}
+	assertPromptAbsent(t, prompt, executor.command.args, got.err)
+}
+
+func TestRunnerAlreadyCanceledDoesNotStart(t *testing.T) {
+	executor := &scriptedExecutor{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := New(Options{Executor: executor}).Run(ctx, Turn{Prompt: generatedSensitiveValue(t)})
+	if !errors.Is(err, context.Canceled) || !result.Canceled {
+		t.Fatal("already-canceled turn did not return cancellation")
+	}
+	if executor.commandCount() != 0 {
+		t.Fatal("already-canceled turn crossed the process boundary")
+	}
+}
+
+func TestRunnerHooksSeparateStructureFromPresentation(t *testing.T) {
+	response := strings.ToUpper(t.Name())
+	executor := &scriptedExecutor{streams: []string{eventStream(t,
+		map[string]any{"type": "thread.started", "thread_id": firstThreadID},
+		map[string]any{"type": "item.completed", "item": map[string]any{"type": "agent_message", "text": response}},
+	)}}
+	var events []Event
+	var presentations []Presentation
+	result, err := New(Options{Executor: executor}).Run(context.Background(), Turn{Hooks: Hooks{
+		Events: EventSinkFunc(func(_ context.Context, event Event) error {
+			events = append(events, event)
+			return nil
+		}),
+		Presenter: PresenterFunc(func(_ context.Context, presentation Presentation) error {
+			presentations = append(presentations, presentation)
+			return nil
+		}),
+	}})
+	if err != nil || result.Response != response {
+		t.Fatal("hooked turn failed")
+	}
+	if len(events) != 2 || events[0].Kind != EventThreadStarted || events[1].Kind != EventAssistantMessage {
+		t.Fatal("structural event sequence changed")
+	}
+	if len(presentations) != 1 || presentations[0] != (Presentation{Kind: PresentationText, Text: response}) {
+		t.Fatal("response did not remain inside the presentation boundary")
+	}
+}
+
+func TestRunnerSanitizesPlanLimitPresentation(t *testing.T) {
+	providerMessage := generatedSensitiveValue(t) + " quota"
+	executor := &scriptedExecutor{streams: []string{eventStream(t,
+		map[string]any{"type": "thread.started", "thread_id": firstThreadID},
+		map[string]any{"type": "error", "message": providerMessage},
+	)}}
+	var events []Event
+	var presentations []Presentation
+
+	result, err := New(Options{Executor: executor}).Run(context.Background(), Turn{Hooks: Hooks{
+		Events: EventSinkFunc(func(_ context.Context, event Event) error {
+			events = append(events, event)
+			return nil
+		}),
+		Presenter: PresenterFunc(func(_ context.Context, presentation Presentation) error {
+			presentations = append(presentations, presentation)
+			return nil
+		}),
+	}})
+	if err != nil || !result.PlanLimit {
+		t.Fatal("plan-limit event was not classified")
+	}
+	wantEvents := []EventKind{EventThreadStarted, EventProviderError, EventPlanLimit}
+	if len(events) != len(wantEvents) {
+		t.Fatal("plan-limit structural event count changed")
+	}
+	for index, want := range wantEvents {
+		if events[index].Kind != want {
+			t.Fatal("plan-limit structural event sequence changed")
+		}
+	}
+	if len(presentations) != 1 || presentations[0] != (Presentation{Kind: PresentationPlanLimit}) {
+		t.Fatal("provider payload crossed the sanitized plan-limit presentation boundary")
+	}
+	if strings.Contains(result.Response, providerMessage) {
+		t.Fatal("provider payload crossed the result boundary")
+	}
+}
+
+type recordedCommand struct {
+	executable       string
+	args             []string
+	stdin            string
+	workingDirectory string
+}
+
+type scriptedExecutor struct {
+	mu         sync.Mutex
+	streams    []string
+	waitErrors []error
+	startErr   error
+	commands   []recordedCommand
+}
+
+func (executor *scriptedExecutor) Start(_ context.Context, command Command) (ToolProcess, error) {
+	input, readErr := io.ReadAll(command.Stdin)
+	if readErr != nil {
+		return nil, readErr
+	}
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	executor.commands = append(executor.commands, recordedCommand{
+		executable:       command.Executable,
+		args:             append([]string(nil), command.Args...),
+		stdin:            string(input),
+		workingDirectory: command.WorkingDirectory,
+	})
+	if executor.startErr != nil {
+		return nil, executor.startErr
+	}
+	index := len(executor.commands) - 1
+	if index >= len(executor.streams) {
+		return nil, errors.New("test stream unavailable")
+	}
+	var waitErr error
+	if index < len(executor.waitErrors) {
+		waitErr = executor.waitErrors[index]
+	}
+	return staticProcess{stdout: strings.NewReader(executor.streams[index]), waitErr: waitErr}, nil
+}
+
+func (executor *scriptedExecutor) command(t *testing.T, index int) recordedCommand {
+	t.Helper()
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if index >= len(executor.commands) {
+		t.Fatal("expected command was not recorded")
+	}
+	return executor.commands[index]
+}
+
+func (executor *scriptedExecutor) commandCount() int {
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	return len(executor.commands)
+}
+
+type staticProcess struct {
+	stdout  io.Reader
+	waitErr error
+}
+
+func (process staticProcess) Stdout() io.Reader { return process.stdout }
+func (process staticProcess) Wait() error       { return process.waitErr }
+
+type cancelExecutor struct {
+	testing *testing.T
+	id      string
+	started chan struct{}
+	command recordedCommand
+}
+
+func newCancelExecutor(t *testing.T, id string) *cancelExecutor {
+	return &cancelExecutor{testing: t, id: id, started: make(chan struct{})}
+}
+
+func (executor *cancelExecutor) Start(ctx context.Context, command Command) (ToolProcess, error) {
+	input, err := io.ReadAll(command.Stdin)
+	if err != nil {
+		return nil, err
+	}
+	executor.command = recordedCommand{args: append([]string(nil), command.Args...), stdin: string(input)}
+	reader, writer := io.Pipe()
+	ready := make(chan struct{})
+	go func() {
+		defer writer.Close()
+		_, _ = io.WriteString(writer, eventStream(executor.testing, map[string]any{"type": "thread.started", "thread_id": executor.id}))
+		close(ready)
+		<-ctx.Done()
+	}()
+	go func() {
+		<-ready
+		close(executor.started)
+	}()
+	return &cancelProcess{stdout: reader, ctx: ctx}, nil
+}
+
+type cancelProcess struct {
+	stdout io.Reader
+	ctx    context.Context
+}
+
+func (process *cancelProcess) Stdout() io.Reader { return process.stdout }
+func (process *cancelProcess) Wait() error {
+	<-process.ctx.Done()
+	return process.ctx.Err()
+}
+
+func eventStream(t *testing.T, events ...map[string]any) string {
+	t.Helper()
+	var stream bytes.Buffer
+	encoder := json.NewEncoder(&stream)
+	for _, event := range events {
+		if err := encoder.Encode(event); err != nil {
+			t.Fatal("could not construct synthetic event stream")
+		}
+	}
+	return stream.String()
+}
+
+func generatedSensitiveValue(t *testing.T) string {
+	t.Helper()
+	return strings.Repeat(t.Name(), 2)
+}
+
+func assertPromptAbsent(t *testing.T, prompt string, args []string, err error) {
+	t.Helper()
+	for _, arg := range args {
+		if strings.Contains(arg, prompt) {
+			t.Fatal("prompt escaped into process arguments")
+		}
+	}
+	if err != nil && strings.Contains(err.Error(), prompt) {
+		t.Fatal("prompt escaped into a public error")
+	}
+}

--- a/internal/agent/cc_agent.go
+++ b/internal/agent/cc_agent.go
@@ -29,6 +29,12 @@ type CLIAgent interface {
 	Cleanup()
 }
 
+// ConversationResetter is implemented by CLI backends that keep native
+// conversation continuity outside the built-in agent history.
+type ConversationResetter interface {
+	ResetConversation()
+}
+
 // TurnStatsProvider is optionally implemented by CLI agents that can report
 // token usage for their most recent Run. The REPL folds these numbers into
 // the session totals shown in the input status bar; backends whose stream
@@ -72,9 +78,9 @@ type CCAgent struct {
 	mcpConfigPath  string // temp MCP config written once per qmax session
 	mcpConfigInfo  os.FileInfo
 	sctx           *api.SessionContext
-	lastToolName   string // track last tool name for result display
+	lastToolName   string                  // track last tool name for result display
 	fileSnaps      map[string]fileSnapshot // CC tool_use id → pre-edit snapshot
-	lastTurnIn     int    // token usage of the most recent turn (from CC's result event)
+	lastTurnIn     int                     // token usage of the most recent turn (from CC's result event)
 	lastTurnOut    int
 	lastTurnOK     bool // true once a result event carried usage this turn
 	mu             sync.Mutex

--- a/internal/agent/cc_agent_session_test.go
+++ b/internal/agent/cc_agent_session_test.go
@@ -189,12 +189,12 @@ func TestOutputStyleDirectiveModes(t *testing.T) {
 
 func TestCodexBuildPromptReflectsOutputVerbose(t *testing.T) {
 	a := &CodexAgent{effort: "high", outputVerbose: false, sctx: &api.SessionContext{}}
-	if !strings.Contains(a.buildPrompt("hi"), "OUTPUT MODE: COMPACT") {
+	if !strings.Contains(a.buildPrompt("hi", true), "OUTPUT MODE: COMPACT") {
 		t.Fatal("compact directive not in built prompt")
 	}
 
 	a.SetOutputVerbose(true)
-	if !strings.Contains(a.buildPrompt("hi"), "OUTPUT MODE: VERBOSE") {
+	if !strings.Contains(a.buildPrompt("hi", true), "OUTPUT MODE: VERBOSE") {
 		t.Fatal("SetOutputVerbose(true) did not propagate into the built prompt")
 	}
 }

--- a/internal/agent/codex_agent.go
+++ b/internal/agent/codex_agent.go
@@ -1,17 +1,15 @@
 package agent
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/qualitymax/qmax-code/codexrunner"
 	"github.com/qualitymax/qmax-code/internal/api"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
 	"github.com/qualitymax/qmax-code/internal/tui"
@@ -24,35 +22,25 @@ import (
 //
 // Per-message flow:
 //  1. qmax-code writes ~/.codex/config.toml with the qmax MCP server entry
-//  2. qmax-code spawns: codex exec --json [--dangerously-bypass-approvals-and-sandbox] "msg"
+//  2. qmax-code starts or resumes a Codex thread through codexrunner
 //  3. Codex picks up the MCP config and spawns qmax-code serve --mcp
 //  4. Codex uses qmax tools natively, runs on OpenAI subscription
 //  5. qmax-code streams Codex's stdout to the terminal
-//
-// Unlike CCAgent, Codex does not expose a rich stream-json format, so output
-// is captured as plain text. History is managed by qmax-code itself (passed
-// as context in the system/user turn) since Codex has no --resume equivalent.
 type CodexAgent struct {
 	codexBin       string
-	modelID        string // "" = codex default; otherwise passed as -m
 	effort         string // "low" | "medium" | "high"
 	outputVerbose  bool   // false = compact answer style; true = previous detailed style
-	permissionMode string // "standard" (Codex prompts per-action) | "unattended" (--dangerously-bypass-approvals-and-sandbox)
 	sctx           *api.SessionContext
-	history        []codexTurn // conversation history managed on our side
-	lastTurnIn     int         // token usage of the most recent turn, when codex reports it
+	continuity     *codexrunner.Continuity
+	lastTurnIn     int // token usage of the most recent turn, when codex reports it
 	lastTurnOut    int
 	lastTurnOK     bool
 	lastLimitHit   bool      // true if the plan limit was hit this turn
 	lastLimitReset time.Time // provider-reported reset (usually zero for codex)
 	mu             sync.Mutex
+	turnMu         sync.Mutex // keeps checkpoint selection and execution atomic
 	runMu          sync.Mutex
 	runCancel      context.CancelFunc // non-nil while Run() is active
-}
-
-type codexTurn struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
 }
 
 // FindCodex returns the path to the codex CLI binary, or "" if not installed.
@@ -73,26 +61,19 @@ func FindCodex() string {
 	return ""
 }
 
-// NewCodexAgent creates a Codex subprocess orchestrator.
-// modelID is passed as -m to the codex CLI (empty = codex default).
-// effort is "low" | "medium" | "high" (empty defaults to "high").
-// permissionMode is "standard" or "unattended" — Codex has no allowlist primitive,
-// so Standard relies on Codex's own sandbox policy and Unattended adds
-// --dangerously-bypass-approvals-and-sandbox.
-func NewCodexAgent(bin, modelID, effort, permissionMode string, outputVerbose bool, sctx *api.SessionContext) *CodexAgent {
+// NewCodexAgent creates a Codex subprocess orchestrator. Model, approval, and
+// sandbox choices come from Codex's own configuration because the public
+// runner intentionally uses a fixed command line.
+func NewCodexAgent(bin, effort string, outputVerbose bool, sctx *api.SessionContext) *CodexAgent {
 	if effort == "" {
 		effort = "high"
 	}
-	if permissionMode == "" {
-		permissionMode = "standard"
-	}
 	return &CodexAgent{
-		codexBin:       bin,
-		modelID:        modelID,
-		effort:         effort,
-		outputVerbose:  outputVerbose,
-		permissionMode: permissionMode,
-		sctx:           sctx,
+		codexBin:      bin,
+		effort:        effort,
+		outputVerbose: outputVerbose,
+		sctx:          sctx,
+		continuity:    codexrunner.NewContinuity(codexrunner.New(codexrunner.Options{Executable: bin})),
 	}
 }
 
@@ -151,6 +132,9 @@ End each response with the next highest-impact action.
 
 // Run executes one conversation turn through a Codex subprocess.
 func (a *CodexAgent) Run(userMsg string, term *tui.Terminal) (string, error) {
+	a.turnMu.Lock()
+	defer a.turnMu.Unlock()
+
 	if err := a.WriteMCPConfig(); err != nil {
 		return "", fmt.Errorf("MCP config: %w", err)
 	}
@@ -160,17 +144,9 @@ func (a *CodexAgent) Run(userMsg string, term *tui.Terminal) (string, error) {
 	a.lastLimitHit, a.lastLimitReset = false, time.Time{}
 	a.mu.Unlock()
 
-	// Build the full prompt: QA system prompt + conversation history + current message.
-	prompt := a.buildPrompt(userMsg)
-
-	args := []string{"exec", "--json"}
-	if a.permissionMode == "unattended" {
-		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
-	}
-	if a.modelID != "" {
-		args = append(args, "-m", a.modelID)
-	}
-	args = append(args, prompt)
+	continuity := a.getContinuity()
+	isInitialTurn := continuity.Checkpoint().ThreadID == ""
+	prompt := a.buildPrompt(userMsg, isInitialTurn)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
@@ -184,100 +160,74 @@ func (a *CodexAgent) Run(userMsg string, term *tui.Terminal) (string, error) {
 		a.runMu.Unlock()
 	}()
 
-	cmd := exec.CommandContext(ctx, a.codexBin, args...)
-	cmd.Stdin = strings.NewReader("")
-	cmd.Stderr = term.Stderr()
+	result, err := continuity.Run(ctx, prompt, codexrunner.Hooks{
+		Presenter: codexrunner.PresenterFunc(func(_ context.Context, presentation codexrunner.Presentation) error {
+			if term == nil {
+				return nil
+			}
+			switch presentation.Kind {
+			case codexrunner.PresentationText:
+				term.StreamText(presentation.Text + "\n")
+			case codexrunner.PresentationPlanLimit:
+				term.PrintError("Coding-plan limit reached (see /plan)")
+			}
+			return nil
+		}),
+	})
 
-	stdout, err := cmd.StdoutPipe()
+	a.mu.Lock()
+	if result.Usage.InputTokens > 0 || result.Usage.OutputTokens > 0 {
+		a.lastTurnIn = result.Usage.InputTokens
+		a.lastTurnOut = result.Usage.OutputTokens
+		a.lastTurnOK = true
+	}
+	a.lastLimitHit = result.PlanLimit
+	a.mu.Unlock()
+
+	if result.Canceled {
+		return result.Response, nil
+	}
 	if err != nil {
-		return "", fmt.Errorf("stdout pipe: %w", err)
+		return result.Response, fmt.Errorf("codex turn: %w", err)
 	}
-	if err := cmd.Start(); err != nil {
-		return "", fmt.Errorf("start codex: %w", err)
+	if term != nil {
+		term.FinishMarkdown(result.Response)
 	}
-
-	// Stream JSONL events from codex exec --json.
-	var sb strings.Builder
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 1<<20), 1<<20)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		a.inspectCodexEvent(line, term)
-		text := extractCodexMessage(line)
-		if text != "" {
-			term.StreamText(text + "\n")
-			sb.WriteString(text)
-			sb.WriteByte('\n')
-		}
-	}
-
-	if err := cmd.Wait(); err != nil {
-		// Intentional cancel (user pressed Enter to interrupt) — not an error.
-		if ctx.Err() != nil {
-			return strings.TrimSpace(sb.String()), nil
-		}
-		if sb.Len() == 0 {
-			return "", fmt.Errorf("codex exited with error: %w", err)
-		}
-	}
-
-	result := strings.TrimSpace(sb.String())
-	term.FinishMarkdown(result)
-
-	// Add to our local history for context on subsequent turns.
-	a.mu.Lock()
-	a.history = append(a.history,
-		codexTurn{Role: "user", Content: userMsg},
-		codexTurn{Role: "assistant", Content: result},
-	)
-	// Keep last 10 turns (20 messages) to stay within Codex's context.
-	if len(a.history) > 20 {
-		a.history = a.history[len(a.history)-20:]
-	}
-	a.mu.Unlock()
-
-	return result, nil
+	return result.Response, nil
 }
 
-// buildPrompt constructs a full prompt including conversation history and effort level.
-func (a *CodexAgent) buildPrompt(userMsg string) string {
+func (a *CodexAgent) getContinuity() *codexrunner.Continuity {
 	a.mu.Lock()
-	history := a.history
-	a.mu.Unlock()
-
-	systemPrompt := cliQASystemPrompt(a.sctx, codexQASystemPrompt) + effortDirective(a.effort) + outputStyleDirective(a.outputVerbose) + "\n\n"
-
-	if len(history) == 0 {
-		// First turn: include the system prompt.
-		return systemPrompt + userMsg
+	defer a.mu.Unlock()
+	if a.continuity == nil {
+		a.continuity = codexrunner.NewContinuity(codexrunner.New(codexrunner.Options{Executable: a.codexBin}))
 	}
-
-	// Subsequent turns: include compressed history.
-	var sb strings.Builder
-	sb.WriteString(systemPrompt)
-	sb.WriteString("[Previous conversation]\n")
-	for _, turn := range history {
-		role := "User"
-		if turn.Role == "assistant" {
-			role = "Assistant"
-		}
-		content := turn.Content
-		if len(content) > 500 {
-			content = content[:500] + "..."
-		}
-		fmt.Fprintf(&sb, "%s: %s\n\n", role, content)
-	}
-	sb.WriteString("[Current message]\n")
-	sb.WriteString(userMsg)
-	return sb.String()
+	return a.continuity
 }
 
-// ClearHistory resets conversation history (used when the user types /clear).
+// buildPrompt constructs the current turn without replaying local transcripts.
+// Codex's validated native thread is the sole conversation continuity source,
+// so the QA scaffold is sent only when starting that thread.
+func (a *CodexAgent) buildPrompt(userMsg string, initial bool) string {
+	a.mu.Lock()
+	effort := a.effort
+	outputVerbose := a.outputVerbose
+	a.mu.Unlock()
+	prefix := effortDirective(effort) + outputStyleDirective(outputVerbose)
+	if initial {
+		prefix = cliQASystemPrompt(a.sctx, codexQASystemPrompt) + prefix
+	}
+	return prefix + "\n\n" + userMsg
+}
+
+// ClearHistory resets native Codex continuity (used when the user types /clear).
 func (a *CodexAgent) ClearHistory() {
-	a.mu.Lock()
-	a.history = nil
-	a.mu.Unlock()
+	a.getContinuity().Reset()
+}
+
+// ResetConversation implements ConversationResetter.
+func (a *CodexAgent) ResetConversation() {
+	a.ClearHistory()
 }
 
 func (a *CodexAgent) SetOutputVerbose(verbose bool) {
@@ -298,62 +248,6 @@ func (a *CodexAgent) Cancel() {
 // Cleanup is a no-op for CodexAgent (no temp files to remove).
 func (a *CodexAgent) Cleanup() {}
 
-// codexEvent is a tolerant view of a `codex exec --json` event line, capturing
-// the token-usage and error fields qmax-code needs for the coding-plan window.
-// Field names are best-effort across codex versions (confirm against a real
-// run); the time-based window works even when none are populated.
-type codexEvent struct {
-	Type    string `json:"type"`
-	Message string `json:"message"`
-	Error   string `json:"error"`
-
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
-	Usage        *struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
-		Input        int `json:"input"`
-		Output       int `json:"output"`
-	} `json:"usage"`
-}
-
-// inspectCodexEvent folds token usage from a codex event line into the turn
-// stats and surfaces plan-limit errors that would otherwise be invisible (codex
-// prints them to its JSON stream, not always to stderr).
-func (a *CodexAgent) inspectCodexEvent(line string, term *tui.Terminal) {
-	var ev codexEvent
-	if json.Unmarshal([]byte(line), &ev) != nil {
-		return
-	}
-
-	in, out := ev.InputTokens, ev.OutputTokens
-	if ev.Usage != nil {
-		if ev.Usage.InputTokens > 0 || ev.Usage.OutputTokens > 0 {
-			in, out = ev.Usage.InputTokens, ev.Usage.OutputTokens
-		} else if ev.Usage.Input > 0 || ev.Usage.Output > 0 {
-			in, out = ev.Usage.Input, ev.Usage.Output
-		}
-	}
-	if in > 0 || out > 0 {
-		a.mu.Lock()
-		a.lastTurnIn, a.lastTurnOut, a.lastTurnOK = in, out, true
-		a.mu.Unlock()
-	}
-
-	if strings.Contains(ev.Type, "error") || ev.Error != "" {
-		msg := ev.Error
-		if msg == "" {
-			msg = ev.Message
-		}
-		if isPlanLimitMessage(msg) {
-			a.mu.Lock()
-			a.lastLimitHit = true
-			a.mu.Unlock()
-			term.PrintError("Coding-plan limit reached — " + msg + " (see /plan)")
-		}
-	}
-}
-
 // LastTurnStats returns codex's token usage for the most recent turn, when its
 // stream carried any. Satisfies TurnStatsProvider.
 func (a *CodexAgent) LastTurnStats() (inputTokens, outputTokens int, ok bool) {
@@ -369,24 +263,4 @@ func (a *CodexAgent) LastPlanLimit() (reset time.Time, hit bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.lastLimitReset, a.lastLimitHit
-}
-
-// extractCodexMessage parses a JSONL line from `codex exec --json` and returns
-// the assistant text if the event is an item.completed with type "agent_message".
-// Returns "" for all other event types (turn lifecycle, tool calls, etc.).
-func extractCodexMessage(line string) string {
-	var event struct {
-		Type string `json:"type"`
-		Item struct {
-			Type string `json:"type"`
-			Text string `json:"text"`
-		} `json:"item"`
-	}
-	if json.Unmarshal([]byte(line), &event) != nil {
-		return ""
-	}
-	if event.Type == "item.completed" && event.Item.Type == "agent_message" {
-		return event.Item.Text
-	}
-	return ""
 }

--- a/internal/agent/codex_agent_continuity_test.go
+++ b/internal/agent/codex_agent_continuity_test.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
+)
+
+func TestCodexAgentUsesNativeContinuityAndClearStartsFresh(t *testing.T) {
+	_ = withTempHome(t)
+	codexBin := writeFakeCLI(t, "codex-continuity", `#!/bin/sh
+thread_id='abcdef12-3456-4abc-8def-1234567890ab'
+if [ "$#" -eq 3 ] && [ "$1" = 'exec' ] && [ "$2" = '--json' ] && [ "$3" = '-' ]; then
+  :
+elif [ "$#" -eq 5 ] && [ "$1" = 'exec' ] && [ "$2" = 'resume' ] && [ "$3" = '--json' ] && [ "$4" = "$thread_id" ] && [ "$5" = '-' ]; then
+  :
+else
+  exit 64
+fi
+printf '%s\n' "{\"type\":\"thread.started\",\"thread_id\":\"$thread_id\"}"
+`)
+	a := NewCodexAgent(codexBin, "high", false, &api.SessionContext{})
+
+	if _, err := a.Run(strings.Repeat(t.Name(), 1), nil); err != nil {
+		t.Fatal("initial adapter turn failed")
+	}
+	if a.continuity.Checkpoint().ThreadID != firstAdapterThreadID {
+		t.Fatal("adapter did not retain the exact thread ID")
+	}
+	if _, err := a.Run(strings.Repeat(t.Name(), 2), nil); err != nil {
+		t.Fatal("adapter resume turn failed")
+	}
+
+	a.ClearHistory()
+	if _, err := a.Run(strings.Repeat(t.Name(), 3), nil); err != nil {
+		t.Fatal("adapter did not start fresh after clear")
+	}
+}
+
+func TestCodexAgentAddsQAScaffoldOnlyToInitialTurn(t *testing.T) {
+	a := NewCodexAgent("codex", "high", false, &api.SessionContext{})
+
+	initial := a.buildPrompt(strings.Repeat(t.Name(), 1), true)
+	if !strings.Contains(initial, codexQASystemPrompt) {
+		t.Fatal("initial turn is missing the QA scaffold")
+	}
+
+	followUp := a.buildPrompt(strings.Repeat(t.Name(), 2), false)
+	if strings.Contains(followUp, codexQASystemPrompt) {
+		t.Fatal("follow-up turn repeated the QA scaffold")
+	}
+}
+
+const firstAdapterThreadID = "abcdef12-3456-4abc-8def-1234567890ab"

--- a/internal/agent/mcp_reconnect_test.go
+++ b/internal/agent/mcp_reconnect_test.go
@@ -27,10 +27,11 @@ func TestCodexRunRestoresMCPConfigBeforeExec(t *testing.T) {
 	home := withTempHome(t)
 	resetLiveURLFileForTest()
 	codexBin := writeFakeCLI(t, "codex", `#!/bin/sh
+printf '%s\n' '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}'
 printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"codex ok"}}'
 `)
 
-	a := NewCodexAgent(codexBin, "", "high", "standard", false, &api.SessionContext{
+	a := NewCodexAgent(codexBin, "high", false, &api.SessionContext{
 		ProjectID: 88,
 		LiveFeed:  true,
 		LocalOnly: true,

--- a/internal/agent/opencode_agent.go
+++ b/internal/agent/opencode_agent.go
@@ -25,8 +25,8 @@ import (
 // managed opencode config, so opencode can call them natively.
 //
 // opencode supports native session resume (--session) and a rich NDJSON event
-// stream (opencode run --format json), so this mirrors the CCAgent design
-// rather than CodexAgent's self-managed history.
+// stream (opencode run --format json), so it retains its provider session ID
+// much like CodexAgent retains its exact native thread checkpoint.
 //
 // Per-message flow:
 //  1. qmax-code writes ~/.qmax-code/opencode.json (provider blocks + qmax MCP)
@@ -46,7 +46,7 @@ type OpenCodeAgent struct {
 	sctx           *api.SessionContext
 	lastToolName   string
 	fileSnaps      map[string]fileSnapshot // opencode tool part id → pre-edit snapshot
-	lastTurnIn     int  // token usage of the most recent turn (from opencode's stream)
+	lastTurnIn     int                     // token usage of the most recent turn (from opencode's stream)
 	lastTurnOut    int
 	lastTurnOK     bool      // true once a usage event carried tokens this turn
 	lastLimitHit   bool      // true if the plan limit was hit this turn
@@ -264,8 +264,8 @@ type ocPart struct {
 	Type   string          `json:"type"`
 	Text   string          `json:"text"`
 	Tool   string          `json:"tool"`
-	State  string          `json:"state,omitempty"`  // tool parts: pending|running|completed|error
-	Input  json.RawMessage `json:"input,omitempty"`  // tool parts: tool input (has file path)
+	State  string          `json:"state,omitempty"` // tool parts: pending|running|completed|error
+	Input  json.RawMessage `json:"input,omitempty"` // tool parts: tool input (has file path)
 	Tokens *ocTokens       `json:"tokens,omitempty"`
 	Usage  *ocTokens       `json:"usage,omitempty"`
 }
@@ -532,6 +532,11 @@ func (a *OpenCodeAgent) ClearSession() {
 	a.mu.Lock()
 	a.sessionID = ""
 	a.mu.Unlock()
+}
+
+// ResetConversation implements ConversationResetter.
+func (a *OpenCodeAgent) ResetConversation() {
+	a.ClearSession()
 }
 
 func (a *OpenCodeAgent) SetOutputVerbose(verbose bool) {

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -73,7 +73,8 @@ type Config struct {
 	EnabledProviders []string `json:"enabled_providers,omitempty"`
 
 	// ModelOverride is the specific model ID selected via the /orch TUI picker.
-	// Empty means "let the CLI pick its default". Used with CC and Codex backends.
+	// Empty means "let the backend pick its default". Codex always uses its own
+	// configuration; this override remains relevant to CC and opencode.
 	ModelOverride string `json:"model_override,omitempty"`
 
 	// Effort controls how thorough the CLI agent should be: "low", "medium", "high".
@@ -81,7 +82,7 @@ type Config struct {
 	Effort string `json:"effort,omitempty"`
 
 	// OrchPermissionMode records the autonomy level the user consented to for
-	// CC/Codex backends:
+	// CC and opencode backends. Codex uses its own approval and sandbox policy:
 	//   ""           = no consent yet; activation will prompt
 	//   "standard"   = curated allowlist auto-approved (reads, test runners,
 	//                  qmax MCP tools); edits and destructive shell still gated

--- a/internal/repl/cli_continuity_test.go
+++ b/internal/repl/cli_continuity_test.go
@@ -1,0 +1,40 @@
+package repl
+
+import (
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/api"
+	"github.com/qualitymax/qmax-code/internal/tui"
+)
+
+func TestResetCLIConversationUsesBackendContinuityHook(t *testing.T) {
+	spy := &continuityResetSpy{}
+	resetCLIConversation(spy)
+	if spy.resets != 1 {
+		t.Fatal("clear did not reset CLI continuity")
+	}
+}
+
+func TestPersistOrchModelSelectionPreservesPreferenceForCodex(t *testing.T) {
+	cfg := &api.Config{ModelOverride: "saved-preference"}
+
+	persistOrchModelSelection(cfg, "codex", "")
+	if cfg.ModelOverride != "saved-preference" {
+		t.Fatal("selecting Codex erased another backend's model preference")
+	}
+
+	persistOrchModelSelection(cfg, "cc", "replacement-preference")
+	if cfg.ModelOverride != "replacement-preference" {
+		t.Fatal("non-Codex model selection was not persisted")
+	}
+}
+
+type continuityResetSpy struct {
+	resets int
+}
+
+func (*continuityResetSpy) Run(string, *tui.Terminal) (string, error) { return "", nil }
+func (*continuityResetSpy) Cancel()                                   {}
+func (*continuityResetSpy) SetOutputVerbose(bool)                     {}
+func (*continuityResetSpy) Cleanup()                                  {}
+func (spy *continuityResetSpy) ResetConversation()                    { spy.resets++ }

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -205,6 +205,10 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 			if backend != "api" {
 				permissionMode = ag.AppConfig.OrchPermissionMode
 			}
+			if backend == "codex" {
+				model = "Codex config"
+				permissionMode = "codex policy"
+			}
 		}
 		// Report the window belonging to the backend that is actually active.
 		planWindow := planWindowFor(backend)
@@ -301,9 +305,7 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 		case input == "/clear":
 			ag.ClearHistory()
 			lastContextTokens = 0
-			if oc, ok := cliAgent.(*agent.OpenCodeAgent); ok {
-				oc.ClearSession()
-			}
+			resetCLIConversation(cliAgent)
 			term.PrintSystem("Conversation cleared.")
 			continue
 		case strings.HasPrefix(input, "/project "):
@@ -666,12 +668,12 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 				cliAgent = agent.NewCCAgent(agent.FindClaudeCode(), result.ModelID, result.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, ag.Cfg.Context)
 				term.PrintSystem(fmt.Sprintf("Backend: Claude Code  model: %s  effort: %s", result.ModelID, result.Effort))
 			case "codex":
-				ca := agent.NewCodexAgent(agent.FindCodex(), result.ModelID, result.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, ag.Cfg.Context)
+				ca := agent.NewCodexAgent(agent.FindCodex(), result.Effort, cfg.OutputVerbose, ag.Cfg.Context)
 				if err := ca.WriteMCPConfig(); err != nil {
 					term.PrintSystem(fmt.Sprintf("Warning: Codex MCP config: %v", err))
 				}
 				cliAgent = ca
-				term.PrintSystem(fmt.Sprintf("Backend: Codex  model: %s  effort: %s", result.ModelID, result.Effort))
+				term.PrintSystem(fmt.Sprintf("Backend: Codex  model/policy: Codex config  prompt effort: %s", result.Effort))
 			case "opencode":
 				oc := agent.NewOpenCodeAgent(agent.FindOpenCode(), result.ModelID, result.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, cfg, ag.Cfg.Context)
 				if _, err := agent.WriteOpenCodeConfig(cfg, ag.Cfg.Context, cfg.OrchPermissionMode); err != nil {
@@ -684,7 +686,7 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 			}
 
 			cfg.Backend = result.Backend
-			cfg.ModelOverride = result.ModelID
+			persistOrchModelSelection(cfg, result.Backend, result.ModelID)
 			cfg.Effort = result.Effort
 			ag.Cfg.Context.Backend = result.Backend
 			_ = cfg.Save()
@@ -847,14 +849,14 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 					}
 					setup.InstallSkillsReport("codex", term)
 				}
-				ca := agent.NewCodexAgent(bin, cfg.ModelOverride, cfg.Effort, cfg.OrchPermissionMode, cfg.OutputVerbose, ag.Cfg.Context)
+				ca := agent.NewCodexAgent(bin, cfg.Effort, cfg.OutputVerbose, ag.Cfg.Context)
 				if err := ca.WriteMCPConfig(); err != nil {
 					term.PrintSystem(fmt.Sprintf("Warning: MCP config: %v", err))
 				}
 				cliAgent = ca
 				cfg.Backend = "codex"
 				_ = cfg.Save()
-				term.PrintSystem(fmt.Sprintf("Backend → Codex (%s) · %s mode", bin, cfg.OrchPermissionMode))
+				term.PrintSystem(fmt.Sprintf("Backend → Codex (%s) · Codex config policy", bin))
 
 			case "opencode":
 				// Pre-flight above already validated the CLI, providers, model, and
@@ -1706,6 +1708,21 @@ func reconnectMCPTransport(cliAgent agent.CLIAgent, term *tui.Terminal) {
 		term.PrintSystem("QMax MCP transport restored for Codex.")
 	default:
 		term.PrintSystem("No CC/Codex MCP transport is active. Use /cc or /codex first.")
+	}
+}
+
+func resetCLIConversation(cliAgent agent.CLIAgent) {
+	if resetter, ok := cliAgent.(agent.ConversationResetter); ok {
+		resetter.ResetConversation()
+	}
+}
+
+func persistOrchModelSelection(cfg *api.Config, backend, modelID string) {
+	// Codex owns its model selection in Codex config. Its terminal-neutral
+	// picker entry intentionally has no model ID, so do not let choosing it
+	// erase the saved preference used by the other orchestration backends.
+	if backend != "codex" {
+		cfg.ModelOverride = modelID
 	}
 }
 

--- a/internal/setup/consent.go
+++ b/internal/setup/consent.go
@@ -41,8 +41,10 @@ func PromptOrchConsent(cfg *api.Config, backend string) ConsentResult {
 
 	reader := bufio.NewReader(os.Stdin)
 
-	// First prompt: autonomy level. Skip if previously chosen.
-	if res.PermissionMode == "" {
+	// First prompt: autonomy level. Codex is deliberately excluded because the
+	// fixed runner command leaves approval and sandbox policy to Codex's own
+	// configuration; presenting a qmax choice here would be misleading.
+	if qmaxSelectsPermissionMode(backend) && res.PermissionMode == "" {
 		fmt.Println()
 		fmt.Printf("  Activating %s backend.\n", cliName)
 		fmt.Println()
@@ -97,4 +99,8 @@ func PromptOrchConsent(cfg *api.Config, backend string) ConsentResult {
 
 	res.Proceed = true
 	return res
+}
+
+func qmaxSelectsPermissionMode(backend string) bool {
+	return backend != "codex"
 }

--- a/internal/setup/consent_test.go
+++ b/internal/setup/consent_test.go
@@ -1,0 +1,14 @@
+package setup
+
+import "testing"
+
+func TestCodexDefersPermissionPolicyToCodexConfiguration(t *testing.T) {
+	if qmaxSelectsPermissionMode("codex") {
+		t.Fatal("Codex activation must not present a qmax permission selector")
+	}
+	for _, backend := range []string{"cc", "opencode"} {
+		if !qmaxSelectsPermissionMode(backend) {
+			t.Fatalf("%s unexpectedly stopped using qmax permission selection", backend)
+		}
+	}
+}

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -20,7 +20,7 @@ type StatusInfo struct {
 	Backend        string // "cc" | "codex" | "opencode" | "cerebras" | "ollama" | "" (direct API)
 	Model          string // active model ID; "" = backend default
 	Effort         string // "low" | "medium" | "high" (CLI backends)
-	PermissionMode string // "standard" | "unattended" (CLI backends)
+	PermissionMode string // autonomy mode, or "codex policy" for Codex-owned policy
 	OutputVerbose  bool
 	Task           string        // what the agent is working on (latest user prompt)
 	TokensIn       int           // session input tokens

--- a/internal/tui/tui_backend.go
+++ b/internal/tui/tui_backend.go
@@ -121,7 +121,7 @@ var (
 
 type pickerEntry struct {
 	backend  string // "cc" | "codex" | ""
-	modelID  string // passed via --model to the CLI
+	modelID  string // model selection, or empty when the backend owns selection
 	label    string // display name
 	subLabel string // e.g. "1M ctx"
 	isNew    bool
@@ -141,14 +141,7 @@ var ccModels = []pickerEntry{
 }
 
 var codexModels = []pickerEntry{
-	{backend: "codex", modelID: "gpt-5.6-terra", label: "GPT-5.6 Terra", isNew: true, external: true, shortcut: '6'},
-	{backend: "codex", modelID: "gpt-5.6-sol", label: "GPT-5.6 Sol", isNew: true, external: true, shortcut: '7'},
-	{backend: "codex", modelID: "gpt-5.6-luna", label: "GPT-5.6 Luna", isNew: true, external: true, shortcut: '8'},
-	{backend: "codex", modelID: "gpt-5.5", label: "GPT-5.5", external: true, shortcut: '9'},
-	{backend: "codex", modelID: "o4-mini", label: "o4-mini", external: true, isFav: true, shortcut: '0'},
-	{backend: "codex", modelID: "o3", label: "o3", external: true},
-	{backend: "codex", modelID: "o3-mini", label: "o3-mini", external: true},
-	{backend: "codex", modelID: "gpt-4o", label: "GPT-4o", external: true},
+	{backend: "codex", modelID: "", label: "Codex default", subLabel: "uses Codex config", external: true, isFav: true, shortcut: '6'},
 }
 
 var apiModels = []pickerEntry{
@@ -281,7 +274,7 @@ func newModelPickerModel(currentBackend, currentModelID, effort, ollamaURL, olla
 	// Start cursor on the active entry.
 	cursor := 0
 	for i, e := range entries {
-		if e.backend == currentBackend && (e.modelID == currentModelID || currentModelID == "") && e.isFav {
+		if e.backend == currentBackend && (e.modelID == currentModelID || currentModelID == "" || e.modelID == "") && e.isFav {
 			cursor = i
 		}
 		if e.backend == currentBackend && e.modelID == currentModelID {

--- a/internal/tui/tui_backend_cc_test.go
+++ b/internal/tui/tui_backend_cc_test.go
@@ -47,36 +47,24 @@ func TestPickerClaudeCodeDefaultCursorOnSonnet5(t *testing.T) {
 	}
 }
 
-func TestPickerIncludesCodexGPT56Variants(t *testing.T) {
-	m := newModelPickerModel("codex", "", "high", "", "", true, true, false, false, nil)
+func TestPickerUsesCodexConfigurationInsteadOfClaimingModelControl(t *testing.T) {
+	// A legacy saved model must still put the cursor on the terminal-neutral
+	// Codex entry; the runner no longer puts model IDs on the command line.
+	m := newModelPickerModel("codex", "legacy-model", "high", "", "", true, true, false, false, nil)
 
-	seen := map[string]pickerEntry{}
+	var entries []pickerEntry
 	for _, e := range m.allEntries {
 		if e.backend == "codex" {
-			seen[e.modelID] = e
+			entries = append(entries, e)
 		}
 	}
-
-	for id, wantLabel := range map[string]string{
-		"gpt-5.6-terra": "GPT-5.6 Terra",
-		"gpt-5.6-sol":   "GPT-5.6 Sol",
-		"gpt-5.6-luna":  "GPT-5.6 Luna",
-	} {
-		e, ok := seen[id]
-		if !ok {
-			t.Fatalf("Codex picker missing %s", id)
-		}
-		if e.label != wantLabel {
-			t.Errorf("%s label = %q, want %q", id, e.label, wantLabel)
-		}
-		if !e.isNew {
-			t.Errorf("%s should be flagged isNew", id)
-		}
+	if len(entries) != 1 {
+		t.Fatalf("Codex picker entries = %d, want 1", len(entries))
 	}
-
-	// o4-mini remains the default Codex model — adding new rows above it
-	// must not silently change which model launches when none is specified.
-	if fav := seen["o4-mini"]; !fav.isFav {
-		t.Error("o4-mini should remain the default Codex picker row")
+	if entries[0].modelID != "" || entries[0].subLabel != "uses Codex config" || !entries[0].isFav {
+		t.Fatal("Codex picker must defer model selection to Codex configuration")
+	}
+	if got := m.allEntries[m.cursor].backend; got != "codex" {
+		t.Fatalf("cursor backend = %q, want codex", got)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -521,7 +521,7 @@ func main() {
 		if appConfig.OrchGlobalInstall {
 			_, _ = setup.InstallSkills("codex")
 		}
-		ca := agent.NewCodexAgent(agent.FindCodex(), appConfig.ModelOverride, appConfig.Effort, appConfig.OrchPermissionMode, appConfig.OutputVerbose, ctx)
+		ca := agent.NewCodexAgent(agent.FindCodex(), appConfig.Effort, appConfig.OutputVerbose, ctx)
 		if err := ca.WriteMCPConfig(); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: could not write Codex MCP config: %v\n", err)
 		}


### PR DESCRIPTION
## What

- Add a public, terminal-neutral Go runner and continuity adapter for Codex CLI JSONL execution.
- Keep request data on standard input, enforce the exact initial/resume command contract, and require explicit validated thread continuity.
- Integrate the adapter with the existing CLI/TUI while preserving reset, cancellation, presentation, and other backend behavior.

## Acceptance criteria

- [x] Initial turns invoke only `codex exec --json -`.
- [x] Follow-up turns invoke only `codex exec resume --json <thread_id> -`.
- [x] The exact emitted thread ID is returned and reused; `resume --last` is forbidden.
- [x] Request data never enters argv, diagnostics, or fixtures.
- [x] The public package has no private-cloud imports.
- [x] Focused coverage includes command construction, thread capture, malformed streams, cancellation, request secrecy, continuity, and CLI/TUI regressions.

## Validation

- `go test ./...` — pass
- `go test -race ./...` — pass
- `go vet ./...` — pass
- `go build -ldflags="-s -w -X main.Version=dev" -o <temporary-output> .` — pass
- Focused package and regression suites, including focused race runs — pass
- Staged formatting, diff-integrity, and redacted high-confidence secret checks — pass
- Independent adversarial review — no unresolved blocker, high, or medium findings

## Deployment verification

This public Go library/CLI change has no hosted deployment. Post-merge verification will pin the merge SHA, confirm terminal CI, and record the test-backed CLI/library smoke evidence.

## Known unrelated/non-blocking failures

The repository has no `.pre-commit-config.yaml`, so `pre-commit run --all-files` cannot start. The repository's Go test, race, vet, release-build, formatting, diff-integrity, and redacted secret-scan fallbacks all pass.

QualityMax's existing project catalog has no qmax-code repository connection; no duplicate project was created.
