### PR TITLE
feat: add local PR quality gate

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -9,6 +9,7 @@ version and `/help` for its REPL commands.
 ```text
 qmax-code [flags]
 qmax-code [flags] "prompt"
+qmax-code gate [--base REF]
 qmax-code login [--api-key KEY]
 qmax-code config [show|set|unset|reset]
 qmax-code receipt [list|show|verify] [id|latest]
@@ -48,6 +49,22 @@ qmax-code --local --backend codex -p "review the current diff"
 In standalone mode, `--project-id`, `--cloud-url`, cloud sessions, and
 QualityMax-backed tools do not apply. The selected model or CLI backend may
 still require its own provider authentication.
+
+## Local PR quality gate
+
+```bash
+qmax-code gate --base origin/main
+```
+
+The gate compares the complete local candidate—committed, staged, unstaged, and
+untracked files—with the merge base of the requested ref, runs read-only
+deterministic repository checks, and prints the changed-file scope plus bounded,
+redacted failure evidence. The MVP supports Go repositories and runs
+`git diff --check`, `go test ./...`, and `go vet ./...`. It runs before login or
+backend setup and does not require QualityMax cloud or an inference provider.
+
+Exit status is `0` for PASS, `1` for FAIL, and `2` when the gate is INCOMPLETE
+because its ref, repository, or required tooling could not be resolved.
 
 ## Authentication commands
 
@@ -233,6 +250,7 @@ standalone local-only mode because they depend on QualityMax services.
 
 | Command | Action |
 | --- | --- |
+| `/gate [base]` | Run the local PR quality gate; defaults to `origin/main`. |
 | `/help` | Print in-app help. |
 | `/quit`, `/exit`, `/q` | Save when configured and exit. |
 

--- a/gate_command.go
+++ b/gate_command.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/qualitymax/qmax-code/internal/gate"
+)
+
+func runGateCommand(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	opts, err := gate.ParseCLIArgs(args, io.Discard)
+	if err != nil {
+		if gate.IsHelp(err) {
+			gate.WriteCLIUsage(stdout)
+			return 0
+		}
+		_, _ = fmt.Fprintf(stderr, "qmax-code gate: %v\n", err)
+		gate.WriteCLIUsage(stderr)
+		return 2
+	}
+
+	result := gate.Run(ctx, gate.Options{Base: opts.Base, Dir: "."})
+	gate.WriteText(stdout, result)
+	return result.ExitCode()
+}

--- a/gate_command_test.go
+++ b/gate_command_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunGateCommandHelp(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runGateCommand(context.Background(), []string{"--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "Usage: qmax-code gate") {
+		t.Fatalf("stdout = %q, want gate usage", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunGateCommandUsageError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runGateCommand(context.Background(), []string{"unexpected"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unexpected gate argument") {
+		t.Fatalf("stderr = %q, want actionable usage error", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+}

--- a/internal/gate/cli.go
+++ b/internal/gate/cli.go
@@ -1,0 +1,45 @@
+package gate
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+)
+
+// CLIOptions are the stable arguments for the gate subcommand.
+type CLIOptions struct {
+	Base string
+}
+
+// ParseCLIArgs parses qmax-code gate arguments without touching global flags.
+func ParseCLIArgs(args []string, errorOutput io.Writer) (CLIOptions, error) {
+	flags := flag.NewFlagSet("gate", flag.ContinueOnError)
+	flags.SetOutput(errorOutput)
+	base := flags.String("base", DefaultBase, "Git ref to compare HEAD against")
+	flags.Usage = func() { WriteCLIUsage(errorOutput) }
+	if err := flags.Parse(args); err != nil {
+		return CLIOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return CLIOptions{}, fmt.Errorf("unexpected gate argument %q", flags.Arg(0))
+	}
+	if err := validateBase(*base); err != nil {
+		return CLIOptions{}, err
+	}
+	return CLIOptions{Base: *base}, nil
+}
+
+// WriteCLIUsage prints only non-sensitive static command help.
+func WriteCLIUsage(w io.Writer) {
+	const usage = `Usage: qmax-code gate [--base REF]
+
+Runs the local, read-only PR quality gate.
+Exit codes: 0 PASS, 1 FAIL, 2 INCOMPLETE or usage error.
+`
+	_, _ = io.WriteString(w, usage)
+}
+
+func IsHelp(err error) bool {
+	return errors.Is(err, flag.ErrHelp)
+}

--- a/internal/gate/cli_test.go
+++ b/internal/gate/cli_test.go
@@ -1,0 +1,45 @@
+package gate
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseCLIArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantBase string
+		wantErr  bool
+	}{
+		{name: "default", wantBase: DefaultBase},
+		{name: "explicit", args: []string{"--base", "develop"}, wantBase: "develop"},
+		{name: "revision expression", args: []string{"--base", "HEAD~3"}, wantBase: "HEAD~3"},
+		{name: "extra argument", args: []string{"develop"}, wantErr: true},
+		{name: "option shaped ref", args: []string{"--base", "--all"}, wantErr: true},
+		{name: "empty ref", args: []string{"--base", ""}, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var output bytes.Buffer
+			got, err := ParseCLIArgs(tc.args, &output)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseCLIArgs() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got.Base != tc.wantBase {
+				t.Fatalf("base = %q, want %q", got.Base, tc.wantBase)
+			}
+		})
+	}
+}
+
+func TestParseCLIHelp(t *testing.T) {
+	var output bytes.Buffer
+	_, err := ParseCLIArgs([]string{"--help"}, &output)
+	if !IsHelp(err) {
+		t.Fatalf("error = %v, want help", err)
+	}
+	if output.String() == "" {
+		t.Fatal("help output is empty")
+	}
+}

--- a/internal/gate/cli_test.go
+++ b/internal/gate/cli_test.go
@@ -2,6 +2,8 @@ package gate
 
 import (
 	"bytes"
+	"errors"
+	"flag"
 	"testing"
 )
 
@@ -41,5 +43,14 @@ func TestParseCLIHelp(t *testing.T) {
 	}
 	if output.String() == "" {
 		t.Fatal("help output is empty")
+	}
+}
+
+func TestIsHelp(t *testing.T) {
+	if !IsHelp(errors.Join(errors.New("wrapped"), flag.ErrHelp)) {
+		t.Fatal("IsHelp() did not recognize wrapped help error")
+	}
+	if IsHelp(errors.New("ordinary failure")) || IsHelp(nil) {
+		t.Fatal("IsHelp() classified a non-help error as help")
 	}
 }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -1,0 +1,322 @@
+// Package gate implements the deterministic, local PR quality gate shared by
+// qmax-code's CLI and interactive console.
+package gate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/qualitymax/qmax-code/internal/security"
+)
+
+const (
+	DefaultBase    = "origin/main"
+	DefaultTimeout = 10 * time.Minute
+)
+
+// Verdict is the gate's stable merge decision.
+type Verdict string
+
+const (
+	Pass       Verdict = "PASS"
+	Fail       Verdict = "FAIL"
+	Incomplete Verdict = "INCOMPLETE"
+)
+
+// CheckStatus describes the result of one deterministic check.
+type CheckStatus string
+
+const (
+	CheckPass       CheckStatus = "PASS"
+	CheckFail       CheckStatus = "FAIL"
+	CheckIncomplete CheckStatus = "INCOMPLETE"
+)
+
+// Check records one command without retaining unbounded command output.
+type Check struct {
+	Name     string
+	Command  string
+	Status   CheckStatus
+	Duration time.Duration
+	Evidence string
+}
+
+// Result is shared by all gate presentation surfaces.
+type Result struct {
+	Base      string
+	MergeBase string
+	Head      string
+	Files     []string
+	// FilesTruncated indicates that Files contains only the complete paths that
+	// fit inside the bounded command-output budget.
+	FilesTruncated bool
+	Checks         []Check
+	Verdict        Verdict
+	Incomplete     string
+}
+
+// ExitCode follows the documented command contract.
+func (r Result) ExitCode() int {
+	switch r.Verdict {
+	case Pass:
+		return 0
+	case Fail:
+		return 1
+	default:
+		return 2
+	}
+}
+
+// Options controls local gate execution.
+type Options struct {
+	Base       string
+	Dir        string
+	Timeout    time.Duration
+	Runner     Runner
+	OnProgress func(string)
+}
+
+// Run scopes the complete local candidate diff and runs the repository checks.
+// It does not modify source files, invoke an inference backend, or contact
+// QualityMax.
+func Run(ctx context.Context, opts Options) Result {
+	base := strings.TrimSpace(opts.Base)
+	if base == "" {
+		base = DefaultBase
+	}
+	dir := opts.Dir
+	if dir == "" {
+		dir = "."
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+
+	result := Result{Base: base, Verdict: Incomplete}
+	if err := validateBase(base); err != nil {
+		result.Incomplete = err.Error()
+		return result
+	}
+
+	progress(opts, "scoping local changes against "+base)
+	baseSHA, err := runRequired(ctx, runner, dir, timeout, "git", "rev-parse", "--verify", "--end-of-options", base+"^{commit}")
+	if err != nil {
+		result.Incomplete = fmt.Sprintf("cannot resolve base %q: %s", base, safeError(err))
+		return result
+	}
+	headSHA, err := runRequired(ctx, runner, dir, timeout, "git", "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		result.Incomplete = "cannot resolve HEAD: " + safeError(err)
+		return result
+	}
+	mergeBase, err := runRequired(ctx, runner, dir, timeout, "git", "merge-base", strings.TrimSpace(baseSHA), strings.TrimSpace(headSHA))
+	if err != nil {
+		result.Incomplete = fmt.Sprintf("cannot find a merge base with %q: %s", base, safeError(err))
+		return result
+	}
+	result.MergeBase = strings.TrimSpace(mergeBase)
+	result.Head = strings.TrimSpace(headSHA)
+
+	fileOutput, err := runRequired(ctx, runner, dir, timeout, "git", "diff", "--name-only", "-z", result.MergeBase, "--")
+	if err != nil {
+		result.Incomplete = "cannot read changed-file scope: " + safeError(err)
+		return result
+	}
+	untrackedOutput, err := runRequired(ctx, runner, dir, timeout, "git", "ls-files", "--others", "--exclude-standard", "-z", "--")
+	if err != nil {
+		result.Incomplete = "cannot read untracked-file scope: " + safeError(err)
+		return result
+	}
+	trackedFiles, trackedTruncated := parseNULTerminated(fileOutput)
+	untrackedFiles, untrackedTruncated := parseNULTerminated(untrackedOutput)
+	result.Files = mergeFiles(trackedFiles, untrackedFiles)
+	result.FilesTruncated = trackedTruncated || untrackedTruncated
+
+	checks := []commandCheck{{
+		name:    "diff integrity",
+		command: "git diff --check " + result.MergeBase,
+		binary:  "git",
+		args:    []string{"diff", "--check", result.MergeBase, "--"},
+	}}
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+		checks = append(checks,
+			commandCheck{name: "Go tests", command: "go test ./...", binary: "go", args: []string{"test", "./..."}},
+			commandCheck{name: "Go vet", command: "go vet ./...", binary: "go", args: []string{"vet", "./..."}},
+		)
+	} else if errors.Is(err, os.ErrNotExist) {
+		result.Incomplete = "no supported repository checks found (the gate MVP currently supports Go repositories)"
+		return result
+	} else {
+		result.Incomplete = "cannot inspect repository manifest: " + safeError(err)
+		return result
+	}
+
+	for _, spec := range checks {
+		progress(opts, "running "+spec.command)
+		result.Checks = append(result.Checks, runCheck(ctx, runner, dir, timeout, spec))
+	}
+	result.Verdict = aggregateVerdict(result.Checks)
+	return result
+}
+
+type commandCheck struct {
+	name    string
+	command string
+	binary  string
+	args    []string
+}
+
+func runCheck(ctx context.Context, runner Runner, dir string, timeout time.Duration, spec commandCheck) Check {
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	started := time.Now()
+	output, err := runner.Run(checkCtx, dir, spec.binary, spec.args...)
+	check := Check{Name: spec.name, Command: spec.command, Duration: time.Since(started)}
+	if err == nil {
+		check.Status = CheckPass
+		return check
+	}
+	check.Evidence = cleanEvidence(output, err)
+	if errors.Is(err, ErrToolUnavailable) || errors.Is(err, ErrTimedOut) || errors.Is(err, context.Canceled) {
+		check.Status = CheckIncomplete
+	} else {
+		check.Status = CheckFail
+	}
+	return check
+}
+
+func runRequired(ctx context.Context, runner Runner, dir string, timeout time.Duration, name string, args ...string) (string, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	output, err := runner.Run(commandCtx, dir, name, args...)
+	if err != nil {
+		if evidence := cleanEvidence(output, nil); evidence != "" {
+			return output, fmt.Errorf("%w: %s", err, evidence)
+		}
+	}
+	return output, err
+}
+
+func aggregateVerdict(checks []Check) Verdict {
+	verdict := Pass
+	for _, check := range checks {
+		switch check.Status {
+		case CheckIncomplete:
+			return Incomplete
+		case CheckFail:
+			verdict = Fail
+		}
+	}
+	return verdict
+}
+
+func validateBase(base string) error {
+	if base == "" {
+		return errors.New("base ref cannot be empty")
+	}
+	if len(base) > 256 {
+		return errors.New("base ref is too long")
+	}
+	if strings.HasPrefix(base, "-") {
+		return fmt.Errorf("invalid base ref %q", base)
+	}
+	for _, r := range base {
+		if unicode.IsSpace(r) || unicode.IsControl(r) || unicode.In(r, unicode.Cf) {
+			return fmt.Errorf("invalid base ref %q", base)
+		}
+	}
+	return nil
+}
+
+func parseNULTerminated(output string) ([]string, bool) {
+	truncated := strings.HasSuffix(output, truncationMarker)
+	if truncated {
+		output = strings.TrimSuffix(output, truncationMarker)
+		if lastTerminator := strings.LastIndexByte(output, 0); lastTerminator >= 0 {
+			output = output[:lastTerminator+1]
+		} else {
+			output = ""
+		}
+	}
+	parts := strings.Split(output, "\x00")
+	files := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			files = append(files, part)
+		}
+	}
+	return files, truncated
+}
+
+func mergeFiles(groups ...[]string) []string {
+	unique := make(map[string]struct{})
+	for _, group := range groups {
+		for _, file := range group {
+			unique[file] = struct{}{}
+		}
+	}
+	files := make([]string, 0, len(unique))
+	for file := range unique {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func cleanEvidence(output string, err error) string {
+	evidence := strings.TrimSpace(output)
+	if evidence == "" && err != nil {
+		evidence = err.Error()
+	}
+	return sanitizeTerminalText(security.RedactSensitive(evidence))
+}
+
+func safeError(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+	return sanitizeTerminalText(security.RedactSensitive(err.Error()))
+}
+
+func sanitizeTerminalText(text string) string {
+	var safe strings.Builder
+	for _, r := range text {
+		switch {
+		case r == '\n' || r == '\t':
+			safe.WriteRune(r)
+		case unicode.IsControl(r) || unicode.In(r, unicode.Cf):
+			if r <= 0xffff {
+				fmt.Fprintf(&safe, "\\u%04x", r)
+			} else {
+				fmt.Fprintf(&safe, "\\U%08x", r)
+			}
+		default:
+			safe.WriteRune(r)
+		}
+	}
+	return safe.String()
+}
+
+func progress(opts Options, message string) {
+	if opts.OnProgress != nil {
+		opts.OnProgress(message)
+	}
+}
+
+// DisplayPath quotes paths so unusual filenames cannot inject terminal lines.
+func DisplayPath(path string) string {
+	return strconv.QuoteToASCII(path)
+}

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -204,10 +204,11 @@ func runRequired(ctx context.Context, runner Runner, dir string, timeout time.Du
 	output, err := runner.Run(commandCtx, dir, name, args...)
 	if err != nil {
 		if evidence := cleanEvidence(output, nil); evidence != "" {
-			return output, fmt.Errorf("%w: %s", err, evidence)
+			return "", fmt.Errorf("%w: %s", err, evidence)
 		}
+		return "", err
 	}
-	return output, err
+	return output, nil
 }
 
 func aggregateVerdict(checks []Check) Verdict {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -201,10 +201,11 @@ func TestCleanEvidenceRedactsSensitiveOutput(t *testing.T) {
 }
 
 func TestRunRequiredClearsRawOutputAndSanitizesError(t *testing.T) {
+	cause := errors.New("exit status 1")
 	runner := &fakeRunner{responses: map[string]fakeResponse{
 		"git inspect": {
 			output: "api_key=fixture-only-value\ncommand failed\x1b[2J",
-			err:    errors.New("exit status 1"),
+			err:    cause,
 		},
 	}}
 
@@ -214,6 +215,9 @@ func TestRunRequiredClearsRawOutputAndSanitizesError(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("runRequired() error = nil")
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("runRequired() error = %v, want original cause", err)
 	}
 	message := err.Error()
 	if strings.Contains(message, "fixture-only-value") || strings.ContainsRune(message, '\x1b') {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -96,6 +96,9 @@ func TestRunFailsAndRedactsCheckEvidence(t *testing.T) {
 	if result.Verdict != Fail || result.ExitCode() != 1 {
 		t.Fatalf("result = %+v, want FAIL/1", result)
 	}
+	if len(result.Checks) < 2 {
+		t.Fatalf("checks = %+v, want go test result", result.Checks)
+	}
 	evidence := result.Checks[1].Evidence
 	if strings.Contains(evidence, "do-not-print") || !strings.Contains(evidence, "[REDACTED]") {
 		t.Fatalf("evidence was not redacted: %q", evidence)
@@ -109,8 +112,14 @@ func TestRunMarksMissingToolIncomplete(t *testing.T) {
 
 	result := Run(context.Background(), Options{Base: DefaultBase, Dir: dir, Runner: runner})
 
-	if result.Verdict != Incomplete || result.Checks[2].Status != CheckIncomplete {
+	if result.Verdict != Incomplete {
 		t.Fatalf("result = %+v, want incomplete tooling result", result)
+	}
+	if len(result.Checks) < 3 {
+		t.Fatalf("checks = %+v, want go vet result", result.Checks)
+	}
+	if result.Checks[2].Status != CheckIncomplete {
+		t.Fatalf("go vet check = %+v, want incomplete", result.Checks[2])
 	}
 }
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -56,8 +56,15 @@ func TestRunPassesSharedGoGate(t *testing.T) {
 	if len(result.Checks) != 3 {
 		t.Fatalf("checks = %d, want 3", len(result.Checks))
 	}
-	if len(progress) != 4 {
-		t.Fatalf("progress events = %v, want scope plus 3 checks", progress)
+	for _, wantPrefix := range []string{
+		"scoping local changes against origin/main",
+		"running git diff --check",
+		"running go test ./...",
+		"running go vet ./...",
+	} {
+		if !containsPrefix(progress, wantPrefix) {
+			t.Fatalf("progress events = %v, want prefix %q", progress, wantPrefix)
+		}
 	}
 }
 
@@ -275,6 +282,15 @@ func equalStrings(left, right []string) bool {
 		}
 	}
 	return true
+}
+
+func containsPrefix(values []string, prefix string) bool {
+	for _, value := range values {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func findCheck(t *testing.T, checks []Check, command string) Check {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -1,0 +1,204 @@
+package gate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeResponse struct {
+	output string
+	err    error
+}
+
+type fakeRunner struct {
+	responses map[string]fakeResponse
+	calls     []string
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, name string, args ...string) (string, error) {
+	key := strings.Join(append([]string{name}, args...), " ")
+	f.calls = append(f.calls, key)
+	response, ok := f.responses[key]
+	if !ok {
+		return "", errors.New("unexpected command: " + key)
+	}
+	return response.output, response.err
+}
+
+func TestRunPassesSharedGoGate(t *testing.T) {
+	dir := goRepository(t)
+	runner := successfulRunner()
+	var progress []string
+
+	result := Run(context.Background(), Options{
+		Base:   "origin/main",
+		Dir:    dir,
+		Runner: runner,
+		OnProgress: func(message string) {
+			progress = append(progress, message)
+		},
+	})
+
+	if result.Verdict != Pass {
+		t.Fatalf("verdict = %s, want PASS; result=%+v", result.Verdict, result)
+	}
+	if result.ExitCode() != 0 {
+		t.Fatalf("exit code = %d, want 0", result.ExitCode())
+	}
+	if got, want := result.Files, []string{"docs/COMMANDS.md", "internal/gate/gate.go", "main.go"}; !equalStrings(got, want) {
+		t.Fatalf("files = %v, want %v", got, want)
+	}
+	if len(result.Checks) != 3 {
+		t.Fatalf("checks = %d, want 3", len(result.Checks))
+	}
+	if len(progress) != 4 {
+		t.Fatalf("progress events = %v, want scope plus 3 checks", progress)
+	}
+}
+
+func TestRunReturnsIncompleteWhenBaseCannotResolve(t *testing.T) {
+	dir := goRepository(t)
+	runner := &fakeRunner{responses: map[string]fakeResponse{
+		"git rev-parse --verify --end-of-options missing^{commit}": {output: "fatal: bad revision", err: errors.New("exit status 128")},
+	}}
+
+	result := Run(context.Background(), Options{Base: "missing", Dir: dir, Runner: runner})
+
+	if result.Verdict != Incomplete || result.ExitCode() != 2 {
+		t.Fatalf("result = %+v, want INCOMPLETE/2", result)
+	}
+	if !strings.Contains(result.Incomplete, `cannot resolve base "missing"`) {
+		t.Fatalf("incomplete reason = %q", result.Incomplete)
+	}
+	if !strings.Contains(result.Incomplete, "fatal: bad revision") {
+		t.Fatalf("incomplete reason lacks bounded command evidence: %q", result.Incomplete)
+	}
+	if len(result.Checks) != 0 {
+		t.Fatalf("checks ran after scope failure: %+v", result.Checks)
+	}
+}
+
+func TestRunFailsAndRedactsCheckEvidence(t *testing.T) {
+	dir := goRepository(t)
+	runner := successfulRunner()
+	runner.responses["go test ./..."] = fakeResponse{
+		output: "TestBroken failed\napi_key=do-not-print",
+		err:    errors.New("exit status 1"),
+	}
+
+	result := Run(context.Background(), Options{Base: DefaultBase, Dir: dir, Runner: runner})
+
+	if result.Verdict != Fail || result.ExitCode() != 1 {
+		t.Fatalf("result = %+v, want FAIL/1", result)
+	}
+	evidence := result.Checks[1].Evidence
+	if strings.Contains(evidence, "do-not-print") || !strings.Contains(evidence, "[REDACTED]") {
+		t.Fatalf("evidence was not redacted: %q", evidence)
+	}
+}
+
+func TestRunMarksMissingToolIncomplete(t *testing.T) {
+	dir := goRepository(t)
+	runner := successfulRunner()
+	runner.responses["go vet ./..."] = fakeResponse{err: ErrToolUnavailable}
+
+	result := Run(context.Background(), Options{Base: DefaultBase, Dir: dir, Runner: runner})
+
+	if result.Verdict != Incomplete || result.Checks[2].Status != CheckIncomplete {
+		t.Fatalf("result = %+v, want incomplete tooling result", result)
+	}
+}
+
+func TestRunWithoutSupportedManifestIsIncomplete(t *testing.T) {
+	runner := successfulRunner()
+	result := Run(context.Background(), Options{Base: DefaultBase, Dir: t.TempDir(), Runner: runner})
+	if result.Verdict != Incomplete || !strings.Contains(result.Incomplete, "supports Go") {
+		t.Fatalf("result = %+v, want unsupported repository message", result)
+	}
+}
+
+func TestAggregateVerdict(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []Check
+		want   Verdict
+	}{
+		{name: "all pass", checks: []Check{{Status: CheckPass}}, want: Pass},
+		{name: "failure", checks: []Check{{Status: CheckPass}, {Status: CheckFail}}, want: Fail},
+		{name: "incomplete dominates", checks: []Check{{Status: CheckFail}, {Status: CheckIncomplete}}, want: Incomplete},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := aggregateVerdict(tc.checks); got != tc.want {
+				t.Fatalf("aggregateVerdict() = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDisplayPathQuotesTerminalControlCharacters(t *testing.T) {
+	if got := DisplayPath("safe\nforged"); got != `"safe\nforged"` {
+		t.Fatalf("DisplayPath() = %q", got)
+	}
+}
+
+func TestParseNULTerminatedDropsPartialPathWhenOutputIsTruncated(t *testing.T) {
+	files, truncated := parseNULTerminated("one.go\x00partial" + truncationMarker)
+	if !truncated {
+		t.Fatal("parseNULTerminated() did not report truncation")
+	}
+	if want := []string{"one.go"}; !equalStrings(files, want) {
+		t.Fatalf("files = %v, want %v", files, want)
+	}
+}
+
+func TestCleanEvidenceNeutralizesTerminalControlCharacters(t *testing.T) {
+	got := cleanEvidence("failure\x1b[2J\rforged", errors.New("exit status 1"))
+	if strings.ContainsRune(got, '\x1b') || strings.ContainsRune(got, '\r') {
+		t.Fatalf("cleanEvidence() retained terminal controls: %q", got)
+	}
+	if !strings.Contains(got, `\u001b`) || !strings.Contains(got, `\u000d`) {
+		t.Fatalf("cleanEvidence() did not preserve visible evidence: %q", got)
+	}
+}
+
+func goRepository(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/gate\n\ngo 1.24\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func successfulRunner() *fakeRunner {
+	baseSHA := strings.Repeat("a", 40)
+	headSHA := strings.Repeat("b", 40)
+	mergeSHA := strings.Repeat("c", 40)
+	return &fakeRunner{responses: map[string]fakeResponse{
+		"git rev-parse --verify --end-of-options origin/main^{commit}": {output: baseSHA + "\n"},
+		"git rev-parse --verify HEAD^{commit}":                         {output: headSHA + "\n"},
+		"git merge-base " + baseSHA + " " + headSHA:                    {output: mergeSHA + "\n"},
+		"git diff --name-only -z " + mergeSHA + " --":                  {output: "main.go\x00internal/gate/gate.go\x00"},
+		"git ls-files --others --exclude-standard -z --":               {output: "docs/COMMANDS.md\x00internal/gate/gate.go\x00"},
+		"git diff --check " + mergeSHA + " --":                         {},
+		"go test ./...":                                                {},
+		"go vet ./...":                                                 {},
+	}}
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 type fakeResponse struct {
@@ -121,6 +122,18 @@ func TestRunWithoutSupportedManifestIsIncomplete(t *testing.T) {
 	}
 }
 
+func TestRunReturnsIncompleteWhenManifestCannotBeInspected(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(dir, []byte("fixture"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := Run(context.Background(), Options{Base: DefaultBase, Dir: dir, Runner: successfulRunner()})
+	if result.Verdict != Incomplete || !strings.Contains(result.Incomplete, "cannot inspect repository manifest") {
+		t.Fatalf("result = %+v, want manifest inspection error", result)
+	}
+}
+
 func TestAggregateVerdict(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -140,9 +153,23 @@ func TestAggregateVerdict(t *testing.T) {
 	}
 }
 
-func TestDisplayPathQuotesTerminalControlCharacters(t *testing.T) {
-	if got := DisplayPath("safe\nforged"); got != `"safe\nforged"` {
-		t.Fatalf("DisplayPath() = %q", got)
+func TestDisplayPathQuotesUnusualFilenames(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "terminal control", path: "safe\nforged", want: `"safe\nforged"`},
+		{name: "spaces", path: "file with spaces", want: `"file with spaces"`},
+		{name: "unicode", path: "unicode-αβ", want: `"unicode-\u03b1\u03b2"`},
+		{name: "quote", path: `quote"here`, want: `"quote\"here"`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DisplayPath(tc.path); got != tc.want {
+				t.Fatalf("DisplayPath(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
 	}
 }
 
@@ -163,6 +190,45 @@ func TestCleanEvidenceNeutralizesTerminalControlCharacters(t *testing.T) {
 	}
 	if !strings.Contains(got, `\u001b`) || !strings.Contains(got, `\u000d`) {
 		t.Fatalf("cleanEvidence() did not preserve visible evidence: %q", got)
+	}
+}
+
+func TestCleanEvidenceRedactsSensitiveOutput(t *testing.T) {
+	got := cleanEvidence("command failed\napi_key=fixture-only-value", nil)
+	if strings.Contains(got, "fixture-only-value") || !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("cleanEvidence() did not redact sensitive output: %q", got)
+	}
+}
+
+func TestRunRequiredClearsRawOutputAndSanitizesError(t *testing.T) {
+	runner := &fakeRunner{responses: map[string]fakeResponse{
+		"git inspect": {
+			output: "api_key=fixture-only-value\ncommand failed\x1b[2J",
+			err:    errors.New("exit status 1"),
+		},
+	}}
+
+	output, err := runRequired(context.Background(), runner, ".", time.Second, "git", "inspect")
+	if output != "" {
+		t.Fatalf("runRequired() returned raw output on error: %q", output)
+	}
+	if err == nil {
+		t.Fatal("runRequired() error = nil")
+	}
+	message := err.Error()
+	if strings.Contains(message, "fixture-only-value") || strings.ContainsRune(message, '\x1b') {
+		t.Fatalf("runRequired() returned unsafe error evidence: %q", message)
+	}
+	if !strings.Contains(message, "[REDACTED]") || !strings.Contains(message, `\u001b`) {
+		t.Fatalf("runRequired() omitted sanitized evidence: %q", message)
+	}
+}
+
+func TestValidateBaseRejectsUnicodeControls(t *testing.T) {
+	for _, base := range []string{"main\nforged", "main\u200bforged"} {
+		if err := validateBase(base); err == nil {
+			t.Fatalf("validateBase(%q) accepted a control character", base)
+		}
 	}
 }
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -96,10 +96,7 @@ func TestRunFailsAndRedactsCheckEvidence(t *testing.T) {
 	if result.Verdict != Fail || result.ExitCode() != 1 {
 		t.Fatalf("result = %+v, want FAIL/1", result)
 	}
-	if len(result.Checks) < 2 {
-		t.Fatalf("checks = %+v, want go test result", result.Checks)
-	}
-	evidence := result.Checks[1].Evidence
+	evidence := findCheck(t, result.Checks, "go test ./...").Evidence
 	if strings.Contains(evidence, "do-not-print") || !strings.Contains(evidence, "[REDACTED]") {
 		t.Fatalf("evidence was not redacted: %q", evidence)
 	}
@@ -115,11 +112,9 @@ func TestRunMarksMissingToolIncomplete(t *testing.T) {
 	if result.Verdict != Incomplete {
 		t.Fatalf("result = %+v, want incomplete tooling result", result)
 	}
-	if len(result.Checks) < 3 {
-		t.Fatalf("checks = %+v, want go vet result", result.Checks)
-	}
-	if result.Checks[2].Status != CheckIncomplete {
-		t.Fatalf("go vet check = %+v, want incomplete", result.Checks[2])
+	vet := findCheck(t, result.Checks, "go vet ./...")
+	if vet.Status != CheckIncomplete {
+		t.Fatalf("go vet check = %+v, want incomplete", vet)
 	}
 }
 
@@ -280,4 +275,15 @@ func equalStrings(left, right []string) bool {
 		}
 	}
 	return true
+}
+
+func findCheck(t *testing.T, checks []Check, command string) Check {
+	t.Helper()
+	for _, check := range checks {
+		if check.Command == command {
+			return check
+		}
+	}
+	t.Fatalf("checks = %+v, want command %q", checks, command)
+	return Check{}
 }

--- a/internal/gate/output.go
+++ b/internal/gate/output.go
@@ -1,0 +1,59 @@
+package gate
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// WriteText renders the stable human-readable gate report.
+func WriteText(w io.Writer, result Result) {
+	_, _ = fmt.Fprintln(w, "qmax-code gate")
+	_, _ = fmt.Fprintf(w, "Base: %s\n", result.Base)
+	if result.MergeBase != "" {
+		_, _ = fmt.Fprintf(w, "Merge base: %s\n", shortSHA(result.MergeBase))
+	}
+	if result.Head != "" {
+		_, _ = fmt.Fprintf(w, "Head: %s\n", shortSHA(result.Head))
+	}
+	if result.Incomplete != "" {
+		_, _ = fmt.Fprintf(w, "Scope: incomplete — %s\n", result.Incomplete)
+	} else if result.FilesTruncated {
+		_, _ = fmt.Fprintf(w, "Scope: at least %d changed file(s); list truncated\n", len(result.Files))
+		for _, file := range result.Files {
+			_, _ = fmt.Fprintf(w, "  %s\n", DisplayPath(file))
+		}
+	} else {
+		_, _ = fmt.Fprintf(w, "Scope: %d changed file(s)\n", len(result.Files))
+		for _, file := range result.Files {
+			_, _ = fmt.Fprintf(w, "  %s\n", DisplayPath(file))
+		}
+	}
+	if len(result.Checks) > 0 {
+		_, _ = fmt.Fprintln(w, "Checks:")
+		for _, check := range result.Checks {
+			_, _ = fmt.Fprintf(w, "  %-10s %s (%s)\n", check.Status, check.Command, formatDuration(check.Duration))
+			if check.Evidence != "" {
+				for _, line := range strings.Split(check.Evidence, "\n") {
+					_, _ = fmt.Fprintf(w, "    %s\n", line)
+				}
+			}
+		}
+	}
+	_, _ = fmt.Fprintf(w, "Verdict: %s\n", result.Verdict)
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+func formatDuration(duration time.Duration) string {
+	if duration < time.Millisecond {
+		return "<1ms"
+	}
+	return duration.Round(time.Millisecond).String()
+}

--- a/internal/gate/runner.go
+++ b/internal/gate/runner.go
@@ -1,0 +1,80 @@
+package gate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+)
+
+const (
+	maxCommandOutput = 12 * 1024
+	truncationMarker = "\n… output truncated …"
+)
+
+var (
+	ErrToolUnavailable = errors.New("required tool is unavailable")
+	ErrTimedOut        = errors.New("command timed out")
+)
+
+// Runner is injectable so gate behavior can be tested without spawning tools.
+type Runner interface {
+	Run(ctx context.Context, dir, name string, args ...string) (string, error)
+}
+
+// ExecRunner runs commands directly, never through a shell.
+type ExecRunner struct{}
+
+func (ExecRunner) Run(ctx context.Context, dir, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	output := &limitWriter{limit: maxCommandOutput}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	err := cmd.Run()
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return output.String(), ErrTimedOut
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return output.String(), context.Canceled
+	}
+	var execErr *exec.Error
+	if errors.As(err, &execErr) {
+		return output.String(), fmtToolUnavailable(name, execErr)
+	}
+	return output.String(), err
+}
+
+func fmtToolUnavailable(name string, err error) error {
+	return errors.Join(ErrToolUnavailable, errors.New(name+": "+err.Error()))
+}
+
+type limitWriter struct {
+	buf       []byte
+	limit     int
+	truncated bool
+}
+
+func (w *limitWriter) Write(p []byte) (int, error) {
+	originalLen := len(p)
+	remaining := w.limit - len(w.buf)
+	if remaining > 0 {
+		if len(p) > remaining {
+			p = p[:remaining]
+			w.truncated = true
+		}
+		w.buf = append(w.buf, p...)
+	} else if originalLen > 0 {
+		w.truncated = true
+	}
+	return originalLen, nil
+}
+
+func (w *limitWriter) String() string {
+	if !w.truncated {
+		return string(w.buf)
+	}
+	return string(w.buf) + truncationMarker
+}
+
+var _ io.Writer = (*limitWriter)(nil)

--- a/internal/gate/runner.go
+++ b/internal/gate/runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"os/exec"
+	"sync"
 )
 
 const (
@@ -50,12 +51,16 @@ func fmtToolUnavailable(name string, err error) error {
 }
 
 type limitWriter struct {
+	mu        sync.Mutex
 	buf       []byte
 	limit     int
 	truncated bool
 }
 
 func (w *limitWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	originalLen := len(p)
 	remaining := w.limit - len(w.buf)
 	if remaining > 0 {
@@ -71,6 +76,9 @@ func (w *limitWriter) Write(p []byte) (int, error) {
 }
 
 func (w *limitWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	if !w.truncated {
 		return string(w.buf)
 	}

--- a/internal/gate/runner.go
+++ b/internal/gate/runner.go
@@ -57,6 +57,8 @@ type limitWriter struct {
 	truncated bool
 }
 
+// Write accepts all input so evidence truncation never changes a command's
+// exit status, while retaining only the bounded prefix for display.
 func (w *limitWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/gate/runner_test.go
+++ b/internal/gate/runner_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestLimitWriterBoundsOutput(t *testing.T) {
+func TestLimitWriterConsumesOverflowAndBoundsEvidence(t *testing.T) {
 	w := &limitWriter{limit: 4}
 	input := "abcdefgh"
 	n, err := w.Write([]byte(input))
@@ -18,6 +18,18 @@ func TestLimitWriterBoundsOutput(t *testing.T) {
 	}
 	if got := w.String(); !strings.HasPrefix(got, "abcd") || !strings.Contains(got, "truncated") {
 		t.Fatalf("String() = %q", got)
+	}
+}
+
+func TestFmtToolUnavailablePreservesClassificationAndContext(t *testing.T) {
+	cause := errors.New("missing executable")
+	err := fmtToolUnavailable("git", cause)
+
+	if !errors.Is(err, ErrToolUnavailable) {
+		t.Fatalf("fmtToolUnavailable() error = %v, want ErrToolUnavailable", err)
+	}
+	if !strings.Contains(err.Error(), "git: missing executable") {
+		t.Fatalf("fmtToolUnavailable() error = %q, want tool and cause", err)
 	}
 }
 

--- a/internal/gate/runner_test.go
+++ b/internal/gate/runner_test.go
@@ -1,0 +1,18 @@
+package gate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLimitWriterBoundsOutput(t *testing.T) {
+	w := &limitWriter{limit: 4}
+	input := "abcdefgh"
+	n, err := w.Write([]byte(input))
+	if err != nil || n != len(input) {
+		t.Fatalf("Write() = %d, %v", n, err)
+	}
+	if got := w.String(); !strings.HasPrefix(got, "abcd") || !strings.Contains(got, "truncated") {
+		t.Fatalf("String() = %q", got)
+	}
+}

--- a/internal/gate/runner_test.go
+++ b/internal/gate/runner_test.go
@@ -1,7 +1,11 @@
 package gate
 
 import (
+	"context"
+	"errors"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -14,5 +18,46 @@ func TestLimitWriterBoundsOutput(t *testing.T) {
 	}
 	if got := w.String(); !strings.HasPrefix(got, "abcd") || !strings.Contains(got, "truncated") {
 		t.Fatalf("String() = %q", got)
+	}
+}
+
+func TestLimitWriterDoesNotTruncateExactLimit(t *testing.T) {
+	w := &limitWriter{limit: 4}
+	if n, err := w.Write([]byte("abcd")); err != nil || n != 4 {
+		t.Fatalf("Write() = %d, %v", n, err)
+	}
+	if got := w.String(); got != "abcd" {
+		t.Fatalf("String() = %q, want exact untruncated output", got)
+	}
+}
+
+func TestLimitWriterSupportsConcurrentWrites(t *testing.T) {
+	w := &limitWriter{limit: 128}
+	var group sync.WaitGroup
+	for range 64 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, _ = w.Write([]byte("abcdefgh"))
+		}()
+	}
+	group.Wait()
+
+	got := w.String()
+	if !strings.Contains(got, truncationMarker) {
+		t.Fatalf("String() = %q, want truncation marker", got)
+	}
+	if prefix := strings.TrimSuffix(got, truncationMarker); len(prefix) != 128 {
+		t.Fatalf("captured bytes = %d, want 128", len(prefix))
+	}
+}
+
+func TestExecRunnerPropagatesCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := (ExecRunner{}).Run(ctx, ".", os.Args[0], "-test.run=TestExecRunnerPropagatesCanceledContext")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context.Canceled", err)
 	}
 }

--- a/internal/repl/gate_test.go
+++ b/internal/repl/gate_test.go
@@ -1,0 +1,32 @@
+package repl
+
+import (
+	"testing"
+
+	"github.com/qualitymax/qmax-code/internal/gate"
+)
+
+func TestParseGateCommand(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{input: "/gate", want: gate.DefaultBase},
+		{input: "/gate develop", want: "develop"},
+		{input: "/gate HEAD~3", want: "HEAD~3"},
+		{input: "/gate develop extra", wantErr: true},
+		{input: "/other", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got, err := parseGateCommand(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseGateCommand() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Fatalf("base = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/qualitymax/qmax-code/internal/agent"
 	"github.com/qualitymax/qmax-code/internal/api"
+	"github.com/qualitymax/qmax-code/internal/gate"
 	"github.com/qualitymax/qmax-code/internal/session"
 	"github.com/qualitymax/qmax-code/internal/setup"
 	"github.com/qualitymax/qmax-code/internal/sysutil"
@@ -301,6 +302,21 @@ func Run(ag *agent.Agent, cliAgent agent.CLIAgent, quietMode bool, version strin
 
 		case input == "/help":
 			printHelp()
+			continue
+		case input == "/gate" || strings.HasPrefix(input, "/gate "):
+			base, err := parseGateCommand(input)
+			if err != nil {
+				term.PrintError(err.Error())
+				continue
+			}
+			result := gate.Run(context.Background(), gate.Options{
+				Base: base,
+				Dir:  ".",
+				OnProgress: func(message string) {
+					term.PrintSystem("Gate: " + message)
+				},
+			})
+			gate.WriteText(os.Stdout, result)
 			continue
 		case input == "/clear":
 			ag.ClearHistory()
@@ -1581,9 +1597,24 @@ func currentBackend(ag *agent.Agent) string {
 	return ""
 }
 
+func parseGateCommand(input string) (string, error) {
+	fields := strings.Fields(input)
+	if len(fields) == 0 || fields[0] != "/gate" {
+		return "", fmt.Errorf("usage: /gate [base]")
+	}
+	if len(fields) > 2 {
+		return "", fmt.Errorf("usage: /gate [base]")
+	}
+	if len(fields) == 1 {
+		return gate.DefaultBase, nil
+	}
+	return fields[1], nil
+}
+
 func printHelp() {
 	fmt.Println(`
 Commands:
+  /gate [base]      Run the local PR quality gate (default: origin/main)
   /orch             Pick backend, model, and effort
   /api              Switch to direct Anthropic API
   /cc               Switch to Claude Code (Agent SDK credit)

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -47,6 +47,7 @@ type SlashMenuItem struct {
 
 var slashMenuItems = []SlashMenuItem{
 	{"/help", "Show help"},
+	{"/gate", "Run local PR quality gate against origin/main or another base"},
 	{"/orch", "Backend + model + effort picker"},
 	{"/theme", "Live-preview color scheme picker"},
 	{"/cloudsync", "Toggle cloud session sync (enabled/disabled)"},

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -80,6 +81,15 @@ func main() {
 	sysutil.InitErrorReporting(Version)
 	defer sysutil.FlushErrorReporting()
 	defer sysutil.RecoverPanic()
+
+	// The local PR gate runs before authentication, setup, or backend
+	// initialization. It is deterministic, read-only, and backend-independent.
+	if len(os.Args) > 1 && os.Args[1] == "gate" {
+		if code := runGateCommand(context.Background(), os.Args[2:], os.Stdout, os.Stderr); code != 0 {
+			exitWithReceipt(code)
+		}
+		return
+	}
 
 	// `receipt` inspects prior manifests offline and does no egress of its own.
 	if len(os.Args) > 1 && os.Args[1] == "receipt" {


### PR DESCRIPTION
## Summary

- add a shared local PR quality-gate engine that scopes committed, staged, unstaged, and untracked changes against a configurable base
- expose it as `qmax-code gate --base origin/main` and interactive `/gate [base]`
- emit deterministic PASS, FAIL, or INCOMPLETE verdicts with bounded, redacted, terminal-safe evidence and exit codes 0, 1, or 2
- document the command and cover CLI, engine, runner, and interactive behavior with tests

## Security

- validate the base ref, resolve it to a commit SHA, and execute checks directly without a shell
- cap and redact command evidence, neutralize terminal control characters, and report truncated file lists explicitly
- keep the gate local and read-only with no login, inference provider, or QualityMax backend dependency

## Validation

- `go build -o qmax-code .`
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/gate`
- `golangci-lint run --new-from-rev=origin/main` — 0 new issues
- `qmax-code gate --base origin/main` — PASS over all 14 changed files
- staged secret scan — no real credentials detected; one intentional credential-shaped test fixture ignored

The repository-wide latest golangci-lint currently reports pre-existing findings on `origin/main`; this diff introduces none under `--new-from-rev=origin/main`.

Linear: [QUA-1944](https://linear.app/quality-max/issue/QUA-1944/gate-mvp-shared-engine-cli-command-and-interactive-gate)
