### PR TITLE
release: v1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.29.0] - 2026-09-02
+
 ### Added
 - `codexrunner` checkpoints carry `RolloutPath`, the local Codex rollout
   backing the thread, so a session moved to a replacement sandbox can be
@@ -12,6 +14,16 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
   `$CODEX_HOME`.
 
 ### Fixed
+- `opencode models` queries no longer fail silently in `/orch`: a transient
+  timeout or error is retried once and surfaced per provider, instead of the
+  provider's models quietly missing from the picker.
+- A failed opencode turn surfaces the real provider error (e.g. an entitlement
+  refusal masked as "Unexpected server error") with a pointer to opencode's
+  log, instead of a bare "exit status 1". Deterministic provider refusals are
+  not retried.
+- An opencode internal crash mid-turn (empty-result exit, no stream error) is
+  retried once automatically; if both attempts die, the returned error carries
+  a secret-redacted stderr tail.
 - `Continuity.Run` and `Runner.Result` now carry the rollout reference the
   checkpoint sink already receives, instead of rebuilding a checkpoint from the
   thread ID and model alone and dropping it on every turn.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,18 @@ background-job health—remain experimental and are only exposed when
 
 ## What is new
 
+### v1.29
+
+- **No more silent opencode failures:** `/orch` retries a flaky model-list
+  query once and tells you when a provider's models could not be fetched,
+  instead of them quietly disappearing from the picker.
+- **Real causes on failed turns:** a provider refusal (e.g. a model outside
+  your subscription plan) surfaces its message and a pointer to opencode's log
+  instead of a bare "exit status 1".
+- **Crash-proof turns:** an internal opencode crash mid-turn is retried
+  automatically once; the final error carries a secret-redacted stderr tail
+  when both attempts die.
+
 ### v1.28
 
 - **Public Codex runner:** the terminal-neutral `codexrunner` Go package gives

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.28.0"
+var Version = "1.29.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Version bump for v1.29.0.

- CHANGELOG: [Unreleased] → [1.29.0], including the opencode failure-diagnostics fixes from #181
- main.go Version → 1.29.0, README "What is new" section
- Tagging v1.29.0 after merge; release.yml builds 6 platforms, publishes the GitHub release and the public qmax-code-releases repo