### PR TITLE
fix(tui): satisfy ineffassign in theme picker repaint test

### DIFF
--- a/internal/tui/theme_test.go
+++ b/internal/tui/theme_test.go
@@ -259,6 +259,9 @@ func TestThemePicker_PolarityTransitionsRequestFullRepaint(t *testing.T) {
 	if got := m.themes[m.cursor]; got != "paper" {
 		t.Fatalf("up selected %q, want paper", got)
 	}
+	if cmd != nil {
+		t.Fatal("same-polarity up move requested a full-screen repaint; want none")
+	}
 	updated, cmd = m.Update(tea.KeyMsg{Type: tea.KeyUp})
 	m = updated.(themePickerModel)
 	if got := m.themes[m.cursor]; got != "aurora" {


### PR DESCRIPTION
The CI Lint step (golangci-lint v1.64.8, `ineffassign`) failed on #196: the sky→paper up move assigned `cmd` without reading it. This asserts the same-polarity no-repaint expectation instead. Verified with the exact pinned linter version + tui test suite.