### PR TITLE
release: v1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.30.0] - 2026-09-02
+
+### Added
+- Interactive `/settings` picker (bare `/set` opens it): toggles flip on
+  Enter, enum settings (output mode, theme, Cerebras model/reasoning) cycle,
+  numeric settings (project, budget) edit inline; `s` saves the changed rows
+  through the same validation path as `/set`, Esc discards.
+- `/set apikey` and `/set anthropic-key` without a value prompt hidden instead
+  of requiring the secret on the visible input line.
+
+### Fixed
+- Typing a fully-typed slash command that the menu did not list submitted a
+  description-matched menu row instead (typing `/update` ran `/set`, whose
+  description is "Update config"). Command-name matches now rank ahead of
+  description matches, Enter on an exactly-typed command submits it verbatim,
+  and `/update`, `/context`, `/gemma`, `/plan`, `/settings` are in the menu.
+- `/set project` and `/set budget` silently truncated malformed numbers
+  (`1e3` → 1, `0x1f` → 0, `12abc` → 12); both now parse strictly.
+- `/set project 0` explicitly clears the default project.
+- `/set` usage lists `anthropic_key`, which the switch already accepted.
+- Secret values (`/set apikey …`, `/set anthropic-key …`) are redacted from
+  the in-session input history, including whitespace variations.
+- `/set apikey` no longer panics when the session context is not initialized.
+
 ## [1.29.0] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ background-job health—remain experimental and are only exposed when
 
 ## What is new
 
+### v1.30
+
+- **Settings picker:** `/settings` (or bare `/set`) — flip toggles, cycle
+  themes and Cerebras options, edit project/budget inline; `s` saves, Esc
+  discards.
+- **Slash-menu hijack fixed:** typing `/update` used to run `/set` (its
+  description is "Update config"); an exactly-typed command now always wins.
+- **`/set` hardened:** strict number parsing, `/set project 0` clears, hidden
+  prompts for API keys, and secrets never enter the recallable history.
+
 ### v1.29
 
 - **No more silent opencode failures:** `/orch` retries a flaky model-list

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Version is set at build time via -ldflags "-X main.Version=x.y.z"
-var Version = "1.29.0"
+var Version = "1.30.0"
 
 const Name = "qmax-code"
 


### PR DESCRIPTION
Version bump for v1.30.0.

Includes #183 (slash-menu exact-command fix) and #184 (settings picker + /set hygiene). Tagging v1.30.0 after merge; release.yml builds all platforms and publishes to the public releases repo.