### PR TITLE
fix(tui): enforce backgrounds on light themes to prevent invisible text

### DIFF
--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -2271,7 +2271,7 @@ func applySettingValue(key, value string, ag *agent.Agent, term *tui.Terminal) s
 		}
 		cfg.Theme = strings.ToLower(value)
 		tui.ApplyTheme(tui.ThemeByName(cfg.Theme))
-		term.PrintSystem(fmt.Sprintf("Theme set to: %s (takes full effect on restart)", cfg.Theme))
+		term.PrintSystem(fmt.Sprintf("Theme set to: %s", cfg.Theme))
 
 	case "anthropic-key", "anthropic_key":
 		// Save Anthropic API key to OS keychain

--- a/internal/tui/input.go
+++ b/internal/tui/input.go
@@ -452,7 +452,7 @@ var (
 			BorderForeground(lipgloss.Color("238")).
 			Padding(0, 1)
 
-	statusMetricsStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	statusMetricsStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Background(lipgloss.Color("236"))
 	statusBarStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Background(lipgloss.Color("236"))
 	statusBarModeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Background(lipgloss.Color("236")).Bold(true)
 	statusBarDimStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Background(lipgloss.Color("236"))

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -271,9 +271,13 @@ func NewTerminal() *Terminal {
 		rl, _ = readline.New("> ")
 	}
 
+	gStyle := "dark"
+	if !ThemeIsDark {
+		gStyle = "light"
+	}
 	// Create glamour renderer for markdown
 	renderer, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
+		glamour.WithStandardStyle(gStyle),
 		glamour.WithWordWrap(100),
 	)
 	if err != nil {

--- a/internal/tui/terminal.go
+++ b/internal/tui/terminal.go
@@ -163,6 +163,8 @@ func (s *spinner) Stop() {
 type Terminal struct {
 	rl            *readline.Instance
 	renderer      *glamour.TermRenderer
+	rendMu        sync.Mutex      // guards renderer swaps during live theme changes
+	markdownDark  bool            // polarity the current renderer was built for
 	streaming     bool            // true when we're in the middle of streaming text
 	streamBuf     strings.Builder // buffers streamed text for post-render
 	currentPrompt string          // track prompt for readline recreation
@@ -271,25 +273,72 @@ func NewTerminal() *Terminal {
 		rl, _ = readline.New("> ")
 	}
 
-	gStyle := "dark"
-	if !ThemeIsDark {
-		gStyle = "light"
+	prompt := fmt.Sprintf("%s%sqmax%s %s>%s ", ColorBold, themePromptName, ColorReset, themePromptArrow, ColorReset)
+	t := &Terminal{
+		rl:            rl,
+		currentPrompt: prompt,
 	}
-	// Create glamour renderer for markdown
+	t.setMarkdownStyle(ThemeIsDark)
+	registerLiveTerminal(t)
+	return t
+}
+
+// setMarkdownStyle rebuilds the glamour renderer for the given background
+// polarity. It keeps the previous renderer when construction fails so a
+// failed swap never disables markdown rendering.
+func (t *Terminal) setMarkdownStyle(dark bool) {
+	gStyle := "light"
+	if dark {
+		gStyle = "dark"
+	}
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithStandardStyle(gStyle),
 		glamour.WithWordWrap(100),
 	)
 	if err != nil {
-		// Fallback: no markdown rendering
-		renderer = nil
+		return
 	}
+	t.rendMu.Lock()
+	t.renderer = renderer
+	t.markdownDark = dark
+	t.rendMu.Unlock()
+}
 
-	prompt := fmt.Sprintf("%s%sqmax%s %s>%s ", ColorBold, themePromptName, ColorReset, themePromptArrow, ColorReset)
-	return &Terminal{
-		rl:            rl,
-		renderer:      renderer,
-		currentPrompt: prompt,
+// renderMarkdown renders through the current renderer. The renderer pointer
+// is read under lock so a live theme switch cannot swap it mid-render.
+func (t *Terminal) renderMarkdown(text string) (string, bool) {
+	t.rendMu.Lock()
+	r := t.renderer
+	t.rendMu.Unlock()
+	if r == nil {
+		return "", false
+	}
+	rendered, err := r.Render(text)
+	if err != nil {
+		return "", false
+	}
+	return rendered, true
+}
+
+// Live terminals are tracked so ApplyTheme can rebuild their markdown
+// renderers when the theme polarity changes mid-session (e.g. /theme).
+var (
+	liveTerminalsMu sync.Mutex
+	liveTerminals   []*Terminal
+)
+
+func registerLiveTerminal(t *Terminal) {
+	liveTerminalsMu.Lock()
+	liveTerminals = append(liveTerminals, t)
+	liveTerminalsMu.Unlock()
+}
+
+func refreshLiveTerminalRenderers(dark bool) {
+	liveTerminalsMu.Lock()
+	terms := append([]*Terminal(nil), liveTerminals...)
+	liveTerminalsMu.Unlock()
+	for _, t := range terms {
+		t.setMarkdownStyle(dark)
 	}
 }
 
@@ -482,12 +531,7 @@ func (t *Terminal) FinishMarkdown(fullText string) {
 	}
 	t.streaming = false
 
-	var rendered string
-	var renderErr error
-	if t.renderer != nil {
-		rendered, renderErr = t.renderer.Render(fullText)
-	}
-	renderedOK := t.renderer != nil && renderErr == nil
+	rendered, renderedOK := t.renderMarkdown(fullText)
 
 	if p := t.activeTurnProgram(); p != nil {
 		raw := t.streamBuf.String()
@@ -530,12 +574,9 @@ func (t *Terminal) FinishMarkdown(fullText string) {
 // Used in non-streaming mode.
 func (t *Terminal) PrintAssistant(text string) {
 	t.toolStreak = false
-	if t.renderer != nil {
-		rendered, err := t.renderer.Render(text)
-		if err == nil {
-			t.emit(rendered)
-			return
-		}
+	if rendered, ok := t.renderMarkdown(text); ok {
+		t.emit(rendered)
+		return
 	}
 	t.emit(text + "\n")
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -339,11 +339,17 @@ var (
 	themeBannerColor = ColorCyan
 	themeCatColor    = ColorYellow
 	themeStatusColor = ColorGreen
+	
+	// ThemeIsDark exposes the active theme's background polarity.
+	ThemeIsDark      = true
 )
 
 // ApplyTheme rebuilds all lipgloss styles and ANSI prompt vars from t.
 // Must be called before NewTerminal() and ShowModelPicker().
 func ApplyTheme(t Theme) {
+	ThemeIsDark = t.Dark
+	lipgloss.SetHasDarkBackground(t.Dark)
+
 	// ANSI prompt/banner vars
 	themePromptName = t.ANSIPromptName
 	themePromptArrow = t.ANSIPromptArrow
@@ -364,6 +370,7 @@ func ApplyTheme(t Theme) {
 	pickerBox = lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(t.SurfaceBorder)).
+		Background(lipgloss.Color(t.SurfaceDark)).
 		Padding(0, 1)
 	pickerSectionHeader = lipgloss.NewStyle().
 		Foreground(lipgloss.Color(t.TextDim)).
@@ -430,4 +437,15 @@ func ApplyTheme(t Theme) {
 		Background(lipgloss.Color(t.Brand))
 	menuHintStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextSubtle))
 	filterStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Bold(true)
+
+	inputBoxStyle = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(t.SurfaceBorder)).
+		Background(lipgloss.Color(t.SurfaceDark)).
+		Padding(0, 1)
+
+	statusMetricsStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextSubtle))
+	statusBarStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextNormal)).Background(lipgloss.Color(t.SurfaceDark))
+	statusBarModeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Background(lipgloss.Color(t.SurfaceDark)).Bold(true)
+	statusBarDimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextDim)).Background(lipgloss.Color(t.SurfaceDark))
 }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -58,7 +58,7 @@ var allThemes = map[string]Theme{
 		TextDim:         "242",
 		TextSubtle:      "240",
 		SurfaceDark:     "236",
-		SurfaceSelect:   "237",
+		SurfaceSelect:   "241", // raised selection bg — must contrast SurfaceDark(236) now that the picker box paints its own background
 		SurfaceBorder:   "238",
 		SurfaceSep:      "237",
 		IconCodex:       "107",
@@ -82,7 +82,7 @@ var allThemes = map[string]Theme{
 		TextDim:         "242",
 		TextSubtle:      "240",
 		SurfaceDark:     "236",
-		SurfaceSelect:   "237",
+		SurfaceSelect:   "241", // raised selection bg — must contrast SurfaceDark(236) now that the picker box paints its own background
 		SurfaceBorder:   "238",
 		SurfaceSep:      "237",
 		IconCodex:       "120",
@@ -106,7 +106,7 @@ var allThemes = map[string]Theme{
 		TextDim:         "242",
 		TextSubtle:      "240",
 		SurfaceDark:     "235",
-		SurfaceSelect:   "236",
+		SurfaceSelect:   "240", // raised selection bg — must contrast SurfaceDark(235)
 		SurfaceBorder:   "237",
 		SurfaceSep:      "235",
 		IconCodex:       "135",
@@ -130,7 +130,7 @@ var allThemes = map[string]Theme{
 		TextDim:         "242",
 		TextSubtle:      "240",
 		SurfaceDark:     "236",
-		SurfaceSelect:   "237",
+		SurfaceSelect:   "241", // raised selection bg — must contrast SurfaceDark(236) now that the picker box paints its own background
 		SurfaceBorder:   "238",
 		SurfaceSep:      "237",
 		IconCodex:       "214",
@@ -154,7 +154,7 @@ var allThemes = map[string]Theme{
 		TextDim:         "242",
 		TextSubtle:      "240",
 		SurfaceDark:     "236",
-		SurfaceSelect:   "237",
+		SurfaceSelect:   "241", // raised selection bg — must contrast SurfaceDark(236) now that the picker box paints its own background
 		SurfaceBorder:   "238",
 		SurfaceSep:      "237",
 		IconCodex:       "71",
@@ -251,7 +251,7 @@ var allThemes = map[string]Theme{
 		TextDim:         "243", // medium gray — section headers
 		TextSubtle:      "247", // lighter gray — hints/footer
 		SurfaceDark:     "224", // blush pink — status bar bg
-		SurfaceSelect:   "225", // pale rose — selected row bg
+		SurfaceSelect:   "217", // salmon — selected row bg, contrasts SurfaceDark(224)
 		SurfaceBorder:   "218", // soft pink border
 		SurfaceSep:      "254", // near-white divider
 		IconCodex:       "125", // deep magenta
@@ -275,7 +275,7 @@ var allThemes = map[string]Theme{
 		TextDim:         "243", // medium gray — section headers
 		TextSubtle:      "247", // lighter gray — hints/footer
 		SurfaceDark:     "229", // pale gold — status bar bg
-		SurfaceSelect:   "223", // honey-gold — selected row bg
+		SurfaceSelect:   "220", // gold — selected row bg, contrasts SurfaceDark(229)
 		SurfaceBorder:   "222", // warm gold border
 		SurfaceSep:      "230", // very pale yellow divider
 		IconCodex:       "136", // warm gold
@@ -339,9 +339,9 @@ var (
 	themeBannerColor = ColorCyan
 	themeCatColor    = ColorYellow
 	themeStatusColor = ColorGreen
-	
+
 	// ThemeIsDark exposes the active theme's background polarity.
-	ThemeIsDark      = true
+	ThemeIsDark = true
 )
 
 // ApplyTheme rebuilds all lipgloss styles and ANSI prompt vars from t.
@@ -444,8 +444,12 @@ func ApplyTheme(t Theme) {
 		Background(lipgloss.Color(t.SurfaceDark)).
 		Padding(0, 1)
 
-	statusMetricsStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextSubtle))
+	statusMetricsStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextSubtle)).Background(lipgloss.Color(t.SurfaceDark))
 	statusBarStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextNormal)).Background(lipgloss.Color(t.SurfaceDark))
 	statusBarModeStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.Accent)).Background(lipgloss.Color(t.SurfaceDark)).Bold(true)
 	statusBarDimStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(t.TextDim)).Background(lipgloss.Color(t.SurfaceDark))
+
+	// Rebuild live markdown renderers so /theme takes effect immediately
+	// instead of only after a restart.
+	refreshLiveTerminalRenderers(t.Dark)
 }

--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -1,6 +1,11 @@
 package tui
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
 
 func TestThemeNames_Order(t *testing.T) {
 	want := []string{"historic", "ocean", "neon", "ember", "aurora", "paper", "sky", "sparkling", "radiance", "goldenhour"}
@@ -111,4 +116,108 @@ func TestApplyTheme_AllBuiltinThemes(t *testing.T) {
 	}
 	// Leave in a consistent state.
 	ApplyTheme(ThemeByName("historic"))
+}
+
+func TestApplyTheme_SetsPolarity(t *testing.T) {
+	for _, name := range ThemeNames() {
+		theme := ThemeByName(name)
+		ApplyTheme(theme)
+		if ThemeIsDark != theme.Dark {
+			t.Errorf("ApplyTheme(%q): ThemeIsDark = %v, want %v", name, ThemeIsDark, theme.Dark)
+		}
+	}
+	ApplyTheme(ThemeByName("historic"))
+}
+
+// TestApplyTheme_BackgroundsFollowTheme guards the invisible-text bug: after
+// ApplyTheme, surfaces that promise a solid background must actually carry
+// the theme's SurfaceDark color, so menus stay readable when the terminal
+// background polarity mismatches the selected theme.
+func TestApplyTheme_BackgroundsFollowTheme(t *testing.T) {
+	for _, name := range ThemeNames() {
+		theme := ThemeByName(name)
+		ApplyTheme(theme)
+		surface := lipgloss.Color(theme.SurfaceDark)
+		cases := []struct {
+			label string
+			got   lipgloss.TerminalColor
+		}{
+			{"pickerBox", pickerBox.GetBackground()},
+			{"inputBoxStyle", inputBoxStyle.GetBackground()},
+			{"statusBarStyle", statusBarStyle.GetBackground()},
+			{"statusMetricsStyle", statusMetricsStyle.GetBackground()},
+		}
+		for _, c := range cases {
+			if c.got != surface {
+				t.Errorf("ApplyTheme(%q): %s background = %v, want %v", name, c.label, c.got, surface)
+			}
+		}
+		if got := pickerRowSelected.GetBackground(); got != lipgloss.Color(theme.SurfaceSelect) {
+			t.Errorf("ApplyTheme(%q): pickerRowSelected background = %v, want %v", name, got, theme.SurfaceSelect)
+		}
+	}
+	ApplyTheme(ThemeByName("historic"))
+}
+
+// TestThemePalette_SelectionContrastsSurface guards the picker selection
+// highlight: SurfaceSelect must be visibly distinct from SurfaceDark now
+// that pickerBox paints its own background behind every row.
+func TestThemePalette_SelectionContrastsSurface(t *testing.T) {
+	for _, name := range ThemeNames() {
+		theme := ThemeByName(name)
+		bg, err1 := strconv.Atoi(theme.SurfaceDark)
+		sel, err2 := strconv.Atoi(theme.SurfaceSelect)
+		if err1 != nil || err2 != nil {
+			t.Fatalf("Theme %q: non-numeric surface colors (%q, %q)", name, theme.SurfaceDark, theme.SurfaceSelect)
+		}
+		if d := absInt(bg - sel); d < 4 {
+			t.Errorf("Theme %q: SurfaceSelect %d is only %d steps from SurfaceDark %d; selection highlight would be invisible", name, sel, d, bg)
+		}
+	}
+}
+
+func absInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+func TestSetMarkdownStyle_SwapsPolarity(t *testing.T) {
+	term := &Terminal{}
+	term.setMarkdownStyle(false)
+	if term.renderer == nil || term.markdownDark {
+		t.Fatal("setMarkdownStyle(false) did not build a light renderer")
+	}
+	light, lightOK := term.renderMarkdown("# hi")
+	term.setMarkdownStyle(true)
+	if term.renderer == nil || !term.markdownDark {
+		t.Fatal("setMarkdownStyle(true) did not build a dark renderer")
+	}
+	dark, darkOK := term.renderMarkdown("# hi")
+	if lightOK && darkOK && light == dark {
+		t.Error("dark and light renderers produced identical output; style was not swapped")
+	}
+}
+
+func TestApplyTheme_RefreshesLiveTerminalRenderer(t *testing.T) {
+	term := &Terminal{}
+	registerLiveTerminal(term)
+	defer func() {
+		liveTerminalsMu.Lock()
+		liveTerminals = nil
+		liveTerminalsMu.Unlock()
+	}()
+
+	ApplyTheme(ThemeByName("paper")) // light theme
+	if term.renderer == nil {
+		t.Fatal("ApplyTheme did not build a renderer for the registered terminal")
+	}
+	if term.markdownDark {
+		t.Error("ApplyTheme(paper) left the renderer on dark style; want light")
+	}
+	ApplyTheme(ThemeByName("historic")) // dark theme, also restores globals
+	if !term.markdownDark {
+		t.Error("ApplyTheme(historic) left the renderer on light style; want dark")
+	}
 }


### PR DESCRIPTION
- Forces `SurfaceDark` background on `pickerBox` and `inputBoxStyle` so TUI menus remain readable on mismatched terminal backgrounds
- Synchronizes `glamour` markdown rendering with the active app theme instead of relying on unreliable terminal auto-detection
- Updates status bar to dynamically obey selected theme colors