### PR TITLE
release: v1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.31.0] - 2026-09-05
+
+### Added
+- GPT 6 Astra is available through the native Codex harness in `/orch` and via
+  `--backend codex --model gpt-6-astra`. Its selection is retained across
+  Codex resumed turns and `/clear`; choosing Codex default continues to use
+  the local Codex configuration.
+- Claude Fable 5.1 (`claude-fable-5-1`) is selectable in `/orch` for Claude
+  Code and the Anthropic API. The `fable` alias resolves to Fable 5.1 while
+  the existing Fable 5 model remains available.
+- Orchestration documentation now explains the Go subprocess integrations for
+  Claude Code and Codex, Claude Code subscription authentication, API-key
+  billing overrides, and Fable 5.1 plan requirements.
+
+### Changed
+- Go dependencies were refreshed and source builds now require Go 1.25.13 or
+  later. CI builds the pinned linter with that same Go toolchain.
+
+### Fixed
+- Anthropic API tool continuations omit incomplete thinking blocks, avoiding
+  invalid replay of provider-signed reasoning payloads.
+
 ## [1.30.0] - 2026-09-02
 
 ### Added


### PR DESCRIPTION
Prepares v1.31.0 release notes for the GPT 6 Astra and Claude Fable 5.1 update.

Release highlights:

- Select GPT 6 Astra through the native Codex harness, with model choice retained across resumed turns and `/clear`.
- Select Claude Fable 5.1 through Claude Code or the Anthropic API; `fable` resolves to `claude-fable-5-1`.
- Document native Claude Code subscription authentication, API-key billing overrides, and the Go subprocess integrations.
- Refresh Go modules and require Go 1.25.13+ for source builds.
- Prevent invalid replay of incomplete Anthropic thinking blocks during tool continuations.

Validation: full `go test ./...`, `go vet ./...`, `go mod verify`, pinned golangci-lint, and release builds for macOS, Linux, and Windows on amd64 and arm64 all pass.
