### PR TITLE
feat(codexrunner): carry the Codex rollout in durable checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+### Added
+- `codexrunner` checkpoints carry `RolloutPath`, the local Codex rollout
+  backing the thread, so a session moved to a replacement sandbox can be
+  resumed with its transcript instead of a thread ID that names nothing there.
+  `Options.Rollouts` selects the locator; `CodexHomeLocator` reads
+  `$CODEX_HOME`.
+
+### Fixed
+- `Continuity.Run` and `Runner.Result` now carry the rollout reference the
+  checkpoint sink already receives, instead of rebuilding a checkpoint from the
+  thread ID and model alone and dropping it on every turn.
+- `Continuity.Restore` refuses a checkpoint naming a rollout that is missing on
+  this box (`ErrRolloutUnavailable`) or given as a relative path
+  (`ErrInvalidRolloutPath`), rather than silently resuming into an empty
+  thread.
+
 ## [1.28.0] - 2026-08-25
 
 ### Added

--- a/codexrunner/continuity.go
+++ b/codexrunner/continuity.go
@@ -49,7 +49,11 @@ func (continuity *Continuity) Run(ctx Cancellation, prompt string, hooks Hooks) 
 	})
 	if result.ThreadID != "" {
 		continuity.mu.Lock()
-		continuity.state = Checkpoint{ThreadID: result.ThreadID, Model: result.Model}
+		continuity.state = Checkpoint{
+			ThreadID:    result.ThreadID,
+			Model:       result.Model,
+			RolloutPath: result.RolloutPath,
+		}
 		continuity.mu.Unlock()
 	}
 	return result, err
@@ -64,6 +68,12 @@ func (continuity *Continuity) Checkpoint() Checkpoint {
 
 // Restore validates and installs a durable checkpoint. An empty checkpoint is
 // equivalent to Reset.
+//
+// A checkpoint naming a rollout that is not present on this box is refused
+// with ErrRolloutUnavailable and not installed, so a replacement sandbox
+// cannot resume into a thread whose transcript it does not have. Callers
+// recover by reporting the reason and restoring the same checkpoint with
+// RolloutPath cleared, which starts a new thread.
 func (continuity *Continuity) Restore(checkpoint Checkpoint) error {
 	continuity.runMu.Lock()
 	defer continuity.runMu.Unlock()
@@ -74,6 +84,9 @@ func (continuity *Continuity) Restore(checkpoint Checkpoint) error {
 		if err := ValidateModel(checkpoint.Model); err != nil {
 			return err
 		}
+	}
+	if err := validateRolloutPath(checkpoint.RolloutPath); err != nil {
+		return err
 	}
 	continuity.mu.Lock()
 	continuity.state = checkpoint

--- a/codexrunner/doc.go
+++ b/codexrunner/doc.go
@@ -7,4 +7,12 @@
 // against an exact allowlist before process start and is preserved in durable
 // checkpoints. Prompts are supplied only through stdin. Raw provider events
 // and diagnostics are never exposed through the structural event interfaces.
+//
+// Because "codex exec resume" resolves a thread from the local Codex session
+// store, a checkpoint also records the path of the rollout backing its thread.
+// The package locates that file and nothing more: it never reads, uploads, or
+// logs a rollout. Hosts that move a session between sandboxes are responsible
+// for shipping the file and for restoring it before they resume, and
+// Continuity.Restore refuses a checkpoint whose rollout is not present rather
+// than resuming into a thread this box cannot reconstruct.
 package codexrunner

--- a/codexrunner/rollout.go
+++ b/codexrunner/rollout.go
@@ -1,0 +1,104 @@
+package codexrunner
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// RolloutLocator resolves the local Codex rollout file backing a validated
+// thread ID. It returns an empty path when no rollout can be found, which the
+// runner records as "not locatable" rather than as an error: a checkpoint
+// without a rollout is still a usable same-sandbox checkpoint.
+//
+// Implementations must not read or log rollout contents. A rollout is a full
+// transcript, and this package never moves transcript data outside Presenter.
+type RolloutLocator interface {
+	LocateRollout(threadID string) string
+}
+
+// RolloutLocatorFunc adapts a function to RolloutLocator.
+type RolloutLocatorFunc func(threadID string) string
+
+// LocateRollout implements RolloutLocator.
+func (f RolloutLocatorFunc) LocateRollout(threadID string) string { return f(threadID) }
+
+// CodexHomeLocator finds rollouts in a Codex session store. Codex writes one
+// rollout per thread under
+// sessions/<yyyy>/<mm>/<dd>/rollout-<timestamp>-<thread_id>.jsonl.
+type CodexHomeLocator struct {
+	// Home overrides the Codex home directory. Empty resolves $CODEX_HOME,
+	// then $HOME/.codex.
+	Home string
+}
+
+// LocateRollout implements RolloutLocator. It returns an absolute path, or ""
+// when the store is absent or holds no rollout for threadID.
+func (locator CodexHomeLocator) LocateRollout(threadID string) string {
+	if !validThreadID(threadID) {
+		return ""
+	}
+	home := locator.Home
+	if home == "" {
+		home = codexHome()
+	}
+	if home == "" {
+		return ""
+	}
+	sessions := filepath.Join(home, "sessions")
+	// threadID is a validated UUID, so it carries no glob metacharacters.
+	name := "rollout-*-" + threadID + ".jsonl"
+	for _, pattern := range []string{
+		filepath.Join(sessions, "*", "*", "*", name),
+		filepath.Join(sessions, name),
+	} {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			continue
+		}
+		for _, match := range matches {
+			if !regularFile(match) {
+				continue
+			}
+			absolute, err := filepath.Abs(match)
+			if err != nil {
+				continue
+			}
+			return absolute
+		}
+	}
+	return ""
+}
+
+func codexHome() string {
+	if home := os.Getenv("CODEX_HOME"); home != "" {
+		return home
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codex")
+}
+
+func regularFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
+}
+
+// validateRolloutPath enforces the two properties a durable rollout reference
+// must have to be resumable: it is absolute, so it does not depend on the
+// working directory of whichever sandbox restores it, and it exists on this
+// box. A checkpoint restored into a replacement sandbox fails the second
+// check, which is exactly the handover this validation exists to make loud.
+func validateRolloutPath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if !filepath.IsAbs(path) {
+		return ErrInvalidRolloutPath
+	}
+	if !regularFile(path) {
+		return ErrRolloutUnavailable
+	}
+	return nil
+}

--- a/codexrunner/rollout_test.go
+++ b/codexrunner/rollout_test.go
@@ -1,0 +1,171 @@
+package codexrunner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeRollout(t *testing.T, home, threadID string) string {
+	t.Helper()
+	directory := filepath.Join(home, "sessions", "2026", "08", "27")
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal("could not create a session store")
+	}
+	path := filepath.Join(directory, "rollout-2026-08-27T10-15-00-"+threadID+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal("could not write a rollout")
+	}
+	return path
+}
+
+func TestCodexHomeLocatorFindsRolloutForExactThread(t *testing.T) {
+	home := t.TempDir()
+	want := writeRollout(t, home, firstThreadID)
+	locator := CodexHomeLocator{Home: home}
+
+	if got := locator.LocateRollout(firstThreadID); got != want {
+		t.Fatal("locator did not find the rollout for the exact thread")
+	}
+	if locator.LocateRollout(secondThreadID) != "" {
+		t.Fatal("locator matched a thread with no rollout")
+	}
+	if locator.LocateRollout("--last") != "" {
+		t.Fatal("locator accepted a non-canonical thread ID")
+	}
+	if (CodexHomeLocator{Home: filepath.Join(home, "absent")}).LocateRollout(firstThreadID) != "" {
+		t.Fatal("locator invented a rollout for an absent store")
+	}
+}
+
+func TestCodexHomeLocatorReadsCodexHomeEnvironment(t *testing.T) {
+	home := t.TempDir()
+	want := writeRollout(t, home, firstThreadID)
+	t.Setenv("CODEX_HOME", home)
+
+	if got := (CodexHomeLocator{}).LocateRollout(firstThreadID); got != want {
+		t.Fatal("locator did not resolve $CODEX_HOME")
+	}
+}
+
+func TestRunnerCheckpointCarriesRolloutPath(t *testing.T) {
+	rollout := writeRollout(t, t.TempDir(), firstThreadID)
+	executor := &scriptedExecutor{streams: []string{eventStream(t,
+		map[string]any{"type": "thread.started", "thread_id": firstThreadID},
+	)}}
+	var checkpoints []Checkpoint
+	runner := New(Options{Executor: executor, Rollouts: RolloutLocatorFunc(func(threadID string) string {
+		if threadID != firstThreadID {
+			t.Fatal("runner located a rollout for the wrong thread")
+		}
+		return rollout
+	})})
+
+	result, err := runner.Run(context.Background(), Turn{
+		Prompt: generatedSensitiveValue(t),
+		Hooks: Hooks{Checkpoints: CheckpointSinkFunc(func(_ context.Context, checkpoint Checkpoint) error {
+			checkpoints = append(checkpoints, checkpoint)
+			return nil
+		})},
+	})
+	if err != nil {
+		t.Fatal("turn failed")
+	}
+	if result.RolloutPath != rollout {
+		t.Fatal("result did not carry the rollout path")
+	}
+	if len(checkpoints) != 1 || checkpoints[0].RolloutPath != rollout {
+		t.Fatal("checkpoint sink did not receive the rollout path at thread.started")
+	}
+}
+
+func TestRunnerCheckpointOmitsUnlocatableRollout(t *testing.T) {
+	executor := &scriptedExecutor{streams: []string{eventStream(t,
+		map[string]any{"type": "thread.started", "thread_id": firstThreadID},
+	)}}
+	runner := New(Options{Executor: executor, Rollouts: RolloutLocatorFunc(func(string) string { return "" })})
+
+	result, err := runner.Run(context.Background(), Turn{Prompt: generatedSensitiveValue(t)})
+	if err != nil {
+		t.Fatal("a turn without a locatable rollout must still succeed")
+	}
+	if result.RolloutPath != "" {
+		t.Fatal("runner invented a rollout path")
+	}
+}
+
+func TestContinuityRetainsRolloutAcrossTurns(t *testing.T) {
+	rollout := writeRollout(t, t.TempDir(), firstThreadID)
+	executor := &scriptedExecutor{streams: []string{
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID}),
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": firstThreadID}),
+	}}
+	continuity := NewContinuity(New(Options{
+		Executor: executor,
+		Rollouts: RolloutLocatorFunc(func(string) string { return rollout }),
+	}))
+
+	if _, err := continuity.Run(context.Background(), generatedSensitiveValue(t), Hooks{}); err != nil {
+		t.Fatal("initial turn failed")
+	}
+	if continuity.Checkpoint().RolloutPath != rollout {
+		t.Fatal("continuity dropped the rollout on the initial turn")
+	}
+	if _, err := continuity.Run(context.Background(), generatedSensitiveValue(t), Hooks{}); err != nil {
+		t.Fatal("resumed turn failed")
+	}
+	if continuity.Checkpoint().RolloutPath != rollout {
+		t.Fatal("continuity dropped the rollout when adopting the resumed turn")
+	}
+}
+
+func TestContinuityRestoreValidatesRollout(t *testing.T) {
+	rollout := writeRollout(t, t.TempDir(), firstThreadID)
+	continuity := NewContinuity(New(Options{Executor: &scriptedExecutor{}}))
+
+	restored := Checkpoint{ThreadID: firstThreadID, Model: DefaultModel, RolloutPath: rollout}
+	if err := continuity.Restore(restored); err != nil {
+		t.Fatal("restore rejected a rollout present on this box")
+	}
+	if continuity.Checkpoint() != restored {
+		t.Fatal("restore changed the durable checkpoint")
+	}
+
+	continuity.Reset()
+	missing := filepath.Join(t.TempDir(), "rollout-2026-08-27T10-15-00-"+firstThreadID+".jsonl")
+	err := continuity.Restore(Checkpoint{ThreadID: firstThreadID, RolloutPath: missing})
+	if !errors.Is(err, ErrRolloutUnavailable) {
+		t.Fatal("restore resumed into a rollout that does not exist on this box")
+	}
+	if continuity.Checkpoint() != (Checkpoint{}) {
+		t.Fatal("a refused restore installed state anyway")
+	}
+
+	relative := filepath.Join("sessions", "rollout-2026-08-27T10-15-00-"+firstThreadID+".jsonl")
+	if err := continuity.Restore(Checkpoint{ThreadID: firstThreadID, RolloutPath: relative}); !errors.Is(err, ErrInvalidRolloutPath) {
+		t.Fatal("restore accepted a rollout path that depends on the working directory")
+	}
+}
+
+func TestContinuityRestoreWithoutRolloutStartsFreshThread(t *testing.T) {
+	executor := &scriptedExecutor{streams: []string{
+		eventStream(t, map[string]any{"type": "thread.started", "thread_id": secondThreadID}),
+	}}
+	continuity := NewContinuity(New(Options{
+		Executor: executor,
+		Rollouts: RolloutLocatorFunc(func(string) string { return "" }),
+	}))
+
+	// The documented recovery from ErrRolloutUnavailable: restore the same
+	// checkpoint with the rollout cleared, which starts a new thread instead of
+	// resuming into one whose transcript this box does not have.
+	if err := continuity.Restore(Checkpoint{Model: DefaultModel}); err != nil {
+		t.Fatal("restore rejected a checkpoint with no thread and no rollout")
+	}
+	result, err := continuity.Run(context.Background(), generatedSensitiveValue(t), Hooks{})
+	if err != nil || result.ThreadID != secondThreadID {
+		t.Fatal("recovery did not start a fresh thread")
+	}
+}

--- a/codexrunner/runner.go
+++ b/codexrunner/runner.go
@@ -17,6 +17,14 @@ const maxEventBytes = 4 << 20
 var (
 	// ErrInvalidThreadID means a caller or stream supplied a non-canonical UUID.
 	ErrInvalidThreadID = errors.New("codex runner: invalid thread ID")
+	// ErrInvalidRolloutPath means a checkpoint carried a rollout reference that
+	// is not an absolute path, so it cannot be resolved on another box.
+	ErrInvalidRolloutPath = errors.New("codex runner: invalid rollout path")
+	// ErrRolloutUnavailable means a checkpoint named a rollout that is not
+	// present on this box, which is the expected result of restoring a
+	// checkpoint into a replacement sandbox. Callers must surface a recovery
+	// reason and start a new thread rather than resume into an empty one.
+	ErrRolloutUnavailable = errors.New("codex runner: checkpoint rollout unavailable")
 	// ErrThreadMismatch means a resumed stream identified a different thread.
 	ErrThreadMismatch = errors.New("codex runner: resumed thread does not match checkpoint")
 	// ErrMissingThreadID means the stream ended without a thread.started event.
@@ -79,9 +87,19 @@ func (f EventSinkFunc) OnEvent(ctx context.Context, event Event) error {
 
 // Checkpoint is the minimum durable state required to continue a Codex thread
 // on the same exact model.
+//
+// ThreadID alone is only sufficient on the box that produced it: "codex exec
+// resume" resolves a thread from the local Codex session store, so a thread ID
+// restored into a fresh sandbox names a rollout that no longer exists there.
+// RolloutPath is what makes the thread portable.
 type Checkpoint struct {
 	ThreadID string
 	Model    string
+	// RolloutPath is the local Codex rollout for ThreadID, or "" when the
+	// executor cannot locate one. Callers upload it and record the result as
+	// checkpoint.codex.rollout_ref; this package never reads or ships the
+	// file itself.
+	RolloutPath string
 }
 
 // CheckpointSink persists a validated checkpoint as soon as thread.started is
@@ -163,6 +181,9 @@ type Options struct {
 	Executable       string
 	WorkingDirectory string
 	Executor         ToolExecutor
+	// Rollouts resolves the local rollout backing a thread. A nil locator uses
+	// CodexHomeLocator.
+	Rollouts RolloutLocator
 }
 
 // Hooks are optional per-turn observation and presentation boundaries.
@@ -192,6 +213,10 @@ type Result struct {
 	Usage     Usage
 	Canceled  bool
 	PlanLimit bool
+	// RolloutPath mirrors Checkpoint.RolloutPath for the thread this turn ran
+	// on, so a caller adopting a Result as durable state does not silently
+	// drop the rollout reference the checkpoint sink already received.
+	RolloutPath string
 }
 
 // Runner executes terminal-neutral Codex turns.
@@ -199,10 +224,12 @@ type Runner struct {
 	executable       string
 	workingDirectory string
 	executor         ToolExecutor
+	rollouts         RolloutLocator
 }
 
-// New returns a runner. An empty executable uses "codex" and a nil executor
-// uses the local OS process implementation.
+// New returns a runner. An empty executable uses "codex", a nil executor uses
+// the local OS process implementation, and a nil rollout locator uses
+// CodexHomeLocator.
 func New(options Options) *Runner {
 	executable := options.Executable
 	if executable == "" {
@@ -212,10 +239,15 @@ func New(options Options) *Runner {
 	if executor == nil {
 		executor = OSExecutor{}
 	}
+	rollouts := options.Rollouts
+	if rollouts == nil {
+		rollouts = CodexHomeLocator{}
+	}
 	return &Runner{
 		executable:       executable,
 		workingDirectory: options.WorkingDirectory,
 		executor:         executor,
+		rollouts:         rollouts,
 	}
 }
 
@@ -320,8 +352,14 @@ func (r *Runner) handleEvent(ctx context.Context, turn Turn, event wireEvent, re
 		}
 		if result.ThreadID == "" {
 			result.ThreadID = event.ThreadID
+			result.RolloutPath = r.locateRollout(event.ThreadID)
 			if turn.Hooks.Checkpoints != nil {
-				if err := turn.Hooks.Checkpoints.OnCheckpoint(ctx, Checkpoint{ThreadID: event.ThreadID, Model: turn.Model}); err != nil {
+				checkpoint := Checkpoint{
+					ThreadID:    event.ThreadID,
+					Model:       turn.Model,
+					RolloutPath: result.RolloutPath,
+				}
+				if err := turn.Hooks.Checkpoints.OnCheckpoint(ctx, checkpoint); err != nil {
 					return ErrCheckpointSink
 				}
 			}
@@ -365,6 +403,16 @@ func (r *Runner) handleEvent(ctx context.Context, turn Turn, event wireEvent, re
 		}
 		return nil
 	}
+}
+
+// locateRollout resolves the rollout for a validated thread ID. A locator that
+// finds nothing is not an error: the turn is still valid, the checkpoint is
+// just not portable to another sandbox.
+func (r *Runner) locateRollout(threadID string) string {
+	if r == nil || r.rollouts == nil {
+		return ""
+	}
+	return r.rollouts.LocateRollout(threadID)
 }
 
 func emitEvent(ctx context.Context, sink EventSink, event Event) error {


### PR DESCRIPTION
Implements Ask **A** of the *Cross-Sandbox Continuity* handoff: let a checkpoint carry the rollout, not just its id.

## The problem

`Checkpoint` held a thread ID and a model. That is enough to resume on the box that produced it, because `codex exec resume` resolves a thread from the local Codex session store — and enough for nothing at all on a replacement sandbox, where that store is empty and the thread ID names a rollout no process can reach.

## What changed

`Checkpoint` gains `RolloutPath`, the local rollout backing its thread, so a host can upload it and restore it into a rebuilt sandbox before resuming. The package locates the file and stops there: it never reads, ships, or logs a rollout, and it learns nothing about artifact storage. `Options.Rollouts` selects the locator; `CodexHomeLocator` resolves `$CODEX_HOME`, then `$HOME/.codex`, and matches `sessions/<yyyy>/<mm>/<dd>/rollout-*-<thread_id>.jsonl`.

**Adding the field is not sufficient on its own.** Two sites rebuilt `Checkpoint` as a literal and would have dropped it silently:

- `Runner.handleEvent` (`runner.go:324`) emitted the sink checkpoint from the thread ID and model, so `Result` never saw the rollout it had just located.
- `Continuity.Run` (`continuity.go:51`) adopted the post-turn checkpoint from `Result`'s thread ID and model, zeroing the rollout on every turn after the first.

Both now carry it, and `Result` grew the mirroring field so a caller adopting a `Result` as durable state keeps what the sink already received.

`Continuity.Restore` validates the rollout the way it already validates the thread ID and the model:

| Condition | Result |
|---|---|
| Empty `RolloutPath` | Accepted — a same-sandbox checkpoint stays valid |
| Relative path | `ErrInvalidRolloutPath`, not installed |
| Absent on this box | `ErrRolloutUnavailable`, not installed |

`ErrRolloutUnavailable` is the sandbox handover made loud. Callers recover by reporting the reason and restoring with `RolloutPath` cleared, which starts a fresh thread rather than resuming into an empty one that looks live.

## Scope

Digest verification stays with the host: the checkpoint struct records no hash, and the contract's `rollout_ref` carries `sha256` alongside the reference. Asks **B** (rehydrate `$CODEX_HOME` before resuming) and **C** (snapshot the working tree) land on the worker and are untouched here.

## Testing

`go build ./... && go vet ./... && go test ./...` all pass.

New `codexrunner/rollout_test.go` covers the locator (exact-thread match, unknown thread, non-canonical thread ID, absent store, `$CODEX_HOME`), the checkpoint sink receiving the path at `thread.started`, a turn succeeding when no rollout is locatable, retention across a resumed turn, all three `Restore` outcomes, and the documented fresh-thread recovery.

Both regression tests were mutation-checked: reverting the two literal sites and the `Restore` validation fails `TestContinuityRetainsRolloutAcrossTurns` and `TestContinuityRestoreValidatesRollout` respectively, and nothing else.

---
_Generated by [Claude Code](https://claude.ai/code/session_014apoNDacRcYKGdxtLaauu1)_