### PR TITLE
fix: preserve exact Codex model across resumes (QUA-1910)

### DIFF
--- a/codexrunner/continuity.go
+++ b/codexrunner/continuity.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 )
 
-// Continuity serializes turns and remembers only the exact validated thread
-// checkpoint. It stores no prompts, responses, source, or provider payloads.
-// Durable callers should also provide Hooks.Checkpoints on every turn.
+// Continuity serializes turns and remembers only the exact validated thread and
+// model checkpoint. It stores no prompts, responses, source, or provider
+// payloads. Durable callers should also provide Hooks.Checkpoints on every turn.
 type Continuity struct {
 	runner *Runner
 	runMu  sync.Mutex
@@ -44,11 +44,12 @@ func (continuity *Continuity) Run(ctx Cancellation, prompt string, hooks Hooks) 
 	result, err := continuity.runner.Run(ctx, Turn{
 		Prompt:   prompt,
 		ThreadID: checkpoint.ThreadID,
+		Model:    checkpoint.Model,
 		Hooks:    hooks,
 	})
 	if result.ThreadID != "" {
 		continuity.mu.Lock()
-		continuity.state = Checkpoint{ThreadID: result.ThreadID}
+		continuity.state = Checkpoint{ThreadID: result.ThreadID, Model: result.Model}
 		continuity.mu.Unlock()
 	}
 	return result, err
@@ -68,6 +69,11 @@ func (continuity *Continuity) Restore(checkpoint Checkpoint) error {
 	defer continuity.runMu.Unlock()
 	if checkpoint.ThreadID != "" && !validThreadID(checkpoint.ThreadID) {
 		return ErrInvalidThreadID
+	}
+	if checkpoint.Model != "" {
+		if err := ValidateModel(checkpoint.Model); err != nil {
+			return err
+		}
 	}
 	continuity.mu.Lock()
 	continuity.state = checkpoint

--- a/codexrunner/continuity_test.go
+++ b/codexrunner/continuity_test.go
@@ -45,10 +45,13 @@ func TestContinuityCheckpointRestoreIsValidated(t *testing.T) {
 	if err := continuity.Restore(Checkpoint{ThreadID: "--last"}); !errors.Is(err, ErrInvalidThreadID) {
 		t.Fatal("restore accepted implicit continuity")
 	}
-	if err := continuity.Restore(Checkpoint{ThreadID: firstThreadID}); err != nil {
+	if err := continuity.Restore(Checkpoint{ThreadID: firstThreadID, Model: DefaultModel}); err != nil {
 		t.Fatal("restore rejected a canonical checkpoint")
 	}
-	if continuity.Checkpoint().ThreadID != firstThreadID {
-		t.Fatal("restore changed the exact thread ID")
+	if continuity.Checkpoint() != (Checkpoint{ThreadID: firstThreadID, Model: DefaultModel}) {
+		t.Fatal("restore changed the exact thread or model")
+	}
+	if err := continuity.Restore(Checkpoint{ThreadID: firstThreadID, Model: "auto"}); !errors.Is(err, ErrInvalidModel) {
+		t.Fatal("restore accepted a non-exact model")
 	}
 }

--- a/codexrunner/doc.go
+++ b/codexrunner/doc.go
@@ -1,8 +1,10 @@
 // Package codexrunner executes Codex CLI turns without depending on qmax-code's
 // terminal or on any private cloud implementation.
 //
-// A first turn always invokes "codex exec --json -". A continued turn always
-// invokes "codex exec resume --json <thread_id> -" with a validated, explicit
-// thread ID. Prompts are supplied only through stdin. Raw provider events and
-// diagnostics are never exposed through the structural event interfaces.
+// A first turn invokes "codex exec [--model <model>] --json -". A continued
+// turn invokes "codex exec resume [--model <model>] --json <thread_id> -" with
+// a validated, explicit thread ID. When a model is supplied, it is validated
+// against an exact allowlist before process start and is preserved in durable
+// checkpoints. Prompts are supplied only through stdin. Raw provider events
+// and diagnostics are never exposed through the structural event interfaces.
 package codexrunner

--- a/codexrunner/model.go
+++ b/codexrunner/model.go
@@ -1,0 +1,44 @@
+package codexrunner
+
+import "errors"
+
+const (
+	// DefaultModel is the deterministic Codex model selected by QualityMax when
+	// a product client chooses Auto or has no saved preference.
+	DefaultModel = "gpt-5.6-terra"
+)
+
+var (
+	// ErrInvalidModel means a caller supplied a model outside the exact product
+	// allowlist. The value is never forwarded to the process boundary.
+	ErrInvalidModel = errors.New("codex runner: invalid model")
+
+	supportedModels = [...]string{
+		"gpt-5.6-sol",
+		DefaultModel,
+		"gpt-5.6-luna",
+		"gpt-5.5",
+		"gpt-5.4",
+		"gpt-5.4-mini",
+		"gpt-5.3-codex-spark",
+	}
+)
+
+// SupportedModels returns a defensive copy of the exact Codex model
+// allowlist shared by the QualityMax coding-agent contract.
+func SupportedModels() []string {
+	models := make([]string, len(supportedModels))
+	copy(models, supportedModels[:])
+	return models
+}
+
+// ValidateModel accepts only exact allowlisted model IDs. Empty and "auto"
+// are product-level choices that must be resolved before a durable handoff.
+func ValidateModel(model string) error {
+	for _, supported := range supportedModels {
+		if model == supported {
+			return nil
+		}
+	}
+	return ErrInvalidModel
+}

--- a/codexrunner/runner.go
+++ b/codexrunner/runner.go
@@ -77,9 +77,11 @@ func (f EventSinkFunc) OnEvent(ctx context.Context, event Event) error {
 	return f(ctx, event)
 }
 
-// Checkpoint is the minimum durable state required to continue a Codex thread.
+// Checkpoint is the minimum durable state required to continue a Codex thread
+// on the same exact model.
 type Checkpoint struct {
 	ThreadID string
+	Model    string
 }
 
 // CheckpointSink persists a validated checkpoint as soon as thread.started is
@@ -134,8 +136,9 @@ type Cancellation interface {
 }
 
 // Command describes one direct process invocation. Stdin carries the prompt;
-// Args is always one of the two fixed command shapes documented by this
-// package. Stderr is deliberately absent so raw diagnostics cannot be logged.
+// Args is always one of the fixed, allowlisted command shapes documented by
+// this package. Stderr is deliberately absent so raw diagnostics cannot be
+// logged.
 type Command struct {
 	Executable       string
 	Args             []string
@@ -169,18 +172,22 @@ type Hooks struct {
 	Presenter   Presenter
 }
 
-// Turn contains the sensitive prompt and an optional exact continuity ID.
-// Callers must not log this value.
+// Turn contains the sensitive prompt, an optional exact continuity ID, and an
+// optional exact model. When Model is present, it must be allowlisted and is
+// passed on both initial and resumed commands. Callers must not log Prompt.
 type Turn struct {
 	Prompt   string
 	ThreadID string
+	Model    string
 	Hooks    Hooks
 }
 
-// Result contains the exact validated Codex thread ID and response. Response is
-// transcript data and must not be logged or placed in workflow history.
+// Result contains the exact validated Codex thread ID, selected model, and
+// response. Response is transcript data and must not be logged or placed in
+// workflow history.
 type Result struct {
 	ThreadID  string
+	Model     string
 	Response  string
 	Usage     Usage
 	Canceled  bool
@@ -225,10 +232,22 @@ func (r *Runner) Run(ctx Cancellation, turn Turn) (Result, error) {
 	if turn.ThreadID != "" && !validThreadID(turn.ThreadID) {
 		return result, ErrInvalidThreadID
 	}
+	if turn.Model != "" {
+		if err := ValidateModel(turn.Model); err != nil {
+			return result, err
+		}
+		result.Model = turn.Model
+	}
 
 	args := []string{"exec", "--json", "-"}
+	if turn.Model != "" {
+		args = []string{"exec", "--model", turn.Model, "--json", "-"}
+	}
 	if turn.ThreadID != "" {
 		args = []string{"exec", "resume", "--json", turn.ThreadID, "-"}
+		if turn.Model != "" {
+			args = []string{"exec", "resume", "--model", turn.Model, "--json", turn.ThreadID, "-"}
+		}
 	}
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -302,7 +321,7 @@ func (r *Runner) handleEvent(ctx context.Context, turn Turn, event wireEvent, re
 		if result.ThreadID == "" {
 			result.ThreadID = event.ThreadID
 			if turn.Hooks.Checkpoints != nil {
-				if err := turn.Hooks.Checkpoints.OnCheckpoint(ctx, Checkpoint{ThreadID: event.ThreadID}); err != nil {
+				if err := turn.Hooks.Checkpoints.OnCheckpoint(ctx, Checkpoint{ThreadID: event.ThreadID, Model: turn.Model}); err != nil {
 					return ErrCheckpointSink
 				}
 			}

--- a/codexrunner/runner_test.go
+++ b/codexrunner/runner_test.go
@@ -77,6 +77,66 @@ func TestRunnerResumeUsesExactThreadID(t *testing.T) {
 	assertPromptAbsent(t, prompt, command.args, err)
 }
 
+func TestRunnerUsesExactModelOnInitialAndResumedTurns(t *testing.T) {
+	executor := &scriptedExecutor{streams: []string{
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID}),
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID}),
+	}}
+	runner := New(Options{Executor: executor})
+	var checkpoint Checkpoint
+
+	first, err := runner.Run(context.Background(), Turn{
+		Prompt: generatedSensitiveValue(t),
+		Model:  DefaultModel,
+		Hooks: Hooks{Checkpoints: CheckpointSinkFunc(func(_ context.Context, next Checkpoint) error {
+			checkpoint = next
+			return nil
+		})},
+	})
+	if err != nil {
+		t.Fatal("modeled initial turn failed")
+	}
+	if first.Model != DefaultModel || checkpoint != (Checkpoint{ThreadID: firstThreadID, Model: DefaultModel}) {
+		t.Fatal("initial turn did not preserve its exact model")
+	}
+	if want := []string{"exec", "--model", DefaultModel, "--json", "-"}; !slices.Equal(executor.command(t, 0).args, want) {
+		t.Fatal("initial turn did not pass the exact model")
+	}
+
+	second, err := runner.Run(context.Background(), Turn{
+		Prompt:   generatedSensitiveValue(t),
+		ThreadID: checkpoint.ThreadID,
+		Model:    checkpoint.Model,
+	})
+	if err != nil {
+		t.Fatal("modeled resume turn failed")
+	}
+	if second.Model != DefaultModel {
+		t.Fatal("resumed turn changed its exact model")
+	}
+	if want := []string{"exec", "resume", "--model", DefaultModel, "--json", firstThreadID, "-"}; !slices.Equal(executor.command(t, 1).args, want) {
+		t.Fatal("resumed turn did not pass the exact model")
+	}
+}
+
+func TestRunnerRejectsUnsupportedModelBeforeProcessStart(t *testing.T) {
+	for _, model := range []string{"", "auto", "--model", "GPT-5.6-TERRA", "gpt-unknown"} {
+		if model == "" {
+			continue
+		}
+		t.Run(model, func(t *testing.T) {
+			executor := &scriptedExecutor{}
+			_, err := New(Options{Executor: executor}).Run(context.Background(), Turn{Model: model})
+			if !errors.Is(err, ErrInvalidModel) {
+				t.Fatal("unsupported model was not rejected")
+			}
+			if executor.commandCount() != 0 {
+				t.Fatal("unsupported model reached the process boundary")
+			}
+		})
+	}
+}
+
 func TestRunnerRejectsImplicitOrMismatchedContinuity(t *testing.T) {
 	t.Run("option-like ID", func(t *testing.T) {
 		executor := &scriptedExecutor{}


### PR DESCRIPTION
## Summary
- add an exact allowlist and deterministic QualityMax default for Codex models
- pass the selected model to both initial and resumed `codex exec` commands
- preserve and validate the model in durable continuity checkpoints
- reject unsupported or option-like model values before process start

## Verification
- `go test ./...`
- `go vet ./...`
- `go build ./...`

Linear: QUA-1910