### PR TITLE
feat: list all Codex models in /orch and add Qwen 3.8 Cerebras row

### DIFF
--- a/internal/api/cerebras.go
+++ b/internal/api/cerebras.go
@@ -19,6 +19,10 @@ const (
 	// reasoning via the top-level reasoning_effort parameter (off by default).
 	// Model ID per the Cerebras + Gemma 4 hackathon docs.
 	CerebrasGemma4Model = "gemma-4-31b"
+	// CerebrasQwen38Model is Alibaba's Qwen 3.8 as hosted on Cerebras.
+	// Announced as coming soon to the Cerebras model catalog; the ID follows
+	// Cerebras naming and must be confirmed against the live API at launch.
+	CerebrasQwen38Model = "qwen-3.8"
 )
 
 // ResolveCerebrasModel expands shorthand aliases to full Cerebras model IDs.
@@ -27,12 +31,15 @@ const (
 //	""            → CerebrasDefaultModel (gpt-oss-120b)
 //	"gemma"       → CerebrasGemma4Model (gemma-4-31b)
 //	"gemma-4-31b" → CerebrasGemma4Model
+//	"qwen"        → CerebrasQwen38Model (qwen-3.8)
 func ResolveCerebrasModel(name string) string {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "", "default":
 		return CerebrasDefaultModel
 	case "gemma", "gemma4", "gemma-4", "gemma-4-31b", "gemma4-31b", "gemma-4-31":
 		return CerebrasGemma4Model
+	case "qwen", "qwen3.8", "qwen-3-8", "qwen-3.8":
+		return CerebrasQwen38Model
 	}
 	return name
 }

--- a/internal/api/cerebras_test.go
+++ b/internal/api/cerebras_test.go
@@ -15,6 +15,10 @@ func TestResolveCerebrasModel(t *testing.T) {
 		{"gemma-4-31b", CerebrasGemma4Model},
 		{"gemma4-31b", CerebrasGemma4Model},
 		{"gemma-4-31", CerebrasGemma4Model},
+		{"qwen", CerebrasQwen38Model},
+		{"Qwen3.8", CerebrasQwen38Model},
+		{"qwen-3-8", CerebrasQwen38Model},
+		{"qwen-3.8", CerebrasQwen38Model},
 		{"zai-glm-4.7", "zai-glm-4.7"},     // unknown passes through
 		{"  gemma  ", CerebrasGemma4Model}, // whitespace trimmed
 	}

--- a/internal/tui/tui_backend.go
+++ b/internal/tui/tui_backend.go
@@ -144,6 +144,13 @@ var ccModels = []pickerEntry{
 var codexModels = []pickerEntry{
 	{backend: "codex", modelID: "", label: "Codex default", subLabel: "uses Codex config", external: true, isFav: true, shortcut: '6'},
 	{backend: "codex", modelID: "gpt-6-astra", label: "GPT 6 Astra", external: true, isNew: true},
+	{backend: "codex", modelID: "gpt-5.6-sol", label: "GPT 5.6 Sol", external: true},
+	{backend: "codex", modelID: "gpt-5.6-terra", label: "GPT 5.6 Terra", external: true},
+	{backend: "codex", modelID: "gpt-5.6-luna", label: "GPT 5.6 Luna", external: true},
+	{backend: "codex", modelID: "gpt-5.5", label: "GPT 5.5", external: true},
+	{backend: "codex", modelID: "gpt-5.4", label: "GPT 5.4", external: true},
+	{backend: "codex", modelID: "gpt-5.4-mini", label: "GPT 5.4 Mini", external: true},
+	{backend: "codex", modelID: "gpt-5.3-codex-spark", label: "GPT 5.3 Codex Spark", external: true},
 }
 
 var apiModels = []pickerEntry{
@@ -161,6 +168,7 @@ var cerebrasModels = []pickerEntry{
 	{backend: "cerebras", modelID: "gpt-oss-120b", label: "GPT-OSS 120B", subLabel: "fast", isFav: true, external: true},
 	{backend: "cerebras", modelID: "zai-glm-4.7", label: "GLM 4.7", subLabel: "premium", external: true},
 	{backend: "cerebras", modelID: "gemma-4-31b", label: "Gemma 4 31B", subLabel: "vision · preview", external: true},
+	{backend: "cerebras", modelID: api.CerebrasQwen38Model, label: "Qwen 3.8", subLabel: "coming soon", external: true, isNew: true},
 }
 
 // OpenCodeModelEntry is one model offered by an enabled opencode provider. The

--- a/internal/tui/tui_backend_cc_test.go
+++ b/internal/tui/tui_backend_cc_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"testing"
 
+	"github.com/qualitymax/qmax-code/codexrunner"
 	"github.com/qualitymax/qmax-code/internal/api"
 )
 
@@ -57,6 +58,25 @@ func TestPickerCodexDefaultAndExplicitModel(t *testing.T) {
 		cur := m.allEntries[m.cursor]
 		if cur.backend != "codex" || cur.modelID != want {
 			t.Fatalf("selection %q: cursor on %s/%s, want codex/%s", model, cur.backend, cur.modelID, want)
+		}
+	}
+}
+
+func TestPickerOffersEverySupportedCodexModel(t *testing.T) {
+	offered := map[string]bool{}
+	for _, e := range codexModels {
+		if e.backend == "codex" && e.modelID != "" {
+			offered[e.modelID] = true
+		}
+	}
+	for _, m := range codexrunner.SupportedModels() {
+		if !offered[m] {
+			t.Errorf("picker is missing supported Codex model %q", m)
+		}
+	}
+	for m := range offered {
+		if codexrunner.ValidateModel(m) != nil {
+			t.Errorf("picker offers Codex model %q outside the runner allowlist", m)
 		}
 	}
 }


### PR DESCRIPTION
## Why

After v1.31.0, the /orch picker's Codex section offered only two entries (Codex default, GPT 6 Astra) even though the runner allowlist supports eight models. This PR exposes all of them and pre-adds Qwen 3.8 to the Cerebras section.

## Changes

- **internal/tui/tui_backend.go** — `codexModels` now lists every `codexrunner.SupportedModels()` entry (GPT 6 Astra, 5.6 Sol/Terra/Luna, 5.5, 5.4, 5.4 Mini, 5.3 Codex Spark) with `external` badges; Codex default keeps ⭐/shortcut 6.
- **internal/tui/tui_backend_cc_test.go** — new `TestPickerOffersEverySupportedCodexModel` fails when the picker and the runner allowlist drift in either direction.
- **internal/api/cerebras.go** — `CerebrasQwen38Model = "qwen-3.8"` constant plus `qwen`/`qwen3.8`/`qwen-3-8` alias resolution (unknown IDs still pass through).
- **internal/api/cerebras_test.go** — alias table coverage.

## ⚠️ Follow-up at Qwen 3.8 launch

The Cerebras model catalog page was not reachable at authoring time, so `qwen-3.8` follows Cerebras naming (`zai-glm-4.7`, `gemma-4-31b`) but is **unconfirmed against the live API** — per AGENTS.md the model is not live yet. The picker row is labeled `coming soon`; verify the real ID before launch.

## Verification

```
go build -o qmax-code .   # pass
go vet ./...              # pass
go test ./...             # all packages ok
```

Risk: LOW — additive picker rows and alias cases; persisted `codex_model` values are validated against the same allowlist on startup.