### PR TITLE
ci: drop redundant Go module cache step

### DIFF
--- a/.github/workflows/qamax-go.yml
+++ b/.github/workflows/qamax-go.yml
@@ -33,16 +33,6 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Download modules
         run: go mod download
 


### PR DESCRIPTION
## Problem

Every `QualityMax Go Tests` run emits roughly **12,000 red `##[error]` annotations** from a step that succeeds:

```
##[error]/usr/bin/tar: .../x/term@v0.45.0/term.go: Cannot open: File exists
##[error]/usr/bin/tar: .../x/text@v0.16.0/encoding/japanese/iso2022jp.go: Cannot open: File exists
...
```

`actions/setup-go@v5` caches `~/go/pkg/mod` and `~/.cache/go-build` **by default**, keyed on `go.sum`. The `actions/cache@v4` step immediately after it restored the same two paths, so `tar` hit an already-populated directory and refused to overwrite — one error line per file.

## Why it's worth fixing

Not for speed. The wasted time is ~11s per run (6s failed restore + 5s save), which on its own wouldn't justify a PR.

It's about signal. A green run covered in red errors is how a team learns to stop reading CI output — this exact confusion is what prompted the change. The failing restore also meant the manual cache was never actually doing anything.

## The change

Delete the redundant `Cache Go modules` block. `setup-go` keeps caching both paths, keyed off `go.sum` via `go-version-file`, so caching behaviour is preserved. Nothing that currently works is lost, because the manual restore was already failing.

`ci.yml` and `release.yml` already use `setup-go` alone and are unchanged.

## Verification

YAML parses; remaining steps are `Checkout code` → `Set up Go` → `Download modules` → `Run tests` → `Report results to QualityMax` → `Upload test artifacts`.

The real check is this PR's own run: it should stay green **and** produce zero `Cannot open: File exists` annotations. Worth confirming that before merge, since the workflow only exercises itself on a PR.

Pre-existing issue, unrelated to any recent feature work — the v1.33.0 merge run (`53bee916`) has 12,228 of these same errors.