### PR TITLE
release: v1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-09-07
+
 ### Added
 - Antigravity CLI (`agy`) is a first-class `/orch` backend. It runs Google's
   native agent harness as a subprocess (`agy -p --output-format stream-json`),


### PR DESCRIPTION
Release checklist for v1.33.0.

## Ships
- #190 — Antigravity CLI (`agy`) as a first-class `/orch` backend with Google OAuth (interactive `agy` browser sign-in; no Gemini API key)

## Changelog
- [1.33.0] entry under Added

## After merge
Tag `v1.33.0` on main triggers `.github/workflows/release.yml`: go vet + test, 6-platform builds (darwin/linux/windows × amd64/arm64), GitHub Release with archives, publish to Quality-Max/qmax-code-releases.


Made with [Cursor](https://cursor.com)