### PR TITLE
release: v1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to qmax-code. Versions follow [Semantic Versioning](https://
 
 ## [Unreleased]
 
+## [1.34.0] - 2026-09-08
+
+### Added
+- One shared conversation now survives switching models, effort levels, and
+  providers. A lossless portable transcript is retained separately from the
+  model's compacted working context. Claude Code, Codex, Antigravity, and
+  OpenCode reuse their native session when it is still valid and receive only
+  the turns they missed; the built-in Anthropic, Cerebras, and Ollama loops
+  receive the shared history including exposed CLI tool activity.
+- `/save`, `/resume`, and `--resume` carry this state across restarts on every
+  backend, one-shot `-p` runs included. Large conversations stay available
+  through a private, searchable JSONL archive so a backend can retrieve older
+  detail without spending its whole context window on it.
+
+### Changed
+- Retained content is redacted more conservatively than displayed content.
+  Because a saved transcript is replayed as the conversation itself, an
+  over-eager match would silently corrupt the only copy of your context, so
+  only unambiguous credential shapes are rewritten. Structured credential
+  fields are still redacted by key name.
+- `/clear` starts a new session ID instead of overwriting the saved file, so
+  the conversation you cleared stays listed by `/sessions` and resumable.
+- Session storage is bounded: portable transcripts are reclaimed after 90 days,
+  legacy sessions keep the existing 7-day cleanup. Session files no longer
+  store the same conversation twice.
+- Session writes are atomic and owner-only.
+
+### Fixed
+- Turn counts no longer include tool traffic, so a prompt with five tool calls
+  reports one turn rather than six.
+- The temporary context archive is removed on the `Ctrl+C` and `SIGTERM` exit
+  paths, not only on deferred cleanup.
+- A read-only or full temporary directory no longer fails an agent turn; the
+  archive degrades instead of blocking compaction.
+- OpenCode tool parts with a nested `state` object keep their top-level tool
+  input, so file snapshots continue to resolve.
+
 ## [1.33.0] - 2026-09-07
 
 ### Added


### PR DESCRIPTION
Release v1.34.0.

Ships the shared conversation context work merged in #192 — the only change since v1.33.0.

## Highlights

- **Context survives switching** models, effort levels, and providers. A lossless portable transcript is retained separately from the compacted working context; CLI backends reuse their native session and receive only the turns they missed.
- **`/save`, `/resume`, `--resume` on every backend**, one-shot `-p` included. Large conversations stay reachable via a private searchable JSONL archive.
- **Conservative redaction for retained content** — a saved transcript is replayed as the conversation, so only unambiguous credential shapes are rewritten. Structured fields still redacted by key name.
- **Bounded session storage** — 90 days for portable transcripts, 7 for legacy; no more double-storing the same conversation.
- **Fixes** — turn counts exclude tool traffic, archive cleanup on `Ctrl+C`/`SIGTERM`, unwritable temp dir no longer fails a turn, OpenCode nested tool state keeps its input.

Minor bump per SemVer: new backward-compatible functionality, no breaking changes to flags, config, or saved-session compatibility (older session files still load).

Merging this and pushing the `v1.34.0` tag triggers `release.yml`, which builds the six OS/arch binaries and publishes the GitHub release.